### PR TITLE
refactor: centralize ticker normalization

### DIFF
--- a/sp_universe.py
+++ b/sp_universe.py
@@ -7,6 +7,7 @@ from typing import List, Optional
 
 import pandas as pd
 import requests
+from utils.tickers import normalize_symbol
 
 CACHE_PATH = "sp500_cache.json"
 CACHE_MAX_AGE_SECONDS = 6 * 60 * 60  # 6 hours
@@ -14,15 +15,6 @@ WIKI_URL = "https://en.wikipedia.org/wiki/List_of_S%26P_500_companies"
 
 # Expose last error for the UI to show a helpful message
 LAST_ERROR: Optional[str] = None
-
-def _normalize_symbol(sym: str) -> str:
-    s = (sym or "").strip().upper()
-    # Wikipedia uses dots for classes; Yahoo uses dashes
-    # e.g., BRK.B -> BRK-B, BF.B -> BF-B
-    s = s.replace(".", "-")
-    # Strip any footnote markers or stray spaces
-    s = s.replace("\u200b", "").replace("\xa0", "").strip()
-    return s
 
 def _load_cache() -> Optional[List[str]]:
     try:
@@ -82,7 +74,7 @@ def _parse_tickers_from_html(html: str) -> List[str]:
 
     tickers = []
     for raw in df[sym_col_name].astype(str).tolist():
-        sym = _normalize_symbol(raw)
+        sym = normalize_symbol(raw)
         if sym and sym.isascii():
             tickers.append(sym)
 

--- a/utils/tickers.py
+++ b/utils/tickers.py
@@ -1,0 +1,80 @@
+"""Ticker normalization helpers shared across modules."""
+from __future__ import annotations
+
+# Aliases for common company names -> tickers
+ALIAS_MAP = {
+    "NVIDIA": "NVDA", "NVIDIA CORPORATION": "NVDA",
+    "TESLA": "TSLA", "TESLA INC": "TSLA",
+    "APPLE": "AAPL", "APPLE INC": "AAPL",
+    "MICROSOFT": "MSFT", "MICROSOFT CORPORATION": "MSFT",
+    "ALPHABET": "GOOGL", "GOOGLE": "GOOGL",
+    "META": "META", "META PLATFORMS": "META",
+    "AMAZON": "AMZN", "AMAZONCOM": "AMZN", "AMAZON.COM": "AMZN",
+    "NETFLIX": "NFLX", "WALMART": "WMT", "WALMART INC": "WMT",
+    "JPMORGAN": "JPM", "JPMORGAN CHASE": "JPM",
+    "BERKSHIRE": "BRK-B", "BERKSHIRE HATHAWAY": "BRK-B",
+    "UNITEDHEALTH": "UNH", "UNITEDHEALTH GROUP": "UNH",
+    "COCA COLA": "KO", "COCA-COLA": "KO",
+    "PEPSICO": "PEP", "ADOBE": "ADBE", "INTEL": "INTC",
+    "AMD": "AMD", "BROADCOM": "AVGO", "SALESFORCE": "CRM",
+    "SERVICENOW": "NOW", "SERVICE NOW": "NOW",
+    "CROWDSTRIKE": "CRWD", "MCDONALDS": "MCD", "MCDONALD'S": "MCD",
+    "COSTCO": "COST", "HOME DEPOT": "HD",
+    "PROCTER & GAMBLE": "PG", "PROCTER AND GAMBLE": "PG",
+    "ELI LILLY": "LLY", "ABBVIE": "ABBV",
+    "EXXON": "XOM", "EXXONMOBIL": "XOM", "CHEVRON": "CVX",
+}
+
+
+def _normalize_brk(s: str) -> str | None:
+    """Handle Berkshire share classes in various formats."""
+    s2 = (
+        s.replace(" ", "")
+        .replace("-", "")
+        .replace("_", "")
+        .replace(".", "")
+        .upper()
+    )
+    if s2 == "BRKB":
+        return "BRK-B"
+    if s2 == "BRKA":
+        return "BRK-A"
+    return None
+
+
+def normalize_symbol(inp: str) -> str | None:
+    """Best-effort mapping: ticker-looking -> upper, aliases, and heuristics."""
+    if not inp:
+        return None
+
+    s = str(inp)
+    # Strip whitespace and odd spaces from HTML sources
+    s = s.replace("\u200b", "").replace("\xa0", "").strip()
+    if not s:
+        return None
+
+    # Company name path (aliases)
+    key = s.upper()
+    key = key.replace(",", "").replace(".", "")
+    for kill in (" INC", " CORPORATION", " COMPANY", " HOLDINGS", " PLC", " LTD"):
+        key = key.replace(kill, "")
+    key = key.replace(" CLASS A", "").replace(" CLASS B", "")
+    key = " ".join(key.split())
+
+    if key in ALIAS_MAP:
+        return ALIAS_MAP[key]
+
+    # Looks like a ticker already?
+    if 1 <= len(s) <= 6 and all(c.isalnum() or c in ".-_" for c in s):
+        brk = _normalize_brk(s)
+        if brk:
+            return brk
+        return s.upper().replace("_", "-").replace(".", "-")
+
+    # Last chance Berkshire normalization
+    brk = _normalize_brk(s)
+    if brk:
+        return brk
+
+    return s.upper().replace("_", "-").replace(".", "-")
+


### PR DESCRIPTION
## Summary
- move symbol aliases and Berkshire handling into utils/tickers.py
- reuse shared `normalize_symbol` in app and S&P 500 universe fetcher
- remove redundant local normalization helpers

## Testing
- `python -m py_compile app.py sp_universe.py utils/tickers.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5aefd70a483328e5b26161794e2b5