### PR TITLE
Centralize price history fetching and refactor callers

### DIFF
--- a/swing_options_screener.py
+++ b/swing_options_screener.py
@@ -8,6 +8,8 @@ import numpy as np
 import pandas as pd
 import yfinance as yf
 
+from utils.prices import fetch_history
+
 try:
     from zoneinfo import ZoneInfo  # py>=3.9
 except Exception:
@@ -74,20 +76,8 @@ def _fmt_ts(ts):
 
 def _get_history(ticker):
     # UNADJUSTED daily (aligns better with Finviz)
-    try:
-        df = yf.Ticker(ticker).history(period="16mo", auto_adjust=False, actions=False)
-        if df is None or df.empty: return None
-        if not isinstance(df.index, pd.DatetimeIndex):
-            df.index = pd.to_datetime(df.index)
-        if df.index.tz is not None:
-            df.index = df.index.tz_convert(None)
-        df.columns = [c.title() for c in df.columns]
-        for col in ('Open','High','Low','Close','Volume'):
-            if col in df.columns:
-                df[col] = pd.to_numeric(df[col], errors='coerce')
-        return df
-    except Exception:
-        return None
+    start = pd.Timestamp.today() - pd.DateOffset(months=16)
+    return fetch_history(ticker, start=start, auto_adjust=False)
 
 def _atr_from_ohlc(df, win):
     hl  = df['High'] - df['Low']

--- a/utils/prices.py
+++ b/utils/prices.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import pandas as pd
+import yfinance as yf
+
+
+def fetch_history(
+    ticker: str,
+    start: str | pd.Timestamp | None = None,
+    end: str | pd.Timestamp | None = None,
+    interval: str = "1d",
+    auto_adjust: bool = False,
+):
+    """Fetch price history for *ticker* with normalized columns.
+
+    Returns a DataFrame with title-cased columns and numeric price/volume fields
+    or ``None`` if data cannot be retrieved. The helper removes timezone
+    information from the index and gracefully handles any errors.
+    """
+    try:
+        if not ticker:
+            return None
+        df = yf.Ticker(ticker).history(
+            start=start,
+            end=end,
+            interval=interval,
+            auto_adjust=auto_adjust,
+            actions=False,
+        )
+        if df is None or df.empty:
+            return None
+        if not isinstance(df.index, pd.DatetimeIndex):
+            df.index = pd.to_datetime(df.index)
+        if df.index.tz is not None:
+            df.index = df.index.tz_convert(None)
+        df.columns = [c.title() for c in df.columns]
+        for col in ("Open", "High", "Low", "Close", "Adj Close", "Volume"):
+            if col in df.columns:
+                df[col] = pd.to_numeric(df[col], errors="coerce")
+        return df
+    except Exception:
+        return None


### PR DESCRIPTION
## Summary
- add `utils.prices.fetch_history` to standardize yfinance history retrieval
- refactor outcomes helpers and swing screener to reuse new history helper

## Testing
- `python -m py_compile swing_options_screener.py utils/outcomes.py utils/prices.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5b6855a348332bc74fdc2e56c9bba