### PR TITLE
Refactor path handling with shared I/O helpers

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,17 +17,15 @@
 # ============================================================
 # 1. Imports & Safe third-party glue
 # ============================================================
-import os, glob, io, pandas as pd, streamlit as st
+import glob, pandas as pd, streamlit as st
 from datetime import datetime
 import swing_options_screener as sos  # core engine
 from utils.tickers import normalize_symbol
+from utils.io import PASS_DIR, HISTORY_DIR, OUTCOMES_PATH, read_csv
 
 # ============================================================
 # 2. App constants (paths, titles, etc.)
 # ============================================================
-PASS_DIR = "data/pass_logs"
-HIST_DIR = "data/history"
-OUT_FILE = os.path.join(HIST_DIR, "outcomes.csv")
 
 st.set_page_config(
     page_title="Edge500",     # Title shown in browser tab
@@ -149,13 +147,13 @@ def build_why_buy_html(row: dict) -> str:
 def latest_pass_file():
     """Return the newest pass_*.csv from either pass_logs/ or history/."""
     candidates = []
-    for d in [PASS_DIR, HIST_DIR]:
-        candidates.extend(glob.glob(os.path.join(d, "pass_*.csv")))
+    for d in [PASS_DIR, HISTORY_DIR]:
+        candidates.extend(glob.glob(str(d / "pass_*.csv")))
     return sorted(candidates)[-1] if candidates else None
 
 def load_outcomes():
-    if os.path.exists(OUT_FILE):
-        return pd.read_csv(OUT_FILE)
+    if OUTCOMES_PATH.exists():
+        return read_csv(OUTCOMES_PATH)
     return pd.DataFrame()
     
 

--- a/scripts/check_hits.py
+++ b/scripts/check_hits.py
@@ -1,29 +1,22 @@
 #!/usr/bin/env python3
 """Update ``data/history/outcomes.csv`` by evaluating pending rows."""
 
-import os
-import sys
-
-REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-sys.path.insert(0, REPO_ROOT)
-HIST_DIR = os.path.join(REPO_ROOT, "data", "history")
-OUT_PATH = os.path.join(HIST_DIR, "outcomes.csv")
-
-from utils.outcomes import check_pending_hits, read_outcomes, write_outcomes
+from utils.io import OUTCOMES_PATH, read_csv, write_csv
+from utils.outcomes import check_pending_hits
 
 
 def main() -> None:
-    if not os.path.exists(OUT_PATH):
+    if not OUTCOMES_PATH.exists():
         print("No outcomes.csv yet; nothing to check.")
         return
 
-    df = read_outcomes(OUT_PATH)
+    df = read_csv(OUTCOMES_PATH)
     if df.empty:
         print("outcomes.csv empty; nothing to check.")
         return
 
     df = check_pending_hits(df)
-    write_outcomes(df, OUT_PATH)
+    write_csv(OUTCOMES_PATH, df)
     print("Updated outcomes.csv")
 
 

--- a/scripts/run_and_log.py
+++ b/scripts/run_and_log.py
@@ -5,11 +5,8 @@
 Bibliography (Section Index)
 =======================================================================
 1. Imports & CLI
-2. Paths, Constants, Helpers
-3. Robust IO (read/write CSV)
-4. Outcomes Upsert (non-destructive append/update)
-5. Screener Runner (invoke library, gather DataFrames)
-6. Main (glue: run, save pass file, write logs, upsert outcomes)
+2. Screener Runner (invoke library, gather DataFrames)
+3. Main (glue: run, save pass file, write logs, upsert outcomes)
 =======================================================================
 """
 
@@ -17,11 +14,9 @@ Bibliography (Section Index)
 # 1. Imports & CLI
 # --------------------------------------------------------------------
 import argparse
-import os
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-import inspect
 import pandas as pd
 
 # Screener module (must be importable from repo root)
@@ -42,6 +37,7 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 from utils.outcomes import upsert_and_backfill_outcomes, settle_pending_outcomes
+from utils.io import HISTORY_DIR, LOGS_DIR, OUTCOMES_PATH, write_csv
 
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(
@@ -66,67 +62,9 @@ def parse_args() -> argparse.Namespace:
 
 
 # --------------------------------------------------------------------
-# 2. Paths, Constants, Helpers
-# --------------------------------------------------------------------
-HISTORY_DIR = Path("data/history")
-LOGS_DIR = Path("data/logs")
-OUTCOMES_FILE = HISTORY_DIR / "outcomes.csv"
-
-UTC_NOW = datetime.now(timezone.utc)
-STAMP = UTC_NOW.strftime("%Y%m%d-%H%M")
-
-PASS_PATH = HISTORY_DIR / f"pass_{STAMP}.csv"
-SCAN_PATH = HISTORY_DIR / f"scan_{STAMP}.csv"
-LOG_PATH = LOGS_DIR / f"scan_{STAMP}.txt"
-
-
-def ensure_dirs() -> None:
-    HISTORY_DIR.mkdir(parents=True, exist_ok=True)
-    LOGS_DIR.mkdir(parents=True, exist_ok=True)
-
-
-def pick(df: pd.DataFrame, col: str, default=None):
-    """Safe column getter for a homogeneous value; returns default if missing."""
-    try:
-        if df is None or df.empty or col not in df.columns:
-            return default
-        vals = df[col].dropna().unique()
-        if len(vals) == 0:
-            return default
-        return vals[0]
-    except Exception:
-        return default
-
-
-def safe_str(x):
-    return "" if x is None else str(x)
-
-
-# --------------------------------------------------------------------
-# 3. Robust IO (read/write CSV)
-# --------------------------------------------------------------------
-def read_csv_if_exists(path: Path) -> pd.DataFrame:
-    if path.exists():
-        try:
-            return pd.read_csv(path)
-        except Exception as e:
-            print(f"[WARN] Failed reading {path}: {e}", file=sys.stderr)
-    return pd.DataFrame()
-
-
-def write_csv(path: Path, df: pd.DataFrame) -> None:
-    try:
-        df.to_csv(path, index=False)
-    except Exception as e:
-        print(f"[ERROR] Failed writing {path}: {e}", file=sys.stderr)
-
-
-# --------------------------------------------------------------------
-# 5. Screener Runner (invoke library, gather DataFrames)
+# 2. Screener Runner (invoke library, gather DataFrames)
 # --------------------------------------------------------------------
 from typing import Tuple, Optional
-import pandas as pd
-import swing_options_screener as sos
 
 def _safe_engine_run_scan() -> dict:
     """
@@ -177,22 +115,15 @@ def _safe_engine_run_scan() -> dict:
     return {"pass": df_pass, "scan": df_scan}
 
 # --------------------------------------------------------------------
-# 6. Main (glue: run, save pass file, write logs, upsert outcomes)
+# 3. Main (glue: run, save pass file, write logs, upsert outcomes)
 # --------------------------------------------------------------------
-import sys
-from pathlib import Path
-from datetime import datetime, timezone
-
-HIST_DIR = Path("data/history")
-LOG_DIR  = Path("data/logs")
-OUT_PATH = HIST_DIR / "outcomes.csv"
 
 def _utc_ts() -> str:
     return datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
 
 def main() -> int:
-    HIST_DIR.mkdir(parents=True, exist_ok=True)
-    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    HISTORY_DIR.mkdir(parents=True, exist_ok=True)
+    LOGS_DIR.mkdir(parents=True, exist_ok=True)
 
     try:
         res = _safe_engine_run_scan()
@@ -203,14 +134,14 @@ def main() -> int:
         if isinstance(df_pass, pd.DataFrame) and not df_pass.empty:
             # filename with UTC timestamp
             pass_name = f"pass_{_utc_ts()}.csv"
-            pass_path = HIST_DIR / pass_name
-            df_pass.to_csv(pass_path, index=False)
+            pass_path = HISTORY_DIR / pass_name
+            write_csv(pass_path, df_pass)
             print(f"[run_and_log] wrote {pass_path}")
             wrote_pass = True
 
             # Update outcomes.csv (insert new, backfill, settle)
-            upsert_and_backfill_outcomes(df_pass, str(OUT_PATH))
-            settle_pending_outcomes(str(OUT_PATH))
+            upsert_and_backfill_outcomes(df_pass, str(OUTCOMES_PATH))
+            settle_pending_outcomes(str(OUTCOMES_PATH))
         else:
             print("[run_and_log] scan returned no passing tickers.")
 

--- a/scripts/score_history.py
+++ b/scripts/score_history.py
@@ -4,30 +4,22 @@
 # - For Outcome == PENDING, checks if TargetLevel was hit (High >= level)
 #   between EvalDate (inclusive) and min(WindowEnd, today) (inclusive).
 #   Results are written back to outcomes.csv.
-import os
-import sys
-
-ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-sys.path.insert(0, ROOT)
-
-HIST_DIR = os.path.join(ROOT, "data", "history")
-OUTCOMES_CSV = os.path.join(HIST_DIR, "outcomes.csv")
-
-from utils.outcomes import read_outcomes, score_history, write_outcomes
+from utils.io import OUTCOMES_PATH, read_csv, write_csv
+from utils.outcomes import score_history
 
 
 def main() -> None:
-    if not os.path.exists(OUTCOMES_CSV):
+    if not OUTCOMES_PATH.exists():
         print("No outcomes.csv yet; nothing to score.")
         return
 
-    df = read_outcomes(OUTCOMES_CSV)
+    df = read_csv(OUTCOMES_PATH)
     if df.empty:
         print("outcomes.csv empty; nothing to score.")
         return
 
     new_df = score_history(df)
-    write_outcomes(new_df, OUTCOMES_CSV)
+    write_csv(OUTCOMES_PATH, new_df)
     print(f"Scored {len(new_df)} rows → wrote outcomes.csv")
 
 

--- a/utils/io.py
+++ b/utils/io.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Union
+
+import pandas as pd
+
+# Repository paths
+ROOT = Path(__file__).resolve().parents[1]
+DATA_DIR = ROOT / "data"
+HISTORY_DIR = DATA_DIR / "history"
+LOGS_DIR = DATA_DIR / "logs"
+PASS_DIR = DATA_DIR / "pass_logs"
+OUTCOMES_PATH = HISTORY_DIR / "outcomes.csv"
+
+PathLike = Union[str, Path]
+
+def read_csv(path: PathLike) -> pd.DataFrame:
+    """Read a CSV file into a DataFrame, returning empty DF on failure."""
+    try:
+        return pd.read_csv(path)
+    except FileNotFoundError:
+        return pd.DataFrame()
+    except Exception:
+        return pd.DataFrame()
+
+def write_csv(path: PathLike, df: pd.DataFrame) -> None:
+    """Write DataFrame to CSV, creating parent dirs as needed."""
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(p, index=False)


### PR DESCRIPTION
## Summary
- centralize data paths and CSV helpers in new `utils.io`
- update app and scripts to import shared paths and remove local definitions
- drop redundant I/O code from maintenance scripts

## Testing
- `python -m py_compile utils/io.py app.py scripts/check_hits.py scripts/score_history.py scripts/run_and_log.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5b682323c833295fb2e6a18105ba2