### PR TITLE
Unify outcome evaluation and update scripts, docs, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,14 @@
 
 ## Hit Checking
 
-Use the `scripts/check_hits.py` utility to update `data/history/outcomes.csv` with trade results.
+Trade outcomes are evaluated by `utils.outcomes.evaluate_outcomes`, which can
+process both pending trades and historical window checks. The repository
+provides small command line helpers that read `data/history/outcomes.csv`, apply
+`evaluate_outcomes`, and write the results back:
 
 ```bash
-python scripts/check_hits.py
+python scripts/check_hits.py      # evaluate pending trades
+python scripts/score_history.py   # evaluate historical windows
 ```
 
-The script fetches daily price data for each pending entry and marks hits or misses accordingly.
+Both scripts fetch daily price data and mark hits or misses as appropriate.

--- a/scripts/check_hits.py
+++ b/scripts/check_hits.py
@@ -9,7 +9,7 @@ sys.path.insert(0, REPO_ROOT)
 HIST_DIR = os.path.join(REPO_ROOT, "data", "history")
 OUT_PATH = os.path.join(HIST_DIR, "outcomes.csv")
 
-from utils.outcomes import check_pending_hits, read_outcomes, write_outcomes
+from utils.outcomes import evaluate_outcomes, read_outcomes, write_outcomes
 
 
 def main() -> None:
@@ -22,7 +22,7 @@ def main() -> None:
         print("outcomes.csv empty; nothing to check.")
         return
 
-    df = check_pending_hits(df)
+    df = evaluate_outcomes(df)
     write_outcomes(df, OUT_PATH)
     print("Updated outcomes.csv")
 

--- a/scripts/score_history.py
+++ b/scripts/score_history.py
@@ -13,7 +13,7 @@ sys.path.insert(0, ROOT)
 HIST_DIR = os.path.join(ROOT, "data", "history")
 OUTCOMES_CSV = os.path.join(HIST_DIR, "outcomes.csv")
 
-from utils.outcomes import read_outcomes, score_history, write_outcomes
+from utils.outcomes import evaluate_outcomes, read_outcomes, write_outcomes
 
 
 def main() -> None:
@@ -26,7 +26,7 @@ def main() -> None:
         print("outcomes.csv empty; nothing to score.")
         return
 
-    new_df = score_history(df)
+    new_df = evaluate_outcomes(df)
     write_outcomes(new_df, OUTCOMES_CSV)
     print(f"Scored {len(new_df)} rows → wrote outcomes.csv")
 

--- a/tests/test_outcomes.py
+++ b/tests/test_outcomes.py
@@ -1,0 +1,44 @@
+import pandas as pd
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import utils.outcomes as outcomes  # noqa: E402
+
+def _stub_history(ticker, start=None, end=None, auto_adjust=False):
+    dates = pd.date_range('2020-01-01', periods=5, freq='D')
+    highs = [8, 10, 12, 11, 9]
+    return pd.DataFrame({'High': highs}, index=dates)
+
+def test_evaluate_pending(monkeypatch):
+    monkeypatch.setattr(outcomes, 'fetch_history', _stub_history)
+    df = pd.DataFrame([
+        {
+            'Ticker': 'ABC',
+            'EvalDate': '2020-01-01',
+            'result_status': 'PENDING',
+            'TP': 10,
+            'OptExpiry': '2020-01-10',
+        }
+    ])
+    out = outcomes.evaluate_outcomes(df)
+    row = out.iloc[0]
+    assert row['result_status'] == 'HIT'
+    assert row['hit_time'] == '2020-01-02'
+    assert row['hit_price'] == 10
+
+def test_evaluate_history(monkeypatch):
+    monkeypatch.setattr(outcomes, 'fetch_history', _stub_history)
+    df = pd.DataFrame([
+        {
+            'Ticker': 'XYZ',
+            'EvalDate': '2020-01-01',
+            'WindowEnd': '2020-01-05',
+            'TargetLevel': 15,
+            'Outcome': 'PENDING',
+        }
+    ])
+    out = outcomes.evaluate_outcomes(df)
+    row = out.iloc[0]
+    assert row['Outcome'] == 'NO'
+    assert row['MaxHigh'] == 12


### PR DESCRIPTION
## Summary
- Add `evaluate_outcomes` to score pending trades or historical windows
- Refactor hit-checking scripts to use the unified evaluation function
- Document new workflow and add tests for both evaluation scenarios

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5bef22828833286a0e5a38af8747b