### PR TITLE
Centralize CSV paths and I/O helpers

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,22 +12,18 @@
 # 9. TAB – Debugger
 # ============================================================
 
-# ============================================================
-# 1. Imports & Safe third-party glue
-# ============================================================
-import os, glob, io, pandas as pd, streamlit as st
+import glob, io, pandas as pd, streamlit as st
 from datetime import datetime
 import swing_options_screener as sos  # core engine
 from ui.layout import setup_page, render_header
 from ui.debugger import render_debugger_tab
 from utils.formatting import _bold, _usd, _pct, _safe
+from utils.io import DATA_DIR, HISTORY_DIR, OUTCOMES_CSV, read_csv
 
 # ============================================================
 # 2. App constants (paths, titles, etc.)
 # ============================================================
-PASS_DIR = "data/pass_logs"
-HIST_DIR = "data/history"
-OUT_FILE = os.path.join(HIST_DIR, "outcomes.csv")
+PASS_DIR = DATA_DIR / "pass_logs"
 # Initialize page and global layout/CSS
 setup_page()
 
@@ -78,13 +74,13 @@ def build_why_buy_html(row: dict) -> str:
 def latest_pass_file():
     """Return the newest pass_*.csv from either pass_logs/ or history/."""
     candidates = []
-    for d in [PASS_DIR, HIST_DIR]:
-        candidates.extend(glob.glob(os.path.join(d, "pass_*.csv")))
+    for d in [PASS_DIR, HISTORY_DIR]:
+        candidates.extend(glob.glob(str(d / "pass_*.csv")))
     return sorted(candidates)[-1] if candidates else None
 
 def load_outcomes():
-    if os.path.exists(OUT_FILE):
-        return pd.read_csv(OUT_FILE)
+    if OUTCOMES_CSV.exists():
+        return read_csv(OUTCOMES_CSV)
     return pd.DataFrame()
     
 
@@ -274,7 +270,7 @@ with tab_history:
     lastf = latest_pass_file()
     if lastf:
         try:
-            df_last = pd.read_csv(lastf)
+            df_last = read_csv(lastf)
             st.dataframe(df_last, use_container_width=True)
         except Exception as e:
             st.warning(f"Could not read latest pass file: {e}")

--- a/scripts/check_hits.py
+++ b/scripts/check_hits.py
@@ -1,29 +1,29 @@
 #!/usr/bin/env python3
 """Update ``data/history/outcomes.csv`` by evaluating pending rows."""
 
-import os
 import sys
+from pathlib import Path
 
-REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-sys.path.insert(0, REPO_ROOT)
-HIST_DIR = os.path.join(REPO_ROOT, "data", "history")
-OUT_PATH = os.path.join(HIST_DIR, "outcomes.csv")
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
+from utils.io import OUTCOMES_CSV
 from utils.outcomes import check_pending_hits, read_outcomes, write_outcomes
 
 
 def main() -> None:
-    if not os.path.exists(OUT_PATH):
+    if not OUTCOMES_CSV.exists():
         print("No outcomes.csv yet; nothing to check.")
         return
 
-    df = read_outcomes(OUT_PATH)
+    df = read_outcomes(OUTCOMES_CSV)
     if df.empty:
         print("outcomes.csv empty; nothing to check.")
         return
 
     df = check_pending_hits(df)
-    write_outcomes(df, OUT_PATH)
+    write_outcomes(df, OUTCOMES_CSV)
     print("Updated outcomes.csv")
 
 

--- a/scripts/score_history.py
+++ b/scripts/score_history.py
@@ -4,20 +4,19 @@
 # - For Outcome == PENDING, checks if TargetLevel was hit (High >= level)
 #   between EvalDate (inclusive) and min(WindowEnd, today) (inclusive).
 #   Results are written back to outcomes.csv.
-import os
 import sys
+from pathlib import Path
 
-ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-sys.path.insert(0, ROOT)
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
-HIST_DIR = os.path.join(ROOT, "data", "history")
-OUTCOMES_CSV = os.path.join(HIST_DIR, "outcomes.csv")
-
+from utils.io import OUTCOMES_CSV
 from utils.outcomes import read_outcomes, score_history, write_outcomes
 
 
 def main() -> None:
-    if not os.path.exists(OUTCOMES_CSV):
+    if not OUTCOMES_CSV.exists():
         print("No outcomes.csv yet; nothing to score.")
         return
 

--- a/utils/io.py
+++ b/utils/io.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Union
+
+import pandas as pd
+
+# Repository root and common data paths
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DATA_DIR = REPO_ROOT / "data"
+HISTORY_DIR = DATA_DIR / "history"
+OUTCOMES_CSV = HISTORY_DIR / "outcomes.csv"
+
+
+def read_csv(path: Union[str, Path], **kwargs) -> pd.DataFrame:
+    """Read a CSV file into a DataFrame.
+
+    Returns an empty DataFrame on failure.
+    """
+    try:
+        return pd.read_csv(path, **kwargs)
+    except Exception:
+        return pd.DataFrame()
+
+
+def write_csv(path: Union[str, Path], df: pd.DataFrame, **kwargs) -> None:
+    """Write a DataFrame to a CSV file ensuring parent directory exists."""
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(p, index=False, **kwargs)


### PR DESCRIPTION
## Summary
- add `utils/io.py` with shared CSV constants and read/write helpers
- refactor app and scripts to use centralized paths and IO helpers
- simplify outcomes utilities to rely on common IO functions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5beebe3e08332a40ac9294383c8b8