### PR TITLE
Consolidate outcome evaluation logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,13 @@ python scripts/check_hits.py
 ```
 
 The script fetches daily price data for each pending entry and marks hits or misses accordingly.
+
+## Historical Scoring
+
+To evaluate whether historical targets were met within their windows, use:
+
+```bash
+python scripts/score_history.py
+```
+
+Rows are marked `YES` or `NO` depending on whether the target level was reached before the window expired.

--- a/scripts/check_hits.py
+++ b/scripts/check_hits.py
@@ -9,7 +9,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from utils.io import OUTCOMES_CSV
-from utils.outcomes import check_pending_hits, read_outcomes, write_outcomes
+from utils.outcomes import evaluate_outcomes, read_outcomes, write_outcomes
 
 
 def main() -> None:
@@ -22,7 +22,7 @@ def main() -> None:
         print("outcomes.csv empty; nothing to check.")
         return
 
-    df = check_pending_hits(df)
+    df = evaluate_outcomes(df, mode="pending")
     write_outcomes(df, OUTCOMES_CSV)
     print("Updated outcomes.csv")
 

--- a/scripts/run_and_log.py
+++ b/scripts/run_and_log.py
@@ -39,7 +39,11 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 from utils.io import DATA_DIR, HISTORY_DIR, OUTCOMES_CSV, write_csv
-from utils.outcomes import upsert_and_backfill_outcomes, settle_pending_outcomes
+from utils.outcomes import (
+    evaluate_outcomes,
+    upsert_and_backfill_outcomes,
+    write_outcomes,
+)
 
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(
@@ -166,8 +170,9 @@ def main() -> int:
             wrote_pass = True
 
             # Update outcomes.csv (insert new, backfill, settle)
-            upsert_and_backfill_outcomes(df_pass, OUTCOMES_CSV)
-            settle_pending_outcomes(OUTCOMES_CSV)
+            out_df = upsert_and_backfill_outcomes(df_pass, OUTCOMES_CSV)
+            out_df = evaluate_outcomes(out_df, mode="pending")
+            write_outcomes(out_df, OUTCOMES_CSV)
         else:
             print("[run_and_log] scan returned no passing tickers.")
 

--- a/scripts/score_history.py
+++ b/scripts/score_history.py
@@ -12,7 +12,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from utils.io import OUTCOMES_CSV
-from utils.outcomes import read_outcomes, score_history, write_outcomes
+from utils.outcomes import evaluate_outcomes, read_outcomes, write_outcomes
 
 
 def main() -> None:
@@ -25,7 +25,7 @@ def main() -> None:
         print("outcomes.csv empty; nothing to score.")
         return
 
-    new_df = score_history(df)
+    new_df = evaluate_outcomes(df, mode="historical")
     write_outcomes(new_df, OUTCOMES_CSV)
     print(f"Scored {len(new_df)} rows → wrote outcomes.csv")
 


### PR DESCRIPTION
## Summary
- add `evaluate_outcomes` for pending settlement and historical scoring
- refactor scripts to use `evaluate_outcomes`
- update run_and_log to settle outcomes via new helper
- document historical scoring usage

## Testing
- `python -m py_compile utils/outcomes.py scripts/check_hits.py scripts/score_history.py scripts/run_and_log.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5c1203e08833282974a250956ee33