### PR TITLE
Remove pick utility from run_and_log

### DIFF
--- a/scripts/run_and_log.py
+++ b/scripts/run_and_log.py
@@ -74,19 +74,6 @@ def ensure_dirs() -> None:
     LOGS_DIR.mkdir(parents=True, exist_ok=True)
 
 
-def pick(df: pd.DataFrame, col: str, default=None):
-    """Safe column getter for a homogeneous value; returns default if missing."""
-    try:
-        if df is None or df.empty or col not in df.columns:
-            return default
-        vals = df[col].dropna().unique()
-        if len(vals) == 0:
-            return default
-        return vals[0]
-    except Exception:
-        return default
-
-
 # --------------------------------------------------------------------
 # 3. Screener Runner (invoke library, gather DataFrames)
 # --------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- remove unused `pick` helper from run_and_log script

## Testing
- `pytest`
- `rg "pick(" -n`


------
https://chatgpt.com/codex/tasks/task_e_68b5c11ea58883328c2f113ace2d1215