### PR TITLE
refactor: centralize scan compatibility

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,11 +14,11 @@
 
 import glob, io, pandas as pd, streamlit as st
 from datetime import datetime
-import swing_options_screener as sos  # core engine
 from ui.layout import setup_page, render_header
 from ui.debugger import render_debugger_tab
 from utils.formatting import _bold, _usd, _pct, _safe
 from utils.io import DATA_DIR, HISTORY_DIR, OUTCOMES_CSV, read_csv
+from utils.scan import safe_run_scan
 
 # ============================================================
 # 2. App constants (paths, titles, etc.)
@@ -130,51 +130,6 @@ def outcomes_summary(dfh: pd.DataFrame):
 # ─────────────────────────────────────────────────────────────────────────────
 # 9. TAB – Scanner (table → WHY BUY → Sheets export)
 # ─────────────────────────────────────────────────────────────────────────────
-def _safe_run_scan() -> dict:
-    """Call sos.run_scan with backward-compatible signatures and normalize outputs
-    without using boolean truthiness on DataFrames."""
-    import pandas as _pd
-
-    # Try different parameter names used across your versions
-    try:
-        out = sos.run_scan(market="sp500", with_options=True)
-    except TypeError:
-        try:
-            out = sos.run_scan(universe="sp500", with_options=True)
-        except TypeError:
-            out = sos.run_scan(with_options=True)
-
-    df_pass, df_scan = None, None
-
-    if isinstance(out, dict):
-        cand = out.get("pass", None)
-        if isinstance(cand, _pd.DataFrame):
-            df_pass = cand
-        cand = out.get("pass_df", None)
-        if df_pass is None and isinstance(cand, _pd.DataFrame):
-            df_pass = cand
-        cand = out.get("pass_df_unadjusted", None)
-        if df_pass is None and isinstance(cand, _pd.DataFrame):
-            df_pass = cand
-
-        cand = out.get("scan", None)
-        if isinstance(cand, _pd.DataFrame):
-            df_scan = cand
-        cand = out.get("scan_df", None)
-        if df_scan is None and isinstance(cand, _pd.DataFrame):
-            df_scan = cand
-
-    elif isinstance(out, (list, tuple)):
-        if len(out) >= 1 and isinstance(out[0], _pd.DataFrame):
-            df_pass = out[0]
-        if len(out) >= 2 and isinstance(out[1], _pd.DataFrame):
-            df_scan = out[1]
-
-    elif isinstance(out, _pd.DataFrame):
-        # Some versions just return the passing table
-        df_pass = out
-
-    return {"pass": df_pass, "scan": df_scan}
 
 
 def _sheet_friendly(df: pd.DataFrame) -> pd.DataFrame:
@@ -223,7 +178,7 @@ def render_scanner_tab():
 
     if run_clicked:
         with st.spinner("Scanning…"):
-            out = _safe_run_scan()
+            out = safe_run_scan()
         df_pass: pd.DataFrame | None = out.get("pass", None)
 
         st.session_state["last_pass"] = df_pass

--- a/scripts/run_and_log.py
+++ b/scripts/run_and_log.py
@@ -18,15 +18,8 @@ import argparse
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-import inspect
 import pandas as pd
-
-# Screener module (must be importable from repo root)
-try:
-    import swing_options_screener as sos
-except Exception as e:
-    print(f"[FATAL] Could not import swing_options_screener: {e}", file=sys.stderr)
-    sys.exit(1)
+from typing import Optional
 
 # Optional universe helper (only used if present)
 try:
@@ -40,6 +33,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 from utils.io import DATA_DIR, HISTORY_DIR, OUTCOMES_CSV, write_csv
 from utils.outcomes import upsert_and_backfill_outcomes, settle_pending_outcomes
+from utils.scan import safe_run_scan
 
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(
@@ -90,57 +84,7 @@ def pick(df: pd.DataFrame, col: str, default=None):
 # --------------------------------------------------------------------
 # 3. Screener Runner (invoke library, gather DataFrames)
 # --------------------------------------------------------------------
-from typing import Tuple, Optional
-import pandas as pd
-import swing_options_screener as sos
-
-def _safe_engine_run_scan() -> dict:
-    """
-    Call sos.run_scan() across historical signature variants and normalize
-    the result to a dict with keys: {'pass': DataFrame|None, 'scan': DataFrame|None}
-    """
-    import pandas as _pd
-
-    # Try different parameter names used across versions of your engine
-    try:
-        out = sos.run_scan(market="sp500", with_options=True)
-    except TypeError:
-        try:
-            out = sos.run_scan(universe="sp500", with_options=True)
-        except TypeError:
-            out = sos.run_scan(with_options=True)
-
-    df_pass, df_scan = None, None
-
-    if isinstance(out, dict):
-        cand = out.get("pass", None)
-        if isinstance(cand, _pd.DataFrame):
-            df_pass = cand
-        cand = out.get("pass_df", None)
-        if df_pass is None and isinstance(cand, _pd.DataFrame):
-            df_pass = cand
-        cand = out.get("pass_df_unadjusted", None)
-        if df_pass is None and isinstance(cand, _pd.DataFrame):
-            df_pass = cand
-
-        cand = out.get("scan", None)
-        if isinstance(cand, _pd.DataFrame):
-            df_scan = cand
-        cand = out.get("scan_df", None)
-        if df_scan is None and isinstance(cand, _pd.DataFrame):
-            df_scan = cand
-
-    elif isinstance(out, (list, tuple)):
-        if len(out) >= 1 and isinstance(out[0], _pd.DataFrame):
-            df_pass = out[0]
-        if len(out) >= 2 and isinstance(out[1], _pd.DataFrame):
-            df_scan = out[1]
-
-    elif isinstance(out, _pd.DataFrame):
-        # Some versions just return the passing table
-        df_pass = out
-
-    return {"pass": df_pass, "scan": df_scan}
+# safe_run_scan is imported from utils.scan
 
 # --------------------------------------------------------------------
 # 4. Main (glue: run, save pass file, write logs, upsert outcomes)
@@ -152,7 +96,7 @@ def main() -> int:
     ensure_dirs()
 
     try:
-        res = _safe_engine_run_scan()
+        res = safe_run_scan()
         df_pass: Optional[pd.DataFrame] = res.get("pass")
         # df_scan = res.get("scan")  # currently unused here
 

--- a/utils/scan.py
+++ b/utils/scan.py
@@ -1,0 +1,48 @@
+import pandas as pd
+
+
+def safe_run_scan(with_options: bool = True) -> dict:
+    """Call sos.run_scan with backward-compatible signatures and normalize outputs
+    without using boolean truthiness on DataFrames."""
+    import swing_options_screener as sos  # local import for flexibility
+
+    # Try different parameter names used across versions
+    try:
+        out = sos.run_scan(market="sp500", with_options=with_options)
+    except TypeError:
+        try:
+            out = sos.run_scan(universe="sp500", with_options=with_options)
+        except TypeError:
+            out = sos.run_scan(with_options=with_options)
+
+    df_pass, df_scan = None, None
+
+    if isinstance(out, dict):
+        cand = out.get("pass")
+        if isinstance(cand, pd.DataFrame):
+            df_pass = cand
+        cand = out.get("pass_df")
+        if df_pass is None and isinstance(cand, pd.DataFrame):
+            df_pass = cand
+        cand = out.get("pass_df_unadjusted")
+        if df_pass is None and isinstance(cand, pd.DataFrame):
+            df_pass = cand
+
+        cand = out.get("scan")
+        if isinstance(cand, pd.DataFrame):
+            df_scan = cand
+        cand = out.get("scan_df")
+        if df_scan is None and isinstance(cand, pd.DataFrame):
+            df_scan = cand
+
+    elif isinstance(out, (list, tuple)):
+        if len(out) >= 1 and isinstance(out[0], pd.DataFrame):
+            df_pass = out[0]
+        if len(out) >= 2 and isinstance(out[1], pd.DataFrame):
+            df_scan = out[1]
+
+    elif isinstance(out, pd.DataFrame):
+        # Some versions just return the passing table
+        df_pass = out
+
+    return {"pass": df_pass, "scan": df_scan}


### PR DESCRIPTION
## Summary
- extract shared scan compatibility logic to `utils.scan.safe_run_scan`
- use shared `safe_run_scan` in `app` and `run_and_log`
- remove duplicated scan helpers and related imports

## Testing
- `pytest -q`
- `python -m py_compile app.py scripts/run_and_log.py utils/scan.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5c11d7b80833289fb4b2bdef15d6a