### PR TITLE
extract safe run scan helper

### DIFF
--- a/scripts/run_and_log.py
+++ b/scripts/run_and_log.py
@@ -18,15 +18,7 @@ import argparse
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-import inspect
 import pandas as pd
-
-# Screener module (must be importable from repo root)
-try:
-    import swing_options_screener as sos
-except Exception as e:
-    print(f"[FATAL] Could not import swing_options_screener: {e}", file=sys.stderr)
-    sys.exit(1)
 
 # Optional universe helper (only used if present)
 try:
@@ -77,57 +69,8 @@ def ensure_dirs() -> None:
 # --------------------------------------------------------------------
 # 3. Screener Runner (invoke library, gather DataFrames)
 # --------------------------------------------------------------------
-from typing import Tuple, Optional
-import pandas as pd
-import swing_options_screener as sos
-
-def _safe_engine_run_scan() -> dict:
-    """
-    Call sos.run_scan() across historical signature variants and normalize
-    the result to a dict with keys: {'pass': DataFrame|None, 'scan': DataFrame|None}
-    """
-    import pandas as _pd
-
-    # Try different parameter names used across versions of your engine
-    try:
-        out = sos.run_scan(market="sp500", with_options=True)
-    except TypeError:
-        try:
-            out = sos.run_scan(universe="sp500", with_options=True)
-        except TypeError:
-            out = sos.run_scan(with_options=True)
-
-    df_pass, df_scan = None, None
-
-    if isinstance(out, dict):
-        cand = out.get("pass", None)
-        if isinstance(cand, _pd.DataFrame):
-            df_pass = cand
-        cand = out.get("pass_df", None)
-        if df_pass is None and isinstance(cand, _pd.DataFrame):
-            df_pass = cand
-        cand = out.get("pass_df_unadjusted", None)
-        if df_pass is None and isinstance(cand, _pd.DataFrame):
-            df_pass = cand
-
-        cand = out.get("scan", None)
-        if isinstance(cand, _pd.DataFrame):
-            df_scan = cand
-        cand = out.get("scan_df", None)
-        if df_scan is None and isinstance(cand, _pd.DataFrame):
-            df_scan = cand
-
-    elif isinstance(out, (list, tuple)):
-        if len(out) >= 1 and isinstance(out[0], _pd.DataFrame):
-            df_pass = out[0]
-        if len(out) >= 2 and isinstance(out[1], _pd.DataFrame):
-            df_scan = out[1]
-
-    elif isinstance(out, _pd.DataFrame):
-        # Some versions just return the passing table
-        df_pass = out
-
-    return {"pass": df_pass, "scan": df_scan}
+from typing import Optional
+from utils.scan import safe_run_scan
 
 # --------------------------------------------------------------------
 # 4. Main (glue: run, save pass file, write logs, upsert outcomes)
@@ -139,7 +82,7 @@ def main() -> int:
     ensure_dirs()
 
     try:
-        res = _safe_engine_run_scan()
+        res = safe_run_scan()
         df_pass: Optional[pd.DataFrame] = res.get("pass")
         # df_scan = res.get("scan")  # currently unused here
 

--- a/ui/scan.py
+++ b/ui/scan.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import streamlit as st
-import swing_options_screener as sos
 from utils.formatting import _bold, _usd, _pct, _safe
+from utils.scan import safe_run_scan
 
 
 def build_why_buy_html(row: dict) -> str:
@@ -41,53 +41,6 @@ def build_why_buy_html(row: dict) -> str:
     ]
 
     return "<div class='whybuy'>" + header + "<br>" + "<br>".join(bullets) + "</div>"
-
-
-def _safe_run_scan() -> dict:
-    """Call sos.run_scan with backward-compatible signatures and normalize outputs
-    without using boolean truthiness on DataFrames."""
-    import pandas as _pd
-
-    # Try different parameter names used across your versions
-    try:
-        out = sos.run_scan(market="sp500", with_options=True)
-    except TypeError:
-        try:
-            out = sos.run_scan(universe="sp500", with_options=True)
-        except TypeError:
-            out = sos.run_scan(with_options=True)
-
-    df_pass, df_scan = None, None
-
-    if isinstance(out, dict):
-        cand = out.get("pass", None)
-        if isinstance(cand, _pd.DataFrame):
-            df_pass = cand
-        cand = out.get("pass_df", None)
-        if df_pass is None and isinstance(cand, _pd.DataFrame):
-            df_pass = cand
-        cand = out.get("pass_df_unadjusted", None)
-        if df_pass is None and isinstance(cand, _pd.DataFrame):
-            df_pass = cand
-
-        cand = out.get("scan", None)
-        if isinstance(cand, _pd.DataFrame):
-            df_scan = cand
-        cand = out.get("scan_df", None)
-        if df_scan is None and isinstance(cand, _pd.DataFrame):
-            df_scan = cand
-
-    elif isinstance(out, (list, tuple)):
-        if len(out) >= 1 and isinstance(out[0], _pd.DataFrame):
-            df_pass = out[0]
-        if len(out) >= 2 and isinstance(out[1], _pd.DataFrame):
-            df_scan = out[1]
-
-    elif isinstance(out, _pd.DataFrame):
-        # Some versions just return the passing table
-        df_pass = out
-
-    return {"pass": df_pass, "scan": df_scan}
 
 
 def _sheet_friendly(df: pd.DataFrame) -> pd.DataFrame:
@@ -136,7 +89,7 @@ def render_scanner_tab():
 
     if run_clicked:
         with st.spinner("Scanning…"):
-            out = _safe_run_scan()
+            out = safe_run_scan()
         df_pass: pd.DataFrame | None = out.get("pass", None)
 
         st.session_state["last_pass"] = df_pass

--- a/utils/scan.py
+++ b/utils/scan.py
@@ -1,0 +1,45 @@
+import pandas as pd
+import swing_options_screener as sos
+
+def safe_run_scan(with_options: bool = True) -> dict:
+    """Call sos.run_scan across historical signature variants and normalize outputs.
+
+    Returns a dict with keys {"pass": DataFrame|None, "scan": DataFrame|None}.
+    """
+    try:
+        out = sos.run_scan(market="sp500", with_options=with_options)
+    except TypeError:
+        try:
+            out = sos.run_scan(universe="sp500", with_options=with_options)
+        except TypeError:
+            out = sos.run_scan(with_options=with_options)
+
+    df_pass, df_scan = None, None
+
+    if isinstance(out, dict):
+        cand = out.get("pass")
+        if isinstance(cand, pd.DataFrame):
+            df_pass = cand
+        cand = out.get("pass_df")
+        if df_pass is None and isinstance(cand, pd.DataFrame):
+            df_pass = cand
+        cand = out.get("pass_df_unadjusted")
+        if df_pass is None and isinstance(cand, pd.DataFrame):
+            df_pass = cand
+
+        cand = out.get("scan")
+        if isinstance(cand, pd.DataFrame):
+            df_scan = cand
+        cand = out.get("scan_df")
+        if df_scan is None and isinstance(cand, pd.DataFrame):
+            df_scan = cand
+
+    elif isinstance(out, (list, tuple)):
+        if len(out) >= 1 and isinstance(out[0], pd.DataFrame):
+            df_pass = out[0]
+        if len(out) >= 2 and isinstance(out[1], pd.DataFrame):
+            df_scan = out[1]
+    elif isinstance(out, pd.DataFrame):
+        df_pass = out
+
+    return {"pass": df_pass, "scan": df_scan}


### PR DESCRIPTION
## Summary
- centralize run_scan signature fallback in new `safe_run_scan` util
- update UI and logging scripts to use shared `safe_run_scan`
- remove redundant local helpers and streamline imports

## Testing
- `python -m py_compile utils/scan.py ui/scan.py scripts/run_and_log.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5c4655a7c8332added708168f3e00