### PR TITLE
Refactor outcome evaluation into unified function

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,13 @@ python scripts/check_hits.py
 ```
 
 The script fetches daily price data for each pending entry and marks hits or misses accordingly.
+
+## Historical Scoring
+
+For backtesting datasets that include `EvalDate`, `WindowEnd`, and `TargetLevel`
+columns, run `scripts/score_history.py` to evaluate whether price targets were
+hit before each window closed.
+
+```bash
+python scripts/score_history.py
+```

--- a/scripts/check_hits.py
+++ b/scripts/check_hits.py
@@ -9,7 +9,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from utils.io import OUTCOMES_CSV
-from utils.outcomes import check_pending_hits, read_outcomes, write_outcomes
+from utils.outcomes import evaluate_outcomes, read_outcomes, write_outcomes
 
 
 def main() -> None:
@@ -22,7 +22,7 @@ def main() -> None:
         print("outcomes.csv empty; nothing to check.")
         return
 
-    df = check_pending_hits(df)
+    df = evaluate_outcomes(df, mode="pending")
     write_outcomes(df, OUTCOMES_CSV)
     print("Updated outcomes.csv")
 

--- a/scripts/score_history.py
+++ b/scripts/score_history.py
@@ -12,7 +12,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from utils.io import OUTCOMES_CSV
-from utils.outcomes import read_outcomes, score_history, write_outcomes
+from utils.outcomes import evaluate_outcomes, read_outcomes, write_outcomes
 
 
 def main() -> None:
@@ -25,7 +25,7 @@ def main() -> None:
         print("outcomes.csv empty; nothing to score.")
         return
 
-    new_df = score_history(df)
+    new_df = evaluate_outcomes(df, mode="historical")
     write_outcomes(new_df, OUTCOMES_CSV)
     print(f"Scored {len(new_df)} rows → wrote outcomes.csv")
 


### PR DESCRIPTION
## Summary
- add `evaluate_outcomes` handling pending and historical modes
- update hit check and history scoring scripts to use `evaluate_outcomes`
- document historical scoring usage in README

## Testing
- `python scripts/check_hits.py`
- `python scripts/score_history.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5c465ddc083329139053fa1ddae72