### PR TITLE
Remove duplicate imports in run_and_log

### DIFF
--- a/scripts/run_and_log.py
+++ b/scripts/run_and_log.py
@@ -20,6 +20,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 import inspect
 import pandas as pd
+from typing import Optional
 
 # Screener module (must be importable from repo root)
 try:
@@ -77,9 +78,6 @@ def ensure_dirs() -> None:
 # --------------------------------------------------------------------
 # 3. Screener Runner (invoke library, gather DataFrames)
 # --------------------------------------------------------------------
-from typing import Tuple, Optional
-import pandas as pd
-import swing_options_screener as sos
 
 def _safe_engine_run_scan() -> dict:
     """


### PR DESCRIPTION
## Summary
- Deduplicate pandas and screener imports in `scripts/run_and_log.py`
- Keep primary imports at the top and clean up "Screener Runner" section

## Testing
- `python -m py_compile scripts/run_and_log.py`
- `python scripts/run_and_log.py --help` *(fails: No module named 'swing_options_screener')*

------
https://chatgpt.com/codex/tasks/task_e_68b5c46b857c83329b1053605624659c