### PR TITLE
refactor: centralize repo root bootstrap

### DIFF
--- a/scripts/_bootstrap.py
+++ b/scripts/_bootstrap.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def add_repo_root() -> None:
+    """Insert the repository root into ``sys.path``.
+
+    The path is added to the front of ``sys.path`` if it is not already present.
+    This allows scripts to import project modules when executed directly.
+    """
+    root = Path(__file__).resolve().parents[1]
+    root_str = str(root)
+    if root_str not in sys.path:
+        sys.path.insert(0, root_str)
+

--- a/scripts/check_hits.py
+++ b/scripts/check_hits.py
@@ -1,12 +1,7 @@
 #!/usr/bin/env python3
 """Update ``data/history/outcomes.csv`` by evaluating pending rows."""
 
-import sys
-from pathlib import Path
-
-ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
+from _bootstrap import add_repo_root; add_repo_root()
 
 from utils.io import OUTCOMES_CSV
 from utils.outcomes import check_pending_hits, read_outcomes, write_outcomes

--- a/scripts/run_and_log.py
+++ b/scripts/run_and_log.py
@@ -17,9 +17,11 @@ Bibliography (Section Index)
 import argparse
 import sys
 from datetime import datetime, timezone
-from pathlib import Path
-import inspect
+from typing import Optional
+
 import pandas as pd
+
+from _bootstrap import add_repo_root; add_repo_root()
 
 # Screener module (must be importable from repo root)
 try:
@@ -35,9 +37,6 @@ except Exception:
     spuni = None
 
 # Shared outcome helpers
-ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
 from utils.io import DATA_DIR, HISTORY_DIR, OUTCOMES_CSV, write_csv
 from utils.outcomes import upsert_and_backfill_outcomes, settle_pending_outcomes
 
@@ -77,9 +76,6 @@ def ensure_dirs() -> None:
 # --------------------------------------------------------------------
 # 3. Screener Runner (invoke library, gather DataFrames)
 # --------------------------------------------------------------------
-from typing import Tuple, Optional
-import pandas as pd
-import swing_options_screener as sos
 
 def _safe_engine_run_scan() -> dict:
     """

--- a/scripts/score_history.py
+++ b/scripts/score_history.py
@@ -4,12 +4,7 @@
 # - For Outcome == PENDING, checks if TargetLevel was hit (High >= level)
 #   between EvalDate (inclusive) and min(WindowEnd, today) (inclusive).
 #   Results are written back to outcomes.csv.
-import sys
-from pathlib import Path
-
-ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
+from _bootstrap import add_repo_root; add_repo_root()
 
 from utils.io import OUTCOMES_CSV
 from utils.outcomes import read_outcomes, score_history, write_outcomes


### PR DESCRIPTION
## Summary
- add helper to insert repo root into sys.path if missing
- use helper in check_hits, score_history, and run_and_log scripts

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5c46d0f94833287af3a10a65a0d43