### PR TITLE
feat: centralize scripts bootstrap

### DIFF
--- a/scripts/_bootstrap.py
+++ b/scripts/_bootstrap.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+"""Utilities for bootstrapping script imports.
+
+This module exposes :func:`add_repo_root` which ensures that the
+repository root directory is on ``sys.path``. It is safe to call multiple
+times: if the path is already present, the function does nothing.
+"""
+
+from pathlib import Path
+import sys
+
+
+def add_repo_root() -> None:
+    """Insert the repository root into ``sys.path`` if it's missing."""
+    root = Path(__file__).resolve().parents[1]
+    root_str = str(root)
+    if root_str not in sys.path:
+        sys.path.insert(0, root_str)

--- a/scripts/check_hits.py
+++ b/scripts/check_hits.py
@@ -1,12 +1,7 @@
 #!/usr/bin/env python3
 """Update ``data/history/outcomes.csv`` by evaluating pending rows."""
 
-import sys
-from pathlib import Path
-
-ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
+from _bootstrap import add_repo_root; add_repo_root()
 
 from utils.io import OUTCOMES_CSV
 from utils.outcomes import evaluate_outcomes, read_outcomes, write_outcomes

--- a/scripts/run_and_log.py
+++ b/scripts/run_and_log.py
@@ -17,7 +17,6 @@ Bibliography (Section Index)
 import argparse
 import sys
 from datetime import datetime, timezone
-from pathlib import Path
 import pandas as pd
 
 # Optional universe helper (only used if present)
@@ -27,9 +26,7 @@ except Exception:
     spuni = None
 
 # Shared outcome helpers
-ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
+from _bootstrap import add_repo_root; add_repo_root()
 from utils.io import DATA_DIR, HISTORY_DIR, OUTCOMES_CSV, write_csv
 from utils.outcomes import upsert_and_backfill_outcomes, settle_pending_outcomes
 

--- a/scripts/score_history.py
+++ b/scripts/score_history.py
@@ -4,12 +4,7 @@
 # - For Outcome == PENDING, checks if TargetLevel was hit (High >= level)
 #   between EvalDate (inclusive) and min(WindowEnd, today) (inclusive).
 #   Results are written back to outcomes.csv.
-import sys
-from pathlib import Path
-
-ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
+from _bootstrap import add_repo_root; add_repo_root()
 
 from utils.io import OUTCOMES_CSV
 from utils.outcomes import evaluate_outcomes, read_outcomes, write_outcomes


### PR DESCRIPTION
## Summary
- add `_bootstrap.add_repo_root` helper for scripts
- replace manual sys.path injection with shared helper

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5d5d158748332aab86dd942aff2bf