### PR TITLE
Consolidate pending outcome settlement

### DIFF
--- a/scripts/run_and_log.py
+++ b/scripts/run_and_log.py
@@ -31,7 +31,11 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 from utils.io import DATA_DIR, HISTORY_DIR, OUTCOMES_CSV, write_csv
-from utils.outcomes import upsert_and_backfill_outcomes, settle_pending_outcomes
+from utils.outcomes import (
+    upsert_and_backfill_outcomes,
+    evaluate_outcomes,
+    write_outcomes,
+)
 
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(
@@ -95,9 +99,10 @@ def main() -> int:
             print(f"[run_and_log] wrote {pass_path}")
             wrote_pass = True
 
-            # Update outcomes.csv (insert new, backfill, settle)
-            upsert_and_backfill_outcomes(df_pass, OUTCOMES_CSV)
-            settle_pending_outcomes(OUTCOMES_CSV)
+            # Update outcomes.csv (insert new, backfill, evaluate)
+            out_df = upsert_and_backfill_outcomes(df_pass, OUTCOMES_CSV)
+            out_df = evaluate_outcomes(out_df, mode="pending")
+            write_outcomes(out_df, OUTCOMES_CSV)
         else:
             print("[run_and_log] scan returned no passing tickers.")
 


### PR DESCRIPTION
## Summary
- extend `evaluate_outcomes` to settle pending rows including hit date resolution
- remove dedicated `settle_pending_outcomes` helper
- `run_and_log.py` now evaluates and writes outcomes in one step

## Testing
- `python -m py_compile utils/outcomes.py scripts/run_and_log.py scripts/check_hits.py scripts/score_history.py`
- `python scripts/check_hits.py` *(warnings: multiple fetch_history 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d5d40bf0833297d42d37b22e0668