### PR TITLE
Simplify outcome loading with shared reader

### DIFF
--- a/scripts/check_hits.py
+++ b/scripts/check_hits.py
@@ -13,10 +13,6 @@ from utils.outcomes import evaluate_outcomes, read_outcomes, write_outcomes
 
 
 def main() -> None:
-    if not OUTCOMES_CSV.exists():
-        print("No outcomes.csv yet; nothing to check.")
-        return
-
     df = read_outcomes(OUTCOMES_CSV)
     if df.empty:
         print("outcomes.csv empty; nothing to check.")

--- a/scripts/score_history.py
+++ b/scripts/score_history.py
@@ -16,10 +16,6 @@ from utils.outcomes import evaluate_outcomes, read_outcomes, write_outcomes
 
 
 def main() -> None:
-    if not OUTCOMES_CSV.exists():
-        print("No outcomes.csv yet; nothing to score.")
-        return
-
     df = read_outcomes(OUTCOMES_CSV)
     if df.empty:
         print("outcomes.csv empty; nothing to score.")

--- a/tests/test_history_load.py
+++ b/tests/test_history_load.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import ui.history as history
+from utils import outcomes
+
+
+def test_load_outcomes_wraps_read_outcomes(monkeypatch):
+    sentinel = pd.DataFrame({"a": [1]})
+    monkeypatch.setattr(history, "read_outcomes", lambda: sentinel)
+    assert history.load_outcomes() is sentinel
+
+
+def test_load_outcomes_missing_file(tmp_path, monkeypatch):
+    dummy = tmp_path / "missing.csv"
+
+    def fake_read_outcomes():
+        return outcomes.read_outcomes(dummy)
+
+    monkeypatch.setattr(history, "read_outcomes", fake_read_outcomes)
+    df = history.load_outcomes()
+    assert df.empty
+    assert list(df.columns) == outcomes.OUTCOLS

--- a/ui/history.py
+++ b/ui/history.py
@@ -1,7 +1,8 @@
 import glob
 import pandas as pd
 import streamlit as st
-from utils.io import DATA_DIR, HISTORY_DIR, OUTCOMES_CSV, read_csv
+from utils.io import DATA_DIR, HISTORY_DIR, read_csv
+from utils.outcomes import read_outcomes
 
 PASS_DIR = DATA_DIR / "pass_logs"
 
@@ -15,13 +16,12 @@ def latest_pass_file():
 
 
 def load_outcomes():
-    if OUTCOMES_CSV.exists():
-        return read_csv(OUTCOMES_CSV)
-    return pd.DataFrame()
+    """Thin wrapper around :func:`utils.outcomes.read_outcomes`."""
+    return read_outcomes()
 
 
 def outcomes_summary(dfh: pd.DataFrame):
-    if dfh is None or dfh.empty:
+    if dfh.empty:
         st.info("No outcomes yet.")
         return
 
@@ -77,7 +77,7 @@ def render_history_tab():
     st.subheader("Outcomes (sorted by option expiry)")
 
     dfh = load_outcomes()
-    if dfh is None or dfh.empty:
+    if dfh.empty:
         st.info("No outcomes yet.")
     else:
         dfh = dfh.copy()


### PR DESCRIPTION
## Summary
- Streamline history tab by delegating outcome loading to `utils.outcomes.read_outcomes`
- Remove manual CSV existence checks in history UI and scripts
- Add tests for the outcome loader wrapper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5d5d55e7083328e64b55af8d6e803