### PR TITLE
Refactor outcomes summary logic into reusable helper

### DIFF
--- a/ui/history.py
+++ b/ui/history.py
@@ -47,43 +47,103 @@ def load_outcomes():
 
 
 def outcomes_summary(dfh: pd.DataFrame):
+    """Render a concise outcomes table with hit/miss statistics."""
     if dfh.empty:
         st.info("No outcomes yet.")
         return
 
-    n = len(dfh)
-    # Ensure we always have Series (never scalars) to avoid .sum() errors
-    if "result_status" in dfh.columns:
-        s_status = dfh["result_status"].astype(str)
+    dfh = dfh.copy()
+
+    # Ensure expected columns exist so downstream ops don't KeyError
+    for c in ["Expiry", "EvalDate", "Notes"]:
+        if c not in dfh.columns:
+            dfh[c] = pd.NA
+
+    # Prefer result_status then fall back to Status
+    status_col = (
+        "result_status"
+        if "result_status" in dfh.columns
+        else ("Status" if "Status" in dfh.columns else None)
+    )
+
+    # Helper: coerce to tz-naive pandas Timestamp
+    def _to_naive(series: pd.Series) -> pd.Series:
+        s = pd.to_datetime(series, errors="coerce", utc=True)
+        return s.dt.tz_convert("UTC").dt.tz_localize(None)
+
+    dfh["Expiry_parsed"] = _to_naive(dfh["Expiry"])
+    dfh["EvalDate_parsed"] = _to_naive(dfh["EvalDate"])
+
+    # Backfill missing expiry from EvalDate + 30d (display-only)
+    need_exp = dfh["Expiry_parsed"].isna() & dfh["EvalDate_parsed"].notna()
+    if need_exp.any():
+        dfh.loc[need_exp, "Expiry_parsed"] = dfh.loc[need_exp, "EvalDate_parsed"] + pd.Timedelta(
+            days=30
+        )
+
+    # Robust DTE using nanoseconds to avoid dtype issues
+    dfh["DTE"] = pd.Series(pd.NA, index=dfh.index, dtype="Int64")
+    mask = dfh["Expiry_parsed"].notna()
+    if mask.any():
+        base_ns = pd.Timestamp.utcnow().normalize().value  # int64 ns at 00:00 UTC today
+        exp_ns = dfh.loc[mask, "Expiry_parsed"].view("int64")
+        NS_PER_DAY = 86_400_000_000_000
+        dte_days = ((exp_ns - base_ns) // NS_PER_DAY).astype("int64")
+        dfh.loc[mask, "DTE"] = pd.array(dte_days, dtype="Int64")
+
+    # Sort: earliest expiry first; for ties, most recent EvalDate first; NaT at end
+    exp_key = dfh["Expiry_parsed"].fillna(pd.Timestamp.max)
+    dfh_sorted = dfh.assign(_expkey=exp_key).sort_values(
+        ["_expkey", "EvalDate_parsed"], ascending=[True, False]
+    ).drop(columns=["_expkey"])
+
+    # Summary counts
+    notes_up = dfh_sorted["Notes"].astype(str).str.upper()
+    hits = int(notes_up.isin(["HIT_BY_SELLK", "HIT_BY_TP"]).sum())
+    misses = int((notes_up == "EXPIRED_NO_HIT").sum())
+
+    if status_col:
+        s_up = dfh_sorted[status_col].astype(str).str.upper()
+        settled = int((s_up == "SETTLED").sum())
+        pending = int((s_up != "SETTLED").sum())
     else:
-        # Assume not yet settled if the column is missing
-        s_status = pd.Series(["PENDING"] * n, index=dfh.index, dtype="string")
+        settled = hits + misses
+        pending = int(len(dfh_sorted) - settled)
 
-    if "hit" in dfh.columns:
-        hit_mask = dfh["hit"].astype(bool)
-    else:
-        hit_mask = pd.Series([False] * n, index=dfh.index, dtype=bool)
+    st.caption(
+        f"Settled: {settled} • Hits: {hits} • Misses: {misses} • Pending: {pending}"
+    )
 
-    settled_mask = s_status.eq("SETTLED")
-    pending_mask = ~settled_mask
+    # Show parsed expiry when original blank; format for display
+    df_disp = dfh_sorted.copy()
+    use_parsed = df_disp["Expiry"].isna() | (
+        df_disp["Expiry"].astype(str).str.strip() == ""
+    )
+    df_disp.loc[use_parsed, "Expiry"] = df_disp.loc[use_parsed, "Expiry_parsed"].dt.strftime(
+        "%Y-%m-%d"
+    )
 
-    settled = int(settled_mask.sum())
-    pending = int(pending_mask.sum())
-    hits = int((settled_mask & hit_mask).sum())
-    misses = settled - hits
+    preferred = [
+        "Ticker",
+        "EvalDate",
+        "Price",
+        "EntryTimeET",
+        status_col if status_col else "Status",
+        "HitDateET",
+        "Expiry",
+        "DTE",
+        "BuyK",
+        "SellK",
+        "TP",
+        "Notes",
+    ]
+    cols = [c for c in preferred if c in df_disp.columns]
+    if cols:
+        df_disp = df_disp[cols]
 
-    st.caption(f"Settled: {settled} • Hits: {hits} • Misses: {misses} • Pending: {pending}")
-
-    # Nice sort if the columns exist; otherwise just show as-is
-    sort_cols = [c for c in ["run_date", "ticker"] if c in dfh.columns]
-    if sort_cols:
-        # run_date desc if present
-        ascending = [False if c == "run_date" else True for c in sort_cols]
-        df_show = dfh.sort_values(sort_cols, ascending=ascending)
-    else:
-        df_show = dfh
-
-    st.dataframe(df_show, use_container_width=True, height=min(600, 80 + 28 * len(df_show)))
+    st.dataframe(
+        df_disp, use_container_width=True, height=min(600, 80 + 28 * len(df_disp))
+    )
 
 
 def render_history_tab():
@@ -102,77 +162,4 @@ def render_history_tab():
     # --- Outcomes, sorted by option expiry (oldest → newest) ---
     st.subheader("Outcomes (sorted by option expiry)")
 
-    dfh = load_outcomes()
-    if dfh.empty:
-        st.info("No outcomes yet.")
-    else:
-        dfh = dfh.copy()
-
-        # Ensure expected columns exist
-        for c in ["Expiry", "EvalDate", "Notes"]:
-            if c not in dfh.columns:
-                dfh[c] = pd.NA
-
-        # Prefer result_status, then Status
-        status_col = "result_status" if "result_status" in dfh.columns else ("Status" if "Status" in dfh.columns else None)
-
-        # Helper: to tz-naive pandas Timestamp
-        def _to_naive(series: pd.Series) -> pd.Series:
-            s = pd.to_datetime(series, errors="coerce", utc=True)
-            return s.dt.tz_convert("UTC").dt.tz_localize(None)
-
-        # Parse & normalize times
-        dfh["Expiry_parsed"] = _to_naive(dfh["Expiry"])
-        dfh["EvalDate_parsed"] = _to_naive(dfh["EvalDate"])
-
-        # Backfill missing expiry from EvalDate + 30d (display-only)
-        need_exp = dfh["Expiry_parsed"].isna() & dfh["EvalDate_parsed"].notna()
-        if need_exp.any():
-            dfh.loc[need_exp, "Expiry_parsed"] = dfh.loc[need_exp, "EvalDate_parsed"] + pd.Timedelta(days=30)
-
-        # ---- Robust DTE using nanoseconds to avoid dtype issues ----
-        dfh["DTE"] = pd.Series(pd.NA, index=dfh.index, dtype="Int64")
-        mask = dfh["Expiry_parsed"].notna()
-        if mask.any():
-            base_ns = pd.Timestamp.utcnow().normalize().value  # int64 ns at 00:00 UTC today
-            exp_ns = dfh.loc[mask, "Expiry_parsed"].view("int64")
-            NS_PER_DAY = 86_400_000_000_000
-            dte_days = ((exp_ns - base_ns) // NS_PER_DAY).astype("int64")
-            dfh.loc[mask, "DTE"] = pd.array(dte_days, dtype="Int64")
-
-        # Sort: earliest expiry first; for ties, most recent EvalDate first; NaT at end
-        exp_key = dfh["Expiry_parsed"].fillna(pd.Timestamp.max)
-        dfh_sorted = dfh.assign(_expkey=exp_key).sort_values(
-            ["_expkey", "EvalDate_parsed"], ascending=[True, False]
-        ).drop(columns=["_expkey"])
-
-        # Summary counts
-        notes_up = dfh_sorted["Notes"].astype(str).str.upper()
-        hits = int(notes_up.isin(["HIT_BY_SELLK", "HIT_BY_TP"]).sum())
-        misses = int((notes_up == "EXPIRED_NO_HIT").sum())
-
-        if status_col:
-            s_up = dfh_sorted[status_col].astype(str).str.upper()
-            settled = int((s_up == "SETTLED").sum())
-            pending = int((s_up != "SETTLED").sum())
-        else:
-            settled = hits + misses
-            pending = int(len(dfh_sorted) - settled)
-
-        st.caption(f"Settled: {settled} • Hits: {hits} • Misses: {misses} • Pending: {pending}")
-
-        # Show parsed expiry when original blank; format for display
-        df_disp = dfh_sorted.copy()
-        use_parsed = df_disp["Expiry"].isna() | (df_disp["Expiry"].astype(str).str.strip() == "")
-        df_disp.loc[use_parsed, "Expiry"] = df_disp.loc[use_parsed, "Expiry_parsed"].dt.strftime("%Y-%m-%d")
-
-        preferred = [
-            "Ticker","EvalDate","Price","EntryTimeET",
-            status_col if status_col else "Status",
-            "HitDateET","Expiry","DTE","BuyK","SellK","TP","Notes"
-        ]
-        cols = [c for c in preferred if c in df_disp.columns]
-        if cols:
-            df_disp = df_disp[cols]
-
-        st.dataframe(df_disp, use_container_width=True, height=min(600, 80 + 28 * len(df_disp)))
+    outcomes_summary(load_outcomes())


### PR DESCRIPTION
## Summary
- Move outcomes display logic into `outcomes_summary` helper
- Call `outcomes_summary` from `render_history_tab` to avoid duplication

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b61e0df9e88332b7248eeecc9a6a7c