### PR TITLE
Centralize pass file discovery

### DIFF
--- a/tests/test_pass_files.py
+++ b/tests/test_pass_files.py
@@ -1,0 +1,53 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import ui.history as history
+from utils import io
+
+
+def test_list_pass_files(tmp_path, monkeypatch):
+    root = tmp_path
+    data_dir = root / "data"
+    pass_logs = data_dir / "pass_logs"
+    hist_dir = data_dir / "history"
+    legacy_dir = root / "history"
+    pass_logs.mkdir(parents=True)
+    hist_dir.mkdir(parents=True)
+    legacy_dir.mkdir()
+
+    f1 = pass_logs / "pass_20230102.csv"
+    f1.touch()
+    f2 = hist_dir / "pass_20230101.psv"
+    f2.touch()
+    f3 = legacy_dir / "pass_20230103.csv"
+    f3.touch()
+
+    monkeypatch.setattr(io, "REPO_ROOT", root)
+    monkeypatch.setattr(io, "DATA_DIR", data_dir)
+    monkeypatch.setattr(io, "HISTORY_DIR", hist_dir)
+    monkeypatch.setattr(io, "PASS_DIR", pass_logs)
+
+    paths = io.list_pass_files()
+    assert paths == sorted(paths)
+    assert {p.name for p in paths} == {"pass_20230102.csv", "pass_20230101.psv", "pass_20230103.csv"}
+
+
+def test_load_history_df_uses_list_pass_files(monkeypatch, tmp_path):
+    psv = tmp_path / "pass_1.psv"
+    psv.write_text("a|b\n1|2\n")
+    monkeypatch.setattr(history, "list_pass_files", lambda: [psv])
+    df = history.load_history_df()
+    assert df["__source_file"].tolist() == ["pass_1.psv"]
+
+
+def test_latest_pass_file_uses_list_pass_files(monkeypatch, tmp_path):
+    csv1 = tmp_path / "pass_20230101.csv"
+    csv1.touch()
+    csv2 = tmp_path / "pass_20230102.csv"
+    csv2.touch()
+    monkeypatch.setattr(history, "list_pass_files", lambda: [csv1, csv2])
+    assert history.latest_pass_file() == csv2

--- a/ui/history.py
+++ b/ui/history.py
@@ -1,19 +1,12 @@
-import glob
-import os
 import pandas as pd
 import streamlit as st
-from utils.io import DATA_DIR, HISTORY_DIR, read_csv
+from utils.io import list_pass_files, read_csv
 from utils.outcomes import read_outcomes
-
-PASS_DIR = DATA_DIR / "pass_logs"
 
 
 def load_history_df() -> pd.DataFrame:
     """Return a DataFrame concatenating all historical PASS snapshots."""
-    paths = []
-    paths.extend(sorted(glob.glob(str(HISTORY_DIR / "pass_*.psv"))))
-    # Legacy fallback
-    paths.extend(sorted(glob.glob("history/pass_*.psv")))
+    paths = [p for p in list_pass_files() if p.suffix == ".psv"]
 
     if not paths:
         return pd.DataFrame()
@@ -22,7 +15,7 @@ def load_history_df() -> pd.DataFrame:
     for p in paths:
         try:
             df = pd.read_csv(p, sep="|")
-            df["__source_file"] = os.path.basename(p)
+            df["__source_file"] = p.name
             frames.append(df)
         except Exception:
             continue
@@ -35,10 +28,8 @@ def load_history_df() -> pd.DataFrame:
 
 def latest_pass_file():
     """Return the newest pass_*.csv from either pass_logs/ or history/."""
-    candidates = []
-    for d in [PASS_DIR, HISTORY_DIR]:
-        candidates.extend(glob.glob(str(d / "pass_*.csv")))
-    return sorted(candidates)[-1] if candidates else None
+    candidates = [p for p in list_pass_files() if p.suffix == ".csv"]
+    return candidates[-1] if candidates else None
 
 
 def load_outcomes():

--- a/utils/io.py
+++ b/utils/io.py
@@ -9,6 +9,7 @@ import pandas as pd
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DATA_DIR = REPO_ROOT / "data"
 HISTORY_DIR = DATA_DIR / "history"
+PASS_DIR = DATA_DIR / "pass_logs"
 OUTCOMES_CSV = HISTORY_DIR / "outcomes.csv"
 
 
@@ -28,3 +29,12 @@ def write_csv(path: Union[str, Path], df: pd.DataFrame, **kwargs) -> None:
     p = Path(path)
     p.parent.mkdir(parents=True, exist_ok=True)
     df.to_csv(p, index=False, **kwargs)
+
+
+def list_pass_files() -> list[Path]:
+    """Return sorted paths for ``pass_*.{csv,psv}`` from relevant directories."""
+    paths: list[Path] = []
+    for d in [PASS_DIR, HISTORY_DIR, REPO_ROOT / "history"]:
+        paths.extend(d.glob("pass_*.csv"))
+        paths.extend(d.glob("pass_*.psv"))
+    return sorted(paths)


### PR DESCRIPTION
## Summary
- add `utils.io.list_pass_files` to find pass_*.{csv,psv} across data directories
- refactor `ui.history.load_history_df` and `latest_pass_file` to use new helper
- add tests for pass file helper and history utilities

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b61e0f76288332802efdda3bc697e3