### PR TITLE
Refactor float conversion into shared utility

### DIFF
--- a/utils/numeric.py
+++ b/utils/numeric.py
@@ -1,0 +1,37 @@
+"""Numeric utility helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+
+def safe_float(x: Any) -> float:
+    """Best effort float conversion handling iterables and NaNs.
+
+    Parameters
+    ----------
+    x : Any
+        Value to convert. If ``x`` is a pandas Series or other iterable,
+        the first element is used. ``None`` or invalid inputs result in
+        ``numpy.nan``.
+
+    Returns
+    -------
+    float
+        Converted float or ``numpy.nan`` when conversion is not possible.
+    """
+    if isinstance(x, pd.Series):
+        x = x.iloc[0] if not x.empty else np.nan
+    elif isinstance(x, (np.ndarray, list, tuple)):
+        x = x[0] if len(x) else np.nan
+
+    if pd.isna(x):
+        return np.nan
+    try:
+        return float(x)
+    except Exception:
+        return np.nan
+


### PR DESCRIPTION
## Summary
- add `utils.numeric.safe_float` for robust float coercion
- replace bespoke float helpers in outcomes and screener modules
- adjust outcomes helper to ignore NaN values when choosing first non-empty value

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b61e10b08c83329cf9467a704a3cc8