### PR TITLE
Track latest price and distance to target in outcomes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 Use the `scripts/evaluate_outcomes.py` utility to update `data/history/outcomes.csv` with trade results.
 
+`outcomes.csv` tracks columns such as `Ticker`, `EvalDate`, `Price`, `LastPrice`,
+`LastPriceAt`, `PctToTarget`, option strikes, status fields, and other notes.
+
 For pending trades:
 
 ```bash


### PR DESCRIPTION
## Summary
- add `LastPrice`, `LastPriceAt`, and `PctToTarget` to outcomes schema
- seed and backfill new columns when appending outcomes rows
- compute latest close and percent to target during pending evaluations
- document new fields in outcomes.csv

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6243570f083328425f06430def73a