### PR TITLE
Use latest trading-day outcomes in history tab

### DIFF
--- a/tests/test_history_load.py
+++ b/tests/test_history_load.py
@@ -27,3 +27,17 @@ def test_load_outcomes_missing_file(tmp_path, monkeypatch):
     df = history.load_outcomes()
     assert df.empty
     assert list(df.columns) == outcomes.OUTCOLS
+
+
+def test_latest_trading_day_recs_filters_and_dedupes():
+    df = pd.DataFrame(
+        {
+            "Ticker": ["AAA", "BBB", "AAA"],
+            "run_date": ["2023-01-01", "2023-01-02", "2023-01-02"],
+        }
+    )
+
+    latest, date_str = history.latest_trading_day_recs(df)
+    assert date_str == "2023-01-02"
+    assert set(latest["Ticker"]) == {"AAA", "BBB"}
+    assert len(latest) == 2

--- a/tests/test_pass_files.py
+++ b/tests/test_pass_files.py
@@ -42,12 +42,3 @@ def test_load_history_df_uses_list_pass_files(monkeypatch, tmp_path):
     monkeypatch.setattr(history, "list_pass_files", lambda: [psv])
     df = history.load_history_df()
     assert df["__source_file"].tolist() == ["pass_1.psv"]
-
-
-def test_latest_pass_file_uses_list_pass_files(monkeypatch, tmp_path):
-    csv1 = tmp_path / "pass_20230101.csv"
-    csv1.touch()
-    csv2 = tmp_path / "pass_20230102.csv"
-    csv2.touch()
-    monkeypatch.setattr(history, "list_pass_files", lambda: [csv1, csv2])
-    assert history.latest_pass_file() == csv2


### PR DESCRIPTION
## Summary
- show recommendations based on most recent `run_date` from outcomes
- drop legacy `latest_pass_file` approach and related test
- test deduping of tickers for latest trading day

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b70f2b59588332b77becb8b251ebef