### PR TITLE
feat: decouple intraday runs from outcome evaluation

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -111,7 +111,7 @@ jobs:
           echo "Event: $GITHUB_EVENT_NAME  |  Ref: $GITHUB_REF"
 
       # ─────────────────────────────────────────────────────────
-      # 4.4) Run screener via scripts/run_and_log.py + write history files (intraday)
+      # 4.4) Run screener via scripts/run_and_log.py + write history files (intraday, no eval)
       # ─────────────────────────────────────────────────────────
       - name: Run scripts/run_and_log.py and write history files
         if: steps.bizgate.outputs.run == 'yes' && github.event.schedule != '10 23 * * 1-5'
@@ -123,7 +123,7 @@ jobs:
           python scripts/run_and_log.py --universe sp500 --with-options | tee "data/logs/scan_$(date -u +%Y%m%d-%H%M%S).txt"
 
       # ─────────────────────────────────────────────────────────
-      # 4.5) Evaluate outcomes (nightly)
+      # 4.5) Evaluate outcomes via scripts/evaluate_outcomes.py (nightly)
       # ─────────────────────────────────────────────────────────
       - name: Evaluate outcomes
         if: steps.bizgate.outputs.run == 'yes' && github.event.schedule == '10 23 * * 1-5'


### PR DESCRIPTION
## Summary
- add optional `--evaluate` flag to skip outcome scoring during intraday runs
- run nightly outcome checks via `scripts/evaluate_outcomes.py`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b715c705bc8332b2fb4871df6709fe