### PR TITLE
Use New York timezone for outcome run_date

### DIFF
--- a/tests/test_outcomes.py
+++ b/tests/test_outcomes.py
@@ -1,6 +1,7 @@
 import sys
-from datetime import date
+from datetime import datetime
 from pathlib import Path
+from zoneinfo import ZoneInfo
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
@@ -11,7 +12,7 @@ from utils import outcomes
 
 
 def test_upsert_assigns_run_date_and_dedupes(tmp_path):
-    today = date.today().isoformat()
+    today = datetime.now(ZoneInfo("America/New_York")).date().isoformat()
     out_path = tmp_path / "outcomes.csv"
 
     existing = pd.DataFrame([

--- a/utils/outcomes.py
+++ b/utils/outcomes.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import math
 from datetime import datetime, date
+from zoneinfo import ZoneInfo
 from pathlib import Path
 from typing import Any
 
@@ -153,7 +154,7 @@ def upsert_and_backfill_outcomes(
     df_pass["BuyK"] = df_pass["BuyK"].map(safe_float)
     df_pass["SellK"] = df_pass["SellK"].map(safe_float)
     df_pass["TP"] = df_pass["TP"].map(safe_float)
-    today_str = datetime.now().date().isoformat()
+    today_str = datetime.now(ZoneInfo("America/New_York")).date().isoformat()
     df_pass["run_date"] = df_pass["run_date"].apply(_to_date_str).fillna(today_str)
 
     tgt = df_pass["SellK"].combine_first(df_pass["TP"])


### PR DESCRIPTION
## Summary
- Use America/New_York timezone when assigning `run_date` in outcomes
- Add `ZoneInfo` import and update tests accordingly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b715c924b08332bca4b371a3455388