### PR TITLE
Support csv pass file format in history loader

### DIFF
--- a/tests/test_pass_files.py
+++ b/tests/test_pass_files.py
@@ -39,6 +39,10 @@ def test_list_pass_files(tmp_path, monkeypatch):
 def test_load_history_df_uses_list_pass_files(monkeypatch, tmp_path):
     psv = tmp_path / "pass_1.psv"
     psv.write_text("a|b\n1|2\n")
-    monkeypatch.setattr(history, "list_pass_files", lambda: [psv])
+    csv = tmp_path / "pass_2.csv"
+    csv.write_text("a,b\n3,4\n")
+    monkeypatch.setattr(history, "list_pass_files", lambda: [psv, csv])
     df = history.load_history_df()
-    assert df["__source_file"].tolist() == ["pass_1.psv"]
+    assert df["__source_file"].tolist() == ["pass_1.psv", "pass_2.csv"]
+    assert df["a"].tolist() == [1, 3]
+    assert df["b"].tolist() == [2, 4]

--- a/ui/history.py
+++ b/ui/history.py
@@ -6,7 +6,7 @@ from utils.outcomes import read_outcomes
 
 def load_history_df() -> pd.DataFrame:
     """Return a DataFrame concatenating all historical PASS snapshots."""
-    paths = [p for p in list_pass_files() if p.suffix == ".psv"]
+    paths = [p for p in list_pass_files() if p.suffix in {".psv", ".csv"}]
 
     if not paths:
         return pd.DataFrame()
@@ -14,7 +14,8 @@ def load_history_df() -> pd.DataFrame:
     frames = []
     for p in paths:
         try:
-            df = pd.read_csv(p, sep="|")
+            sep = "|" if p.suffix == ".psv" else ","
+            df = pd.read_csv(p, sep=sep)
             df["__source_file"] = p.name
             frames.append(df)
         except Exception:


### PR DESCRIPTION
## Summary
- allow `load_history_df` to read both .psv and .csv pass snapshots with delimiter chosen by suffix
- extend tests to cover parsing of both file formats

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b715ccadc08332922d414a7eae1a49