### PR TITLE
Use NY timezone to compute run_date

### DIFF
--- a/scripts/run_and_log.py
+++ b/scripts/run_and_log.py
@@ -97,7 +97,8 @@ def main() -> int:
 
     try:
         existing = read_outcomes(OUTCOMES_CSV)
-        run_date = previous_trading_day().isoformat()
+        ref_date = datetime.now(ZoneInfo("America/New_York")).date()
+        run_date = previous_trading_day(ref=ref_date).isoformat()
 
         res = safe_run_scan(with_options=args.with_options)
         df_pass: Optional[pd.DataFrame] = res.get("pass")


### PR DESCRIPTION
## Summary
- use New York timezone when computing the reference date and pass it to `previous_trading_day` so nightly and intraday runs map to the correct trading day

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b71c7f262483328690d1dce3ae212e