### PR TITLE
workflow: handle both nightly cron slots

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -132,7 +132,7 @@ jobs:
       # 4.4) Run screener via scripts/run_and_log.py + write history files (intraday, no eval)
       # ─────────────────────────────────────────────────────────
       - name: Run scripts/run_and_log.py and write history files
-        if: steps.bizgate.outputs.run == 'yes' && github.event.schedule != '10 23 * * 1-5'
+        if: steps.bizgate.outputs.run == 'yes' && github.event.schedule != '10 23 * 3-10 1-5' && github.event.schedule != '10 0 * 11-12,1-2 2-6'
         env:
           PYTHONPATH: .:./scripts
         run: |
@@ -144,7 +144,7 @@ jobs:
       # 4.5) Evaluate outcomes via scripts/evaluate_outcomes.py (nightly)
       # ─────────────────────────────────────────────────────────
       - name: Evaluate outcomes
-        if: steps.bizgate.outputs.run == 'yes' && github.event.schedule == '10 23 * * 1-5'
+        if: steps.bizgate.outputs.run == 'yes' && (github.event.schedule == '10 23 * 3-10 1-5' || github.event.schedule == '10 0 * 11-12,1-2 2-6')
         env:
           PYTHONPATH: .:./scripts
         run: |


### PR DESCRIPTION
## Summary
- ensure nightly evaluation triggers cover both DST cron expressions
- adjust intraday gating to exclude both nightly schedules

## Testing
- `pip install -r requirements.txt` *(fails: No matching distribution found for pandas-market-calendars>=4.3)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b71c860a3c83329b3fdd69133146be