### PR TITLE
fix: update NYSE holiday lookup and add cached holiday test

### DIFF
--- a/tests/test_nyse_calendar.py
+++ b/tests/test_nyse_calendar.py
@@ -1,0 +1,38 @@
+import sys
+import json
+from datetime import date
+from pathlib import Path
+
+import pandas_market_calendars as mcal
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from utils import nyse_calendar
+
+
+def test_previous_trading_day_across_july4(monkeypatch, tmp_path):
+    cache = {
+        "2022": [],
+        "2023": ["2023-07-04"],
+        "2024": [],
+    }
+    cache_file = tmp_path / "nyse_holidays_cache.json"
+    cache_file.write_text(json.dumps(cache))
+    override_file = tmp_path / "nyse_holidays_override.json"
+    override_file.write_text("[]")
+
+    monkeypatch.setattr(nyse_calendar, "CACHE_FILE", cache_file)
+    monkeypatch.setattr(nyse_calendar, "OVERRIDE_FILE", override_file)
+
+    def boom(year: int):
+        raise AssertionError("_compute_year should not be called")
+
+    monkeypatch.setattr(nyse_calendar, "_compute_year", boom)
+
+    july4 = date(2023, 7, 4)
+    assert nyse_calendar.previous_trading_day(july4) == date(2023, 7, 3)
+    assert nyse_calendar.previous_trading_day(date(2023, 7, 5)) == date(2023, 7, 5)
+
+    assert mcal is not None

--- a/utils/nyse_calendar.py
+++ b/utils/nyse_calendar.py
@@ -53,7 +53,7 @@ def _compute_year(year: int) -> list[str]:
     cal = mcal.get_calendar("NYSE")
     start = f"{year}-01-01"
     end = f"{year}-12-31"
-    hol = cal.holidays(start=start, end=end)
+    hol = cal.holidays(start_date=start, end_date=end)
     return [d.strftime("%Y-%m-%d") for d in hol.to_pydatetime()]
 
 def get_nyse_holidays(start_year: int, end_year: int) -> Set[date]:


### PR DESCRIPTION
## Summary
- use `start_date`/`end_date` parameters with `cal.holidays`
- add unit test for `previous_trading_day` around July 4 using cached data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7344d4c288332a39d48ae6082f3d6