### PR TITLE
Improve tab navigation responsiveness

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 import streamlit as st
+from streamlit.components.v1 import html
 
 from ui.layout import setup_page, render_header
 from ui.scan import render_scanner_tab
@@ -8,19 +9,52 @@ from ui.debugger import render_debugger_tab
 # Initialize page and global layout/CSS
 setup_page()
 
+# Detect viewport size
+viewport = html(
+    """
+    <script>
+    const send = () => {
+        const dims = {width: window.innerWidth, height: window.innerHeight};
+        Streamlit.setComponentValue(dims);
+    };
+    window.addEventListener('load', send);
+    window.addEventListener('resize', send);
+    send();
+    </script>
+    """,
+    height=0,
+    width=0,
+)
+if viewport and isinstance(viewport, dict):
+    st.session_state["viewport"] = viewport
+
 # ---- Brand header ----
 render_header()
 
-# Create tabs once with unique variable names
-tab_scanner, tab_history, tab_debug = st.tabs(
-    ["Scanner", "History & Outcomes", "Debugger"]
-)
+width = st.session_state.get("viewport", {}).get("width", 1000)
 
-with tab_scanner:
-    render_scanner_tab()
+if width < 400:
+    nav = st.selectbox(
+        "Navigation",
+        ["📈 Scanner", "📊 History & Outcomes", "🐞 Debugger"],
+    )
+    if nav.startswith("📈"):
+        render_scanner_tab()
+    elif nav.startswith("📊"):
+        render_history_tab()
+    else:
+        render_debugger_tab()
+else:
+    # Create tabs once with unique variable names
+    tab_scanner, tab_history, tab_debug = st.tabs(
+        ["📈 Scanner", "📊 History & Outcomes", "🐞 Debugger"]
+    )
 
-with tab_history:
-    render_history_tab()
+    with tab_scanner:
+        render_scanner_tab()
 
-with tab_debug:
-    render_debugger_tab()
+    with tab_history:
+        render_history_tab()
+
+    with tab_debug:
+        render_debugger_tab()

--- a/ui/layout.py
+++ b/ui/layout.py
@@ -53,6 +53,19 @@ def setup_page():
             justify-content: center;
             margin: 0.5rem 0 1rem;
         }
+
+        /* --- Tabs --- */
+        div[data-testid="stTabs"] button {
+            padding: 0.25rem 0.5rem;
+        }
+        @media (max-width: 600px) {
+            div[data-testid="stTabs"] > div > div > div[role="tablist"] {
+                flex-wrap: wrap;
+            }
+            div[data-testid="stTabs"] button {
+                flex: 1 0 auto;
+            }
+        }
         </style>
         """,
         unsafe_allow_html=True,


### PR DESCRIPTION
## Summary
- Add viewport detection and switch to selectbox navigation on very small screens
- Decorate tab labels with emojis and shrink padding with responsive CSS

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b742de763883328814cd4367f34b0a