### PR TITLE
Style Streamlit dataframes with global dark theme

### DIFF
--- a/ui/layout.py
+++ b/ui/layout.py
@@ -139,6 +139,23 @@ def setup_page():
             padding-left: var(--padding);
             padding-right: var(--padding);
         }}
+
+        /* --- DataFrame tables --- */
+        div[data-testid="stDataFrame"] table {{
+            color: var(--text-color);
+            background-color: var(--bg-color);
+        }}
+        div[data-testid="stDataFrame"] th {{
+            background-color: #1a1a1a !important;
+            color: var(--text-color) !important;
+        }}
+        div[data-testid="stDataFrame"] td {{
+            background-color: #000000 !important;
+            color: var(--text-color) !important;
+            border-color: #333333 !important;
+        }}
+        div[data-testid="stDataFrame"] tr:nth-child(even) {{ background: #0d0d0d; }}
+        div[data-testid="stDataFrame"] tr:hover {{ background: #1a1a1a; }}
         </style>
         """,
         unsafe_allow_html=True,


### PR DESCRIPTION
## Summary
- Apply global dark table styling for all Streamlit dataframes via `div[data-testid="stDataFrame"]`
- Add hover and stripe effects to tables for better readability

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b74a95756c8332b710afe008128efa