### PR TITLE
Display richer history details with dark dataframe styling

### DIFF
--- a/ui/history.py
+++ b/ui/history.py
@@ -178,11 +178,16 @@ def render_history_tab():
         if df_last.empty:
             st.info("No tickers passed that day.")
         else:
-            cols = [
-                c
-                for c in ["Ticker", "Price", "RelVol(TimeAdj63d)", "TP"]
-                if c in df_last.columns
+            preferred = [
+                "Ticker",
+                "Price",
+                "TP",
+                "RelVol(TimeAdj63d)",
+                "EntryTimeET",
+                "LastPrice",
+                "LastPriceAt",
             ]
+            cols = [c for c in preferred if c in df_last.columns]
             st.dataframe(df_last[cols] if cols else df_last)
     else:
         st.subheader("Trading day — recommendations")

--- a/ui/layout.py
+++ b/ui/layout.py
@@ -139,6 +139,21 @@ def setup_page():
             padding-left: var(--padding);
             padding-right: var(--padding);
         }}
+
+        div[data-testid="stDataFrame"] div[role="grid"] {{
+            background-color: var(--bg-color);
+            color: var(--text-color);
+            border-radius: 8px;
+        }}
+        div[data-testid="stDataFrame"] th {{
+            background-color: #111;
+            color: var(--text-color);
+            font-weight: 700;
+            border-bottom: 2px solid var(--color-primary);
+        }}
+        div[data-testid="stDataFrame"] td {{
+            border-color: #222;
+        }}
         </style>
         """,
         unsafe_allow_html=True,


### PR DESCRIPTION
## Summary
- Show additional columns in History tab and prioritize price and target
- Introduce dark-themed styling for Streamlit dataframes using app color variables

## Testing
- `pytest -q`
- `streamlit run app.py --server.headless true --server.port 8501`


------
https://chatgpt.com/codex/tasks/task_e_68b74a936b408332b3c3d492c4c115ad