### PR TITLE
Enable dark theme for Streamlit UI

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,5 +1,5 @@
 [theme]
-primaryColor = "#E31B23"   # red
-textColor = "#000000"
-backgroundColor = "#FFFFFF"
-secondaryBackgroundColor = "#F6F6F6"
+primaryColor = "#FF4B4B"   # bright red for dark theme
+textColor = "#f2f2f2"
+backgroundColor = "#000000"
+secondaryBackgroundColor = "#1a1a1a"


### PR DESCRIPTION
## Summary
- switch Streamlit theme configuration to dark colors
- set bright primary color for visibility on dark background

## Testing
- `streamlit run app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b750f2d78c8332a77c28ff29d01f5d