### PR TITLE
Expand history tab columns for enriched view

### DIFF
--- a/tests/test_ui_tables.py
+++ b/tests/test_ui_tables.py
@@ -68,6 +68,12 @@ def test_render_history_tab_shows_extended_columns(monkeypatch):
             "Ticker": ["AAA"],
             "Price": [1],
             "RelVol(TimeAdj63d)": [1.5],
+            "LastPrice": [1.1],
+            "LastPriceAt": ["2024-01-02"],
+            "PctToTarget": [0.2],
+            "EntryTimeET": ["09:30"],
+            "BuyK": [1],
+            "SellK": [2],
             "TP": [2],
             "Extra": [3],
         }
@@ -76,7 +82,9 @@ def test_render_history_tab_shows_extended_columns(monkeypatch):
     calls = {}
     monkeypatch.setattr(history.st, "subheader", lambda *a, **k: None)
     monkeypatch.setattr(history.st, "info", lambda *a, **k: None)
-    monkeypatch.setattr(history.st, "dataframe", lambda df_arg: calls.setdefault("df", df_arg))
+    monkeypatch.setattr(
+        history.st, "dataframe", lambda df_arg, *a, **k: calls.setdefault("df", df_arg)
+    )
     monkeypatch.setattr(history, "load_outcomes", lambda: pd.DataFrame())
     monkeypatch.setattr(history, "latest_trading_day_recs", lambda _df: (df_last, "2024-01-01"))
     monkeypatch.setattr(history, "outcomes_summary", lambda _df: None)
@@ -85,7 +93,18 @@ def test_render_history_tab_shows_extended_columns(monkeypatch):
 
     displayed = calls.get("df")
     assert isinstance(displayed, pd.DataFrame)
-    assert list(displayed.columns) == ["Ticker", "Price", "RelVol(TimeAdj63d)", "TP"]
+    assert list(displayed.columns) == [
+        "Ticker",
+        "Price",
+        "RelVol(TimeAdj63d)",
+        "LastPrice",
+        "LastPriceAt",
+        "PctToTarget",
+        "EntryTimeET",
+        "BuyK",
+        "SellK",
+        "TP",
+    ]
 
 
 def test_render_scanner_tab_shows_dataframe(monkeypatch):

--- a/ui/history.py
+++ b/ui/history.py
@@ -178,12 +178,28 @@ def render_history_tab():
         if df_last.empty:
             st.info("No tickers passed that day.")
         else:
-            cols = [
-                c
-                for c in ["Ticker", "Price", "RelVol(TimeAdj63d)", "TP"]
-                if c in df_last.columns
+            preferred = [
+                "Ticker",
+                "Price",
+                "RelVol(TimeAdj63d)",
+                "LastPrice",
+                "LastPriceAt",
+                "PctToTarget",
+                "EntryTimeET",
+                "BuyK",
+                "SellK",
+                "TP",
             ]
-            st.dataframe(df_last[cols] if cols else df_last)
+            cols = [c for c in preferred if c in df_last.columns]
+            df_show = df_last[cols] if cols else df_last
+
+            kwargs = {"use_container_width": True}
+            if hasattr(st, "column_config"):
+                kwargs["column_config"] = {
+                    c: st.column_config.Column(width=100) for c in df_show.columns
+                }
+
+            st.dataframe(df_show, **kwargs)
     else:
         st.subheader("Trading day — recommendations")
         st.info("No pass files yet. Run the scanner (or wait for the next scheduled run).")


### PR DESCRIPTION
## Summary
- Show richer set of fields in history tab including last price data and option strikes
- Configure Streamlit dataframe with responsive width for readability
- Adjust tests to validate extended column output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b750f4734483328887190c5291da97