### PR TITLE
Persist Change and RelVol in outcomes records

### DIFF
--- a/tests/test_outcomes.py
+++ b/tests/test_outcomes.py
@@ -22,7 +22,13 @@ def test_upsert_assigns_run_date_and_dedupes(tmp_path):
 
     df_pass = pd.DataFrame([
         {"Ticker": "AAPL", "EvalDate": today, "Price": 2.0},
-        {"Ticker": "MSFT", "EvalDate": today, "Price": 3.0},
+        {
+            "Ticker": "MSFT",
+            "EvalDate": today,
+            "Price": 3.0,
+            "Change%": 4.5,
+            "RelVol(TimeAdj63d)": 1.2,
+        },
     ])
 
     result = outcomes.upsert_and_backfill_outcomes(df_pass, out_path)
@@ -32,6 +38,10 @@ def test_upsert_assigns_run_date_and_dedupes(tmp_path):
     assert result.loc[result["Ticker"] == "AAPL", "Price"].iloc[0] == 1.0
     # New MSFT row has today's run_date assigned
     assert result.loc[result["Ticker"] == "MSFT", "run_date"].iloc[0] == today
+    # Newly inserted MSFT row retains Change% and RelVol columns
+    msft_row = result[result["Ticker"] == "MSFT"].iloc[0]
+    assert msft_row["Change%"] == 4.5
+    assert msft_row["RelVol(TimeAdj63d)"] == 1.2
     # Ensure only one entry per ticker per run_date
     assert (
         result.groupby(["Ticker", "run_date"]).size().max() == 1

--- a/utils/outcomes.py
+++ b/utils/outcomes.py
@@ -22,6 +22,8 @@ OUTCOLS = [
     "Ticker",
     "EvalDate",
     "Price",
+    "Change%",
+    "RelVol(TimeAdj63d)",
     "LastPrice",
     "LastPriceAt",
     "PctToTarget",
@@ -137,6 +139,8 @@ def upsert_and_backfill_outcomes(
         "Ticker",
         "EvalDate",
         "Price",
+        "Change%",
+        "RelVol(TimeAdj63d)",
         "BuyK",
         "SellK",
         "TP",
@@ -151,6 +155,8 @@ def upsert_and_backfill_outcomes(
     df_pass["Ticker"] = df_pass["Ticker"].astype(str).str.upper()
     df_pass["EvalDate"] = df_pass["EvalDate"].apply(_to_date_str)
     df_pass["Price"] = df_pass["Price"].map(safe_float)
+    df_pass["Change%"] = df_pass["Change%"].map(safe_float)
+    df_pass["RelVol(TimeAdj63d)"] = df_pass["RelVol(TimeAdj63d)"].map(safe_float)
     df_pass["BuyK"] = df_pass["BuyK"].map(safe_float)
     df_pass["SellK"] = df_pass["SellK"].map(safe_float)
     df_pass["TP"] = df_pass["TP"].map(safe_float)


### PR DESCRIPTION
## Summary
- Track `Change%` and `RelVol(TimeAdj63d)` in outcomes via `OUTCOLS`
- Preserve these fields when upserting pass scan results
- Test that new outcomes retain change and relative volume values

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b756a7ec1083329bd676243d68681b