### PR TITLE
Expose additional columns in history tab

### DIFF
--- a/tests/test_ui_tables.py
+++ b/tests/test_ui_tables.py
@@ -66,7 +66,10 @@ def test_render_history_tab_shows_extended_columns(monkeypatch):
     df_last = pd.DataFrame(
         {
             "Ticker": ["AAA"],
+            "EvalDate": ["2024-01-01"],
+            "run_date": ["2024-01-02"],
             "Price": [1],
+            "Change%": [0.05],
             "RelVol(TimeAdj63d)": [1.5],
             "LastPrice": [1.1],
             "LastPriceAt": ["2024-01-02"],
@@ -95,7 +98,10 @@ def test_render_history_tab_shows_extended_columns(monkeypatch):
     assert isinstance(displayed, pd.DataFrame)
     assert list(displayed.columns) == [
         "Ticker",
+        "EvalDate",
+        "run_date",
         "Price",
+        "Change%",
         "RelVol(TimeAdj63d)",
         "LastPrice",
         "LastPriceAt",

--- a/ui/history.py
+++ b/ui/history.py
@@ -180,7 +180,10 @@ def render_history_tab():
         else:
             preferred = [
                 "Ticker",
+                "EvalDate",
+                "run_date",
                 "Price",
+                "Change%",
                 "RelVol(TimeAdj63d)",
                 "LastPrice",
                 "LastPriceAt",
@@ -191,7 +194,7 @@ def render_history_tab():
                 "TP",
             ]
             cols = [c for c in preferred if c in df_last.columns]
-            df_show = df_last[cols] if cols else df_last
+            df_show = df_last[cols] if cols else df_last  # fall back to full frame
 
             kwargs = {"use_container_width": True}
             if hasattr(st, "column_config"):


### PR DESCRIPTION
## Summary
- show EvalDate, run_date, and Change% when available in history table
- keep the full DataFrame when no preferred columns exist to avoid silent drops
- update tests for new column ordering

## Testing
- `pytest -q`
- `streamlit run app.py --server.headless true`

------
https://chatgpt.com/codex/tasks/task_e_68b756a8b6a48332988335cf393537b5