### PR TITLE
Allow Streamlit to auto-fit history table columns

### DIFF
--- a/ui/history.py
+++ b/ui/history.py
@@ -196,7 +196,7 @@ def render_history_tab():
             kwargs = {"use_container_width": True}
             if hasattr(st, "column_config"):
                 kwargs["column_config"] = {
-                    c: st.column_config.Column(width=100) for c in df_show.columns
+                    c: st.column_config.Column() for c in df_show.columns
                 }
 
             st.dataframe(df_show, **kwargs)


### PR DESCRIPTION
## Summary
- Remove fixed width assignments in `history` table to let Streamlit auto-fit columns
- Keep `use_container_width=True` for responsive layout

## Testing
- `pytest -q`
- `streamlit run app.py` *(server started)*

------
https://chatgpt.com/codex/tasks/task_e_68b756a9a2c88332849e04e4dbab3c5f