### PR TITLE
style: modernize tables and highlight negative values

### DIFF
--- a/ui/history.py
+++ b/ui/history.py
@@ -1,8 +1,18 @@
 import pandas as pd
 import streamlit as st
+from pandas.io.formats.style import Styler
 from utils.io import list_pass_files
 from utils.outcomes import read_outcomes
 from utils.formatting import _usd, _safe
+
+
+def _style_negatives(df: pd.DataFrame) -> Styler:
+    """Return a Styler adding class "neg" to negative numeric cells."""
+    classes = pd.DataFrame("", index=df.index, columns=df.columns)
+    num_cols = df.select_dtypes(include="number").columns
+    for col in num_cols:
+        classes.loc[df[col] < 0, col] = "neg"
+    return df.style.set_td_classes(classes)
 
 
 def load_history_df() -> pd.DataFrame:
@@ -165,7 +175,7 @@ def outcomes_summary(dfh: pd.DataFrame):
     cols = [c for c in preferred if c in df_disp.columns]
     if cols:
         df_disp = df_disp[cols]
-    st.dataframe(df_disp)
+    st.dataframe(_style_negatives(df_disp))
 
 
 def render_history_tab():
@@ -202,7 +212,7 @@ def render_history_tab():
                     c: st.column_config.Column() for c in df_show.columns
                 }
 
-            st.dataframe(df_show, **kwargs)
+            st.dataframe(_style_negatives(df_show), **kwargs)
     else:
         st.subheader("Trading day — recommendations")
         st.info("No pass files yet. Run the scanner (or wait for the next scheduled run).")

--- a/ui/layout.py
+++ b/ui/layout.py
@@ -30,10 +30,10 @@ def setup_page():
             --padding: 1rem;
             --font-size-base: 16px;
             --col-width: 33%;
-            --table-bg: #1a1a1a;
+            --table-bg: #121212;
             --table-text: #e0e0e0;
-            --table-border: #2a2a2a;
-            --table-row-alt: #222;
+            --table-border: #333;
+            --table-row-alt: #1a1a1a;
         }}
 
         body {{
@@ -148,6 +148,9 @@ def setup_page():
         div[data-testid="stDataFrame"] table {{
             background-color: var(--table-bg);
             color: var(--table-text);
+            border-radius: 6px;
+            overflow: hidden;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.3);
         }}
         div[data-testid="stDataFrame"] th,
         div[data-testid="stDataFrame"] td {{
@@ -163,6 +166,13 @@ def setup_page():
         }}
         div[data-testid="stDataFrame"] tr:nth-child(even) {{ background: var(--table-row-alt); }}
         div[data-testid="stDataFrame"] tr:hover {{ background: #2e2e2e; }}
+
+        td[data-testid*="col_PctChange"] {{
+            color: var(--color-primary);
+        }}
+        td[data-testid*="col_PctChange"].neg {{
+            color: #ff6b6b;
+        }}
         </style>
         """,
         unsafe_allow_html=True,


### PR DESCRIPTION
## Summary
- soften table palette and add rounded, shadowed DataFrames with conditional PctChange coloring
- style DataFrames in history and scanner tabs so negative numbers receive a `neg` class
- update tests for new Styler-based rendering and negative highlighting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b75b0664748332a8cf4f14df2aabf3