### PR TITLE
Lighten table styling and standardize borders

### DIFF
--- a/ui/history.py
+++ b/ui/history.py
@@ -175,7 +175,11 @@ def outcomes_summary(dfh: pd.DataFrame):
     cols = [c for c in preferred if c in df_disp.columns]
     if cols:
         df_disp = df_disp[cols]
-    st.dataframe(_style_negatives(df_disp))
+    st.dataframe(
+        _style_negatives(df_disp).set_properties(
+            border_color="#ccc", border_style="solid", border_width="1px"
+        )
+    )
 
 
 def render_history_tab():
@@ -212,7 +216,12 @@ def render_history_tab():
                     c: st.column_config.Column() for c in df_show.columns
                 }
 
-            st.dataframe(_style_negatives(df_show), **kwargs)
+            st.dataframe(
+                _style_negatives(df_show).set_properties(
+                    border_color="#ccc", border_style="solid", border_width="1px"
+                ),
+                **kwargs,
+            )
     else:
         st.subheader("Trading day — recommendations")
         st.info("No pass files yet. Run the scanner (or wait for the next scheduled run).")

--- a/ui/layout.py
+++ b/ui/layout.py
@@ -30,10 +30,10 @@ def setup_page():
             --padding: 1rem;
             --font-size-base: 16px;
             --col-width: 33%;
-            --table-bg: #121212;
-            --table-text: #e0e0e0;
-            --table-border: #333;
-            --table-row-alt: #1a1a1a;
+            --table-bg: #f8f9fa;
+            --table-text: #222;
+            --table-border: #ccc;
+            --table-row-alt: #ffffff;
         }}
 
         body {{
@@ -145,12 +145,15 @@ def setup_page():
         }}
 
         /* --- DataFrame tables --- */
+        div[data-testid="stDataFrame"] > div {{
+            border: 1px solid var(--table-border);
+            border-radius: 8px;
+            overflow: hidden;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+        }}
         div[data-testid="stDataFrame"] table {{
             background-color: var(--table-bg);
             color: var(--table-text);
-            border-radius: 6px;
-            overflow: hidden;
-            box-shadow: 0 2px 4px rgba(0,0,0,0.3);
         }}
         div[data-testid="stDataFrame"] th,
         div[data-testid="stDataFrame"] td {{
@@ -158,14 +161,14 @@ def setup_page():
             color: var(--table-text) !important;
         }}
         div[data-testid="stDataFrame"] th {{
-            background-color: #111 !important;
+            background-color: var(--table-row-alt) !important;
             font-weight: 700;
         }}
         div[data-testid="stDataFrame"] td {{
             background-color: var(--table-bg) !important;
         }}
         div[data-testid="stDataFrame"] tr:nth-child(even) {{ background: var(--table-row-alt); }}
-        div[data-testid="stDataFrame"] tr:hover {{ background: #2e2e2e; }}
+        div[data-testid="stDataFrame"] tr:hover {{ background: #e6e6e6; }}
 
         td[data-testid*="col_PctChange"] {{
             color: var(--color-primary);

--- a/ui/scan.py
+++ b/ui/scan.py
@@ -108,7 +108,11 @@ def render_scanner_tab():
             st.warning("No tickers passed the filters.")
         else:
             st.success(f"Found {len(df_pass)} passing tickers (latest run).")
-            st.dataframe(_style_negatives(df_pass))
+            st.dataframe(
+                _style_negatives(df_pass).set_properties(
+                    border_color="#ccc", border_style="solid", border_width="1px"
+                )
+            )
             _render_why_buy_block(df_pass)
             with st.expander("Google-Sheet style view (optional)", expanded=False):
                 st.table(_sheet_friendly(df_pass))
@@ -116,7 +120,11 @@ def render_scanner_tab():
     elif isinstance(st.session_state.get("last_pass"), pd.DataFrame) and not st.session_state["last_pass"].empty:
         df_pass: pd.DataFrame = st.session_state["last_pass"]
         st.info(f"Showing last run in this session • {len(df_pass)} tickers")
-        st.dataframe(_style_negatives(df_pass))
+        st.dataframe(
+            _style_negatives(df_pass).set_properties(
+                border_color="#ccc", border_style="solid", border_width="1px"
+            )
+        )
         _render_why_buy_block(df_pass)
         with st.expander("Google-Sheet style view (optional)", expanded=False):
             st.table(_sheet_friendly(df_pass))


### PR DESCRIPTION
## Summary
- brighten table theme variables and container styling for rounded borders
- ensure tables use light borders via Styler in history and scanner views

## Testing
- `pytest`
- `streamlit run app.py` *(startup only)*

------
https://chatgpt.com/codex/tasks/task_e_68b75e4fc38883328c0cc646fe6bef5b