### PR TITLE
feat(ui): add light theme helper for tables

### DIFF
--- a/ui/history.py
+++ b/ui/history.py
@@ -15,6 +15,30 @@ def _style_negatives(df: pd.DataFrame) -> Styler:
     return df.style.set_td_classes(classes)
 
 
+def _apply_light_theme(df: pd.DataFrame | Styler) -> Styler:
+    return (
+        (df.style if isinstance(df, pd.DataFrame) else df)
+        .set_table_styles([
+            {
+                "selector": "th",
+                "props": [
+                    ("background-color", "#f8f9fa"),
+                    ("color", "#222"),
+                    ("border", "1px solid #ccc"),
+                ],
+            },
+            {
+                "selector": "td",
+                "props": [
+                    ("background-color", "#ffffff"),
+                    ("color", "#222"),
+                    ("border", "1px solid #ccc"),
+                ],
+            },
+        ])
+    )
+
+
 def load_history_df() -> pd.DataFrame:
     """Return a DataFrame concatenating all historical PASS snapshots."""
     paths = [p for p in list_pass_files() if p.suffix in {".psv", ".csv"}]
@@ -176,9 +200,9 @@ def outcomes_summary(dfh: pd.DataFrame):
     if cols:
         df_disp = df_disp[cols]
     st.dataframe(
-        _style_negatives(df_disp).set_properties(
-            border_color="#ccc", border_style="solid", border_width="1px"
-        )
+        _apply_light_theme(
+            _style_negatives(df_disp)
+        ).set_properties(border_color="#ccc", border_style="solid", border_width="1px")
     )
 
 
@@ -217,9 +241,9 @@ def render_history_tab():
                 }
 
             st.dataframe(
-                _style_negatives(df_show).set_properties(
-                    border_color="#ccc", border_style="solid", border_width="1px"
-                ),
+                _apply_light_theme(
+                    _style_negatives(df_show)
+                ).set_properties(border_color="#ccc", border_style="solid", border_width="1px"),
                 **kwargs,
             )
     else:

--- a/ui/scan.py
+++ b/ui/scan.py
@@ -3,6 +3,7 @@ import streamlit as st
 from pandas.io.formats.style import Styler
 from utils.formatting import _bold, _usd, _pct, _safe
 from utils.scan import safe_run_scan
+from .history import _apply_light_theme
 
 
 def _style_negatives(df: pd.DataFrame) -> Styler:
@@ -109,9 +110,9 @@ def render_scanner_tab():
         else:
             st.success(f"Found {len(df_pass)} passing tickers (latest run).")
             st.dataframe(
-                _style_negatives(df_pass).set_properties(
-                    border_color="#ccc", border_style="solid", border_width="1px"
-                )
+                _apply_light_theme(
+                    _style_negatives(df_pass)
+                ).set_properties(border_color="#ccc", border_style="solid", border_width="1px")
             )
             _render_why_buy_block(df_pass)
             with st.expander("Google-Sheet style view (optional)", expanded=False):
@@ -121,9 +122,9 @@ def render_scanner_tab():
         df_pass: pd.DataFrame = st.session_state["last_pass"]
         st.info(f"Showing last run in this session • {len(df_pass)} tickers")
         st.dataframe(
-            _style_negatives(df_pass).set_properties(
-                border_color="#ccc", border_style="solid", border_width="1px"
-            )
+            _apply_light_theme(
+                _style_negatives(df_pass)
+            ).set_properties(border_color="#ccc", border_style="solid", border_width="1px")
         )
         _render_why_buy_block(df_pass)
         with st.expander("Google-Sheet style view (optional)", expanded=False):


### PR DESCRIPTION
## Summary
- add `_apply_light_theme` utility for consistent light styling across tables
- apply light theme to history and scan dataframes

## Testing
- `pytest`
- `streamlit run app.py --server.headless true --server.port 8501`

------
https://chatgpt.com/codex/tasks/task_e_68b7619907488332a954b62a1769172e