### PR TITLE
style: apply dark palette to dataframes

### DIFF
--- a/ui/history.py
+++ b/ui/history.py
@@ -15,28 +15,34 @@ def _style_negatives(df: pd.DataFrame) -> Styler:
     return df.style.set_td_classes(classes)
 
 
-def _apply_light_theme(df: pd.DataFrame | Styler) -> Styler:
-    return (
-        (df.style if isinstance(df, pd.DataFrame) else df)
-        .set_table_styles([
-            {
-                "selector": "th",
-                "props": [
-                    ("background-color", "#f8f9fa"),
-                    ("color", "#222"),
-                    ("border", "1px solid #ccc"),
-                ],
-            },
-            {
-                "selector": "td",
-                "props": [
-                    ("background-color", "#ffffff"),
-                    ("color", "#222"),
-                    ("border", "1px solid #ccc"),
-                ],
-            },
-        ])
-    )
+def _apply_dark_theme(df: pd.DataFrame | Styler) -> Styler:
+    base = df.style if isinstance(df, pd.DataFrame) else df
+    return base.set_table_styles([
+        {
+            "selector": "th",
+            "props": [
+                ("background-color", "#2A2A3C"),
+                ("color", "#B0B3C5"),
+                ("border", "1px solid #2E2E3E"),
+            ],
+        },
+        {
+            "selector": "td",
+            "props": [
+                ("background-color", "#1E1E2E"),
+                ("color", "#E0E0E0"),
+                ("border", "1px solid #2E2E3E"),
+            ],
+        },
+        {
+            "selector": "tbody tr:nth-child(even)",
+            "props": [("background-color", "#25273A")],
+        },
+        {
+            "selector": "tbody tr:hover",
+            "props": [("background-color", "#2F3349")],
+        },
+    ])
 
 
 def load_history_df() -> pd.DataFrame:
@@ -200,9 +206,9 @@ def outcomes_summary(dfh: pd.DataFrame):
     if cols:
         df_disp = df_disp[cols]
     st.dataframe(
-        _apply_light_theme(
+        _apply_dark_theme(
             _style_negatives(df_disp)
-        ).set_properties(border_color="#ccc", border_style="solid", border_width="1px")
+        ).set_properties(border_color="#2E2E3E", border_style="solid", border_width="1px")
     )
 
 
@@ -241,9 +247,9 @@ def render_history_tab():
                 }
 
             st.dataframe(
-                _apply_light_theme(
+                _apply_dark_theme(
                     _style_negatives(df_show)
-                ).set_properties(border_color="#ccc", border_style="solid", border_width="1px"),
+                ).set_properties(border_color="#2E2E3E", border_style="solid", border_width="1px"),
                 **kwargs,
             )
     else:

--- a/ui/layout.py
+++ b/ui/layout.py
@@ -30,10 +30,15 @@ def setup_page():
             --padding: 1rem;
             --font-size-base: 16px;
             --col-width: 33%;
-            --table-bg: #f8f9fa;
-            --table-text: #222;
-            --table-border: #ccc;
-            --table-row-alt: #ffffff;
+            --table-bg: #1E1E2E;
+            --table-header-bg: #2A2A3C;
+            --table-row-alt: #25273A;
+            --table-hover: #2F3349;
+            --table-text: #E0E0E0;
+            --table-header-text: #B0B3C5;
+            --table-border: #2E2E3E;
+            --table-pos: #4ADE80;
+            --table-neg: #F87171;
         }}
 
         body {{
@@ -154,27 +159,27 @@ def setup_page():
         div[data-testid="stDataFrame"] table {{
             background-color: var(--table-bg);
             color: var(--table-text);
-        }}
-        div[data-testid="stDataFrame"] th,
-        div[data-testid="stDataFrame"] td {{
-            border-color: var(--table-border) !important;
-            color: var(--table-text) !important;
+            border-collapse: collapse;
         }}
         div[data-testid="stDataFrame"] th {{
-            background-color: var(--table-row-alt) !important;
+            background-color: var(--table-header-bg) !important;
+            color: var(--table-header-text) !important;
+            border: 1px solid var(--table-border) !important;
             font-weight: 700;
         }}
         div[data-testid="stDataFrame"] td {{
             background-color: var(--table-bg) !important;
+            color: var(--table-text) !important;
+            border: 1px solid var(--table-border) !important;
         }}
-        div[data-testid="stDataFrame"] tr:nth-child(even) {{ background: var(--table-row-alt); }}
-        div[data-testid="stDataFrame"] tr:hover {{ background: #e6e6e6; }}
+        div[data-testid="stDataFrame"] tbody tr:nth-child(even) {{ background: var(--table-row-alt); }}
+        div[data-testid="stDataFrame"] tbody tr:hover {{ background: var(--table-hover); }}
 
         td[data-testid*="col_PctChange"] {{
-            color: var(--color-primary);
+            color: var(--table-pos);
         }}
         td[data-testid*="col_PctChange"].neg {{
-            color: #ff6b6b;
+            color: var(--table-neg);
         }}
         </style>
         """,

--- a/ui/scan.py
+++ b/ui/scan.py
@@ -3,7 +3,7 @@ import streamlit as st
 from pandas.io.formats.style import Styler
 from utils.formatting import _bold, _usd, _pct, _safe
 from utils.scan import safe_run_scan
-from .history import _apply_light_theme
+from .history import _apply_dark_theme
 
 
 def _style_negatives(df: pd.DataFrame) -> Styler:
@@ -110,9 +110,9 @@ def render_scanner_tab():
         else:
             st.success(f"Found {len(df_pass)} passing tickers (latest run).")
             st.dataframe(
-                _apply_light_theme(
+                _apply_dark_theme(
                     _style_negatives(df_pass)
-                ).set_properties(border_color="#ccc", border_style="solid", border_width="1px")
+                ).set_properties(border_color="#2E2E3E", border_style="solid", border_width="1px")
             )
             _render_why_buy_block(df_pass)
             with st.expander("Google-Sheet style view (optional)", expanded=False):
@@ -122,9 +122,9 @@ def render_scanner_tab():
         df_pass: pd.DataFrame = st.session_state["last_pass"]
         st.info(f"Showing last run in this session • {len(df_pass)} tickers")
         st.dataframe(
-            _apply_light_theme(
+            _apply_dark_theme(
                 _style_negatives(df_pass)
-            ).set_properties(border_color="#ccc", border_style="solid", border_width="1px")
+            ).set_properties(border_color="#2E2E3E", border_style="solid", border_width="1px")
         )
         _render_why_buy_block(df_pass)
         with st.expander("Google-Sheet style view (optional)", expanded=False):


### PR DESCRIPTION
## Summary
- Define reusable dark table styling helper
- Apply modern dark slate palette to all DataFrames
- Sync layout CSS with new hover, border, and highlight colors

## Testing
- `pytest -q`
- `streamlit run app.py --server.headless true --server.port 8501`


------
https://chatgpt.com/codex/tasks/task_e_68b70e6d1c848332872f4acbcbae7af3