### PR TITLE
feat: make DataFrame headers sticky

### DIFF
--- a/ui/layout.py
+++ b/ui/layout.py
@@ -149,6 +149,16 @@ def setup_page():
             padding-right: var(--padding);
         }}
 
+        /* --- DataFrame tables --- */
+        div[data-testid="stDataFrame"] thead th {{
+            position: sticky;
+            top: 0;
+            z-index: 1;
+        }}
+        div[data-testid="stDataFrame"] tbody tr:hover {{
+            background-color: var(--table-hover);
+        }}
+
         td[data-testid*="col_PctChange"] {{
             color: var(--table-pos);
         }}


### PR DESCRIPTION
## Summary
- add sticky header styling for Streamlit DataFrame tables
- retain row hover highlighting

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b777c18b08833289b8fc5c68734339