### PR TITLE
Use consistent Streamlit dataframe tables

### DIFF
--- a/ui/history.py
+++ b/ui/history.py
@@ -205,9 +205,9 @@ def outcomes_summary(dfh: pd.DataFrame):
     cols = [c for c in preferred if c in df_disp.columns]
     if cols:
         df_disp = df_disp[cols]
-    st.markdown(
-        _apply_dark_theme(_style_negatives(df_disp)).to_html(),
-        unsafe_allow_html=True,
+    st.dataframe(
+        _apply_dark_theme(_style_negatives(df_disp)),
+        use_container_width=True,
     )
 
 


### PR DESCRIPTION
## Summary
- Render outcomes summary with `st.dataframe` using a shared dark theme and automatic width.
- Ensure latest recommendations table uses matching `st.dataframe` call for consistent layout.
- Update tests to capture `st.dataframe` usage and validate column order with `pd.read_html`.

## Testing
- `pytest -q`
- `streamlit run app.py` (launched for manual inspection)


------
https://chatgpt.com/codex/tasks/task_e_68b77dfac4488332ba149982e28153b3