### PR TITLE
Apply blue table theme and positive cell styling

### DIFF
--- a/tests/test_ui_tables.py
+++ b/tests/test_ui_tables.py
@@ -183,4 +183,5 @@ def test_style_negatives_marks_negatives():
     styler = scan._style_negatives(df)
     html = styler.to_html()
     assert 'neg"' in html
+    assert 'pos"' in html
 

--- a/ui/history.py
+++ b/ui/history.py
@@ -7,11 +7,12 @@ from utils.formatting import _usd, _safe
 
 
 def _style_negatives(df: pd.DataFrame) -> Styler:
-    """Return a Styler adding class "neg" to negative numeric cells."""
+    """Return a Styler adding classes for positive and negative cells."""
     classes = pd.DataFrame("", index=df.index, columns=df.columns)
     num_cols = df.select_dtypes(include="number").columns
     for col in num_cols:
         classes.loc[df[col] < 0, col] = "neg"
+        classes.loc[df[col] > 0, col] = "pos"
     return df.style.set_td_classes(classes)
 
 
@@ -40,7 +41,10 @@ def _apply_dark_theme(df: pd.DataFrame | Styler) -> Styler:
         },
         {
             "selector": "tbody tr:hover",
-            "props": [("background-color", "var(--table-hover)")],
+            "props": [
+                ("background-color", "var(--table-hover)"),
+                ("color", "var(--table-hover-text)"),
+            ],
         },
     ])
 

--- a/ui/layout.py
+++ b/ui/layout.py
@@ -30,15 +30,16 @@ def setup_page():
             --padding: 1rem;
             --font-size-base: 16px;
             --col-width: 33%;
-            --table-bg: #1E1E2E;
-            --table-header-bg: #2A2A3C;
-            --table-row-alt: #25273A;
-            --table-hover: #3E4967;
-            --table-text: #E0E0E0;
-            --table-header-text: #B0B3C5;
-            --table-border: #2E2E3E;
-            --table-pos: #4ADE80;
-            --table-neg: #F87171;
+            --table-bg: #1f2937;
+            --table-header-bg: #374151;
+            --table-row-alt: #1e293b;
+            --table-hover: #2563eb;
+            --table-hover-text: #ffffff;
+            --table-text: #e5e7eb;
+            --table-header-text: #f9fafb;
+            --table-border: #4b5563;
+            --table-pos: #22c55e;
+            --table-neg: #ef4444;
         }}
 
         body {{
@@ -150,22 +151,50 @@ def setup_page():
         }}
 
         /* --- DataFrame tables --- */
+        div[data-testid="stDataFrame"] {{
+            background-color: var(--table-bg);
+            border: 1px solid var(--table-border);
+            border-radius: 8px;
+            overflow: hidden;
+        }}
         div[data-testid="stDataFrame"] thead th {{
+            background-color: var(--table-header-bg);
+            color: var(--table-header-text);
+            font-weight: 600;
+            text-align: center;
             position: sticky;
             top: 0;
             z-index: 1;
         }}
+        div[data-testid="stDataFrame"] tbody tr {{
+            background-color: var(--table-bg);
+            color: var(--table-text);
+        }}
+        div[data-testid="stDataFrame"] tbody tr:nth-child(even) {{
+            background-color: var(--table-row-alt);
+        }}
         div[data-testid="stDataFrame"] tbody tr:hover {{
             background-color: var(--table-hover);
+            color: var(--table-hover-text);
+        }}
+        div[data-testid="stDataFrame"] td,
+        div[data-testid="stDataFrame"] th {{
+            border-bottom: 1px solid var(--table-border);
+            padding: 8px;
+        }}
+        div[data-testid="stDataFrame"] table {{
+            border-collapse: separate;
+            border-spacing: 0;
+            border-radius: 8px;
+            overflow: hidden;
+        }}
+        td.pos {{
+            color: var(--table-pos) !important;
+            font-weight: 600;
         }}
         td.neg {{
-            color: var(--table-neg);
-        }}
-        td[data-testid*="col_PctChange"] {{
-            color: var(--table-pos);
-        }}
-        td[data-testid*="col_PctChange"].neg {{
-            color: var(--table-neg);
+            color: var(--table-neg) !important;
+            font-weight: 600;
         }}
         </style>
         """,

--- a/ui/scan.py
+++ b/ui/scan.py
@@ -7,11 +7,12 @@ from .history import _apply_dark_theme
 
 
 def _style_negatives(df: pd.DataFrame) -> Styler:
-    """Return a Styler adding class "neg" to negative numeric cells."""
+    """Return a Styler adding classes for positive and negative cells."""
     classes = pd.DataFrame("", index=df.index, columns=df.columns)
     num_cols = df.select_dtypes(include="number").columns
     for col in num_cols:
         classes.loc[df[col] < 0, col] = "neg"
+        classes.loc[df[col] > 0, col] = "pos"
     return df.style.set_td_classes(classes)
 
 


### PR DESCRIPTION
## Summary
- Update global table CSS variables to a blue palette and style Streamlit DataFrames with matching container, header, row, and hover rules.
- Tag positive numeric cells with a `pos` class and color them via CSS alongside negatives.
- Extend unit test to verify both `pos` and `neg` classes are emitted.

## Testing
- `pytest -q`
- `streamlit run app.py --server.headless true`

------
https://chatgpt.com/codex/tasks/task_e_68b84b9420108332986c4ca5d3d94f70