### PR TITLE
Refactor negative styling into shared helper

### DIFF
--- a/tests/test_ui_tables.py
+++ b/tests/test_ui_tables.py
@@ -11,6 +11,7 @@ if str(ROOT) not in sys.path:
 
 import ui.history as history
 import ui.scan as scan
+import ui.table_utils as table_utils
 
 
 def test_outcomes_summary_orders_columns(monkeypatch):
@@ -180,7 +181,7 @@ def test_render_scanner_tab_shows_dataframe(monkeypatch):
 
 def test_style_negatives_marks_negatives():
     df = pd.DataFrame({"PctChange": [1, -2]})
-    styler = scan._style_negatives(df)
+    styler = table_utils._style_negatives(df)
     html = styler.to_html()
     assert 'neg"' in html
 

--- a/ui/history.py
+++ b/ui/history.py
@@ -4,15 +4,7 @@ from pandas.io.formats.style import Styler
 from utils.io import list_pass_files
 from utils.outcomes import read_outcomes
 from utils.formatting import _usd, _safe
-
-
-def _style_negatives(df: pd.DataFrame) -> Styler:
-    """Return a Styler adding class "neg" to negative numeric cells."""
-    classes = pd.DataFrame("", index=df.index, columns=df.columns)
-    num_cols = df.select_dtypes(include="number").columns
-    for col in num_cols:
-        classes.loc[df[col] < 0, col] = "neg"
-    return df.style.set_td_classes(classes)
+from .table_utils import _style_negatives
 
 
 def _apply_dark_theme(df: pd.DataFrame | Styler) -> Styler:

--- a/ui/scan.py
+++ b/ui/scan.py
@@ -4,15 +4,7 @@ from pandas.io.formats.style import Styler
 from utils.formatting import _bold, _usd, _pct, _safe
 from utils.scan import safe_run_scan
 from .history import _apply_dark_theme
-
-
-def _style_negatives(df: pd.DataFrame) -> Styler:
-    """Return a Styler adding class "neg" to negative numeric cells."""
-    classes = pd.DataFrame("", index=df.index, columns=df.columns)
-    num_cols = df.select_dtypes(include="number").columns
-    for col in num_cols:
-        classes.loc[df[col] < 0, col] = "neg"
-    return df.style.set_td_classes(classes)
+from .table_utils import _style_negatives
 
 
 def build_why_buy_html(row: dict) -> str:

--- a/ui/table_utils.py
+++ b/ui/table_utils.py
@@ -1,0 +1,12 @@
+import pandas as pd
+from pandas.io.formats.style import Styler
+
+
+def _style_negatives(df: pd.DataFrame) -> Styler:
+    """Return a Styler adding class "neg" to negative numeric cells."""
+    classes = pd.DataFrame("", index=df.index, columns=df.columns)
+    num_cols = df.select_dtypes(include="number").columns
+    for col in num_cols:
+        classes.loc[df[col] < 0, col] = "neg"
+    return df.style.set_td_classes(classes)
+


### PR DESCRIPTION
## Summary
- centralize `_style_negatives` in new `ui/table_utils.py`
- update `ui.history` and `ui.scan` to reuse the shared helper
- adjust tests to import the helper from its new location

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8529108908332ad293e4ae9179e85