### PR TITLE
refactor: centralize dark theme styling

### DIFF
--- a/ui/history.py
+++ b/ui/history.py
@@ -4,6 +4,7 @@ from pandas.io.formats.style import Styler
 from utils.io import list_pass_files
 from utils.outcomes import read_outcomes
 from utils.formatting import _usd, _safe
+from .table_styles import _apply_dark_theme
 
 
 def _style_negatives(df: pd.DataFrame) -> Styler:
@@ -13,39 +14,6 @@ def _style_negatives(df: pd.DataFrame) -> Styler:
     for col in num_cols:
         classes.loc[df[col] < 0, col] = "neg"
     return df.style.set_td_classes(classes)
-
-
-def _apply_dark_theme(df: pd.DataFrame | Styler) -> Styler:
-    base = df.style if isinstance(df, pd.DataFrame) else df
-    return base.set_table_styles([
-        {
-            "selector": "th",
-            "props": [
-                ("background-color", "var(--table-header-bg)"),
-                ("color", "var(--table-header-text)"),
-                ("border", "1px solid var(--table-border)"),
-            ],
-        },
-        {
-            "selector": "td",
-            "props": [
-                ("background-color", "var(--table-bg)"),
-                ("color", "var(--table-text)"),
-                ("border", "1px solid var(--table-border)"),
-            ],
-        },
-        {
-            "selector": "tbody tr:nth-child(even)",
-            "props": [("background-color", "var(--table-row-alt)")],
-        },
-        {
-            "selector": "tbody tr:hover",
-            "props": [
-                ("background-color", "var(--table-hover)"),
-                ("color", "var(--table-hover-text)"),
-            ],
-        },
-    ])
 
 
 def load_history_df() -> pd.DataFrame:

--- a/ui/scan.py
+++ b/ui/scan.py
@@ -3,7 +3,7 @@ import streamlit as st
 from pandas.io.formats.style import Styler
 from utils.formatting import _bold, _usd, _pct, _safe
 from utils.scan import safe_run_scan
-from .history import _apply_dark_theme
+from .table_styles import _apply_dark_theme
 
 
 def _style_negatives(df: pd.DataFrame) -> Styler:

--- a/ui/table_styles.py
+++ b/ui/table_styles.py
@@ -1,0 +1,36 @@
+import pandas as pd
+from pandas.io.formats.style import Styler
+
+
+def _apply_dark_theme(df: pd.DataFrame | Styler) -> Styler:
+    base = df.style if isinstance(df, pd.DataFrame) else df
+    return base.set_table_styles([
+        {
+            "selector": "th",
+            "props": [
+                ("background-color", "var(--table-header-bg)"),
+                ("color", "var(--table-header-text)"),
+                ("border", "1px solid var(--table-border)"),
+            ],
+        },
+        {
+            "selector": "td",
+            "props": [
+                ("background-color", "var(--table-bg)"),
+                ("color", "var(--table-text)"),
+                ("border", "1px solid var(--table-border)"),
+            ],
+        },
+        {
+            "selector": "tbody tr:nth-child(even)",
+            "props": [("background-color", "var(--table-row-alt)")],
+        },
+        {
+            "selector": "tbody tr:hover",
+            "props": [
+                ("background-color", "var(--table-hover)"),
+                ("color", "var(--table-hover-text)"),
+            ],
+        },
+    ])
+


### PR DESCRIPTION
## Summary
- move `_apply_dark_theme` from history to new `ui/table_styles` module
- update history and scan modules to use shared dark-theme helper

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b85292eafc83329003f94a3d45fe3d