### PR TITLE
style: enhance dark theme for data tables

### DIFF
--- a/tests/test_ui_tables.py
+++ b/tests/test_ui_tables.py
@@ -179,9 +179,10 @@ def test_render_scanner_tab_shows_dataframe(monkeypatch):
     assert list(parsed.columns) == ["Ticker", "Price", "RelVol(TimeAdj63d)", "TP"]
 
 
-def test_style_negatives_marks_negatives():
-    df = pd.DataFrame({"PctChange": [1, -2]})
+def test_style_negatives_marks_both_signs():
+    df = pd.DataFrame({"PctChange": [1, -2, 0]})
     styler = table_utils._style_negatives(df)
     html = styler.to_html()
     assert 'neg"' in html
+    assert 'pos"' in html
 

--- a/ui/history.py
+++ b/ui/history.py
@@ -9,35 +9,50 @@ from .table_utils import _style_negatives
 
 def _apply_dark_theme(df: pd.DataFrame | Styler) -> Styler:
     base = df.style if isinstance(df, pd.DataFrame) else df
-    return base.set_table_styles([
-        {
-            "selector": "th",
-            "props": [
-                ("background-color", "var(--table-header-bg)"),
-                ("color", "var(--table-header-text)"),
-                ("border", "1px solid var(--table-border)"),
-            ],
-        },
-        {
-            "selector": "td",
-            "props": [
-                ("background-color", "var(--table-bg)"),
-                ("color", "var(--table-text)"),
-                ("border", "1px solid var(--table-border)"),
-            ],
-        },
-        {
-            "selector": "tbody tr:nth-child(even)",
-            "props": [("background-color", "var(--table-row-alt)")],
-        },
-        {
-            "selector": "tbody tr:hover",
-            "props": [
-                ("background-color", "var(--table-hover)"),
-                ("color", "var(--table-hover-text)"),
-            ],
-        },
-    ])
+    return base.set_table_styles(
+        [
+            {
+                "selector": "th",
+                "props": [
+                    ("background-color", "var(--table-header-bg)"),
+                    ("color", "var(--table-header-text)"),
+                    ("border-bottom", "1px solid var(--table-border)"),
+                    ("font-weight", "600"),
+                    ("text-align", "center"),
+                    ("padding", "8px"),
+                ],
+            },
+            {
+                "selector": "td",
+                "props": [
+                    ("background-color", "var(--table-bg)"),
+                    ("color", "var(--table-text)"),
+                    ("border-bottom", "1px solid var(--table-border)"),
+                    ("padding", "8px"),
+                ],
+            },
+            {
+                "selector": "tbody tr:nth-child(even)",
+                "props": [("background-color", "var(--table-row-alt)")],
+            },
+            {
+                "selector": "tbody tr:hover",
+                "props": [
+                    ("background-color", "var(--table-hover)"),
+                    ("color", "var(--table-hover-text)"),
+                ],
+            },
+            {
+                "selector": "table",
+                "props": [
+                    ("border-collapse", "separate"),
+                    ("border-spacing", "0"),
+                    ("border-radius", "8px"),
+                    ("overflow", "hidden"),
+                ],
+            },
+        ]
+    )
 
 
 def load_history_df() -> pd.DataFrame:

--- a/ui/layout.py
+++ b/ui/layout.py
@@ -30,16 +30,16 @@ def setup_page():
             --padding: 1rem;
             --font-size-base: 16px;
             --col-width: 33%;
-            --table-bg: #111827;
-            --table-header-bg: #2A2A3C;
-            --table-row-alt: #0f172a;
-            --table-hover: #2f498f;
+            --table-bg: #1f2937;
+            --table-header-bg: #374151;
+            --table-row-alt: #1e293b;
+            --table-hover: #2563eb;
             --table-hover-text: #ffffff;
-            --table-text: #E0E0E0;
-            --table-header-text: #B0B3C5;
-            --table-border: #2E2E3E;
-            --table-pos: #4ADE80;
-            --table-neg: #F87171;
+            --table-text: #e5e7eb;
+            --table-header-text: #f9fafb;
+            --table-border: #4b5563;
+            --table-pos: #22c55e;
+            --table-neg: #ef4444;
         }}
 
         body {{
@@ -151,23 +151,57 @@ def setup_page():
         }}
 
         /* --- DataFrame tables --- */
+        /* Table container */
+        div[data-testid="stDataFrame"] {{
+            background-color: var(--table-bg);
+            border: 1px solid var(--table-border);
+            border-radius: 8px;
+            overflow: hidden;
+        }}
+        /* Header */
         div[data-testid="stDataFrame"] thead th {{
+            background-color: var(--table-header-bg);
+            color: var(--table-header-text);
+            font-weight: 600;
+            text-align: center;
             position: sticky;
             top: 0;
             z-index: 1;
         }}
+        /* Rows */
+        div[data-testid="stDataFrame"] tbody tr {{
+            background-color: var(--table-bg);
+            color: var(--table-text);
+        }}
+        div[data-testid="stDataFrame"] tbody tr:nth-child(even) {{
+            background-color: var(--table-row-alt);
+        }}
+        /* Hover effect */
         div[data-testid="stDataFrame"] tbody tr:hover {{
             background-color: var(--table-hover);
             color: var(--table-hover-text);
         }}
+        /* Borders between cells */
+        div[data-testid="stDataFrame"] td,
+        div[data-testid="stDataFrame"] th {{
+            border-bottom: 1px solid var(--table-border);
+            padding: 8px;
+        }}
+        /* Rounded corners on the full table */
+        div[data-testid="stDataFrame"] table {{
+            border-collapse: separate;
+            border-spacing: 0;
+            border-radius: 8px;
+            overflow: hidden;
+        }}
+        /* Positive / Negative number coloring */
+        td.pos {{
+            color: var(--table-pos) !important;
+            font-weight: 600;
+        }}
         td.neg {{
-            color: var(--table-neg);
-        }}
-        td[data-testid*="col_PctChange"] {{
-            color: var(--table-pos);
-        }}
-        td[data-testid*="col_PctChange"].neg {{
-            color: var(--table-neg);
+            color: var(--table-neg) !important;
+            font-weight: 600;
         }}
         </style>
         """,

--- a/ui/table_utils.py
+++ b/ui/table_utils.py
@@ -3,10 +3,11 @@ from pandas.io.formats.style import Styler
 
 
 def _style_negatives(df: pd.DataFrame) -> Styler:
-    """Return a Styler adding class "neg" to negative numeric cells."""
+    """Return a Styler adding class "neg" or "pos" to numeric cells."""
     classes = pd.DataFrame("", index=df.index, columns=df.columns)
     num_cols = df.select_dtypes(include="number").columns
     for col in num_cols:
         classes.loc[df[col] < 0, col] = "neg"
+        classes.loc[df[col] > 0, col] = "pos"
     return df.style.set_td_classes(classes)
 


### PR DESCRIPTION
## Summary
- update global CSS variables and table styling for Streamlit DataFrames
- highlight positive and negative numbers with pos/neg classes
- adjust dark theme helper to mirror CSS and add table rounding

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b85ad6ff208332bc19eeb3f9ce5afb