### PR TITLE
Use st.markdown for styled history tables

### DIFF
--- a/tests/test_ui_tables.py
+++ b/tests/test_ui_tables.py
@@ -35,22 +35,19 @@ def test_outcomes_summary_orders_columns(monkeypatch):
         }
     )
 
-    df_calls = []
+    html_calls = []
     monkeypatch.setattr(
         history.st,
-        "dataframe",
-        lambda df_arg, *a, **k: df_calls.append((df_arg, k)),
+        "markdown",
+        lambda html_arg, *a, **k: html_calls.append(html_arg),
     )
     monkeypatch.setattr(history.st, "caption", lambda *a, **k: None)
     monkeypatch.setattr(history.st, "info", lambda *a, **k: None)
 
     history.outcomes_summary(df)
 
-    assert df_calls
-    df_shown, kwargs = df_calls[0]
-    assert kwargs.get("use_container_width") is True
-    html = df_shown.to_html()
-    parsed = pd.read_html(html, index_col=0)[0]
+    assert html_calls
+    parsed = pd.read_html(html_calls[0], index_col=0)[0]
     assert list(parsed.columns) == [
         "Ticker",
         "EvalDate",
@@ -95,14 +92,14 @@ def test_render_history_tab_shows_extended_columns(monkeypatch):
         }
     )
 
-    df_calls = []
+    html_calls = []
     monkeypatch.setattr(history.st, "subheader", lambda *a, **k: None)
     monkeypatch.setattr(history.st, "info", lambda *a, **k: None)
     monkeypatch.setattr(history.st, "caption", lambda *a, **k: None)
     monkeypatch.setattr(
         history.st,
-        "dataframe",
-        lambda df_arg, *a, **k: df_calls.append((df_arg, k)),
+        "markdown",
+        lambda html_arg, *a, **k: html_calls.append(html_arg),
     )
 
     df_outcomes = pd.DataFrame(
@@ -129,11 +126,8 @@ def test_render_history_tab_shows_extended_columns(monkeypatch):
 
     history.render_history_tab()
 
-    assert len(df_calls) >= 2
-    df_shown, kwargs = df_calls[0]
-    assert kwargs.get("use_container_width") is True
-    html = df_shown.to_html()
-    parsed = pd.read_html(html, index_col=0)[0]
+    assert len(html_calls) >= 2
+    parsed = pd.read_html(html_calls[0], index_col=0)[0]
     assert list(parsed.columns) == [
         "Ticker",
         "EvalDate",

--- a/ui/history.py
+++ b/ui/history.py
@@ -67,6 +67,7 @@ def _apply_dark_theme(
                 ("border-spacing", "0"),
                 ("border-radius", "8px"),
                 ("overflow", "hidden"),
+                ("width", "100%"),
             ],
         },
         {
@@ -241,9 +242,9 @@ def outcomes_summary(dfh: pd.DataFrame):
     cols = [c for c in preferred if c in df_disp.columns]
     if cols:
         df_disp = df_disp[cols]
-    st.dataframe(
-        _apply_dark_theme(_style_negatives(df_disp)),
-        use_container_width=True,
+    st.markdown(
+        _apply_dark_theme(_style_negatives(df_disp)).to_html(),
+        unsafe_allow_html=True,
     )
 
 
@@ -278,9 +279,9 @@ def render_history_tab():
             ]
             cols = [c for c in preferred if c in df_last.columns]
             df_show = df_last[cols] if cols else df_last  # fall back to full frame
-            st.dataframe(
-                _apply_dark_theme(_style_negatives(df_show)),
-                use_container_width=True,
+            st.markdown(
+                _apply_dark_theme(_style_negatives(df_show)).to_html(),
+                unsafe_allow_html=True,
             )
     else:
         st.subheader("Trading day — recommendations")


### PR DESCRIPTION
## Summary
- Render history tables via `st.markdown` to preserve dark theme and red/green cell styles
- Apply width via CSS and drop `use_container_width` which was ignored by `st.markdown`
- Update table tests to parse HTML generated by the new rendering approach

## Testing
- `pytest -q`
- `python - <<'PY'
import pandas as pd
from ui.history import _apply_dark_theme
from ui.table_utils import _style_negatives

df = pd.DataFrame({'A':[1,-2]})
html = _apply_dark_theme(_style_negatives(df)).to_html()
print('width: 100%' in html)
PY`
- `streamlit run app.py --server.headless true` *(health check via curl)*

------
https://chatgpt.com/codex/tasks/task_e_68b860f3d1a88332bc0edf71e01c4e85