### PR TITLE
Use st.markdown for styled tables with selectable rows

### DIFF
--- a/tests/test_ui_tables.py
+++ b/tests/test_ui_tables.py
@@ -35,21 +35,19 @@ def test_outcomes_summary_orders_columns(monkeypatch):
         }
     )
 
-    df_calls = []
+    html_calls = []
     monkeypatch.setattr(
         history.st,
-        "dataframe",
-        lambda df_arg, *a, **k: df_calls.append((df_arg, k)),
+        "markdown",
+        lambda html_arg, *a, **k: html_calls.append(html_arg),
     )
     monkeypatch.setattr(history.st, "caption", lambda *a, **k: None)
     monkeypatch.setattr(history.st, "info", lambda *a, **k: None)
 
     history.outcomes_summary(df)
 
-    assert df_calls
-    df_shown, kwargs = df_calls[0]
-    assert kwargs.get("use_container_width") is True
-    html = df_shown.to_html()
+    assert html_calls
+    html = html_calls[0]
     parsed = pd.read_html(html, index_col=0)[0]
     assert list(parsed.columns) == [
         "Ticker",
@@ -69,6 +67,10 @@ def test_outcomes_summary_orders_columns(monkeypatch):
         "TP",
         "Notes",
     ]
+    assert 'class="dark-table"' in html
+    assert 'tbody tr:hover td' in html
+    assert 'tbody tr.selected td' in html
+    assert '<script>' in html
 
 
 def test_render_history_tab_shows_extended_columns(monkeypatch):
@@ -95,14 +97,14 @@ def test_render_history_tab_shows_extended_columns(monkeypatch):
         }
     )
 
-    df_calls = []
+    html_calls = []
     monkeypatch.setattr(history.st, "subheader", lambda *a, **k: None)
     monkeypatch.setattr(history.st, "info", lambda *a, **k: None)
     monkeypatch.setattr(history.st, "caption", lambda *a, **k: None)
     monkeypatch.setattr(
         history.st,
-        "dataframe",
-        lambda df_arg, *a, **k: df_calls.append((df_arg, k)),
+        "markdown",
+        lambda html_arg, *a, **k: html_calls.append(html_arg),
     )
 
     df_outcomes = pd.DataFrame(
@@ -129,10 +131,8 @@ def test_render_history_tab_shows_extended_columns(monkeypatch):
 
     history.render_history_tab()
 
-    assert len(df_calls) >= 2
-    df_shown, kwargs = df_calls[0]
-    assert kwargs.get("use_container_width") is True
-    html = df_shown.to_html()
+    assert len(html_calls) >= 2
+    html = html_calls[0]
     parsed = pd.read_html(html, index_col=0)[0]
     assert list(parsed.columns) == [
         "Ticker",
@@ -153,6 +153,8 @@ def test_render_history_tab_shows_extended_columns(monkeypatch):
         "TP",
         "Notes",
     ]
+    assert 'class="dark-table"' in html
+    assert '<script>' in html
 
 
 def test_render_scanner_tab_shows_dataframe(monkeypatch):
@@ -177,6 +179,8 @@ def test_render_scanner_tab_shows_dataframe(monkeypatch):
     assert table_html is not None
     parsed = pd.read_html(table_html, index_col=0)[0]
     assert list(parsed.columns) == ["Ticker", "Price", "RelVol(TimeAdj63d)", "TP"]
+    assert 'class="dark-table"' in table_html
+    assert 'tbody tr.selected td' in table_html
 
 
 def test_style_negatives_marks_both_signs():

--- a/ui/scan.py
+++ b/ui/scan.py
@@ -1,10 +1,8 @@
 import pandas as pd
 import streamlit as st
-from pandas.io.formats.style import Styler
 from utils.formatting import _bold, _usd, _pct, _safe
 from utils.scan import safe_run_scan
-from .history import _apply_dark_theme
-from .table_utils import _style_negatives
+from .history import render_table
 
 
 def build_why_buy_html(row: dict) -> str:
@@ -101,32 +99,22 @@ def render_scanner_tab():
             st.warning("No tickers passed the filters.")
         else:
             st.success(f"Found {len(df_pass)} passing tickers (latest run).")
-            st.markdown(
-                _apply_dark_theme(_style_negatives(df_pass)).to_html(),
-                unsafe_allow_html=True,
-            )
+            st.markdown(render_table(df_pass), unsafe_allow_html=True)
             _render_why_buy_block(df_pass)
             with st.expander("Google-Sheet style view (optional)", expanded=False):
                 st.markdown(
-                    _apply_dark_theme(
-                        _style_negatives(_sheet_friendly(df_pass))
-                    ).to_html(),
+                    render_table(_sheet_friendly(df_pass)),
                     unsafe_allow_html=True,
                 )
 
     elif isinstance(st.session_state.get("last_pass"), pd.DataFrame) and not st.session_state["last_pass"].empty:
         df_pass: pd.DataFrame = st.session_state["last_pass"]
         st.info(f"Showing last run in this session • {len(df_pass)} tickers")
-        st.markdown(
-            _apply_dark_theme(_style_negatives(df_pass)).to_html(),
-            unsafe_allow_html=True,
-        )
+        st.markdown(render_table(df_pass), unsafe_allow_html=True)
         _render_why_buy_block(df_pass)
         with st.expander("Google-Sheet style view (optional)", expanded=False):
             st.markdown(
-                _apply_dark_theme(
-                    _style_negatives(_sheet_friendly(df_pass))
-                ).to_html(),
+                render_table(_sheet_friendly(df_pass)),
                 unsafe_allow_html=True,
             )
     else:


### PR DESCRIPTION
## Summary
- Add hover and click-to-select behavior via CSS and JS helper `render_table`
- Render scanner and history tables through `render_table` for consistent dark theme styling
- Update table tests to ensure selectable rows and scripts are present

## Testing
- `pytest -q`
- `python - <<'PY'
import pandas as pd
from ui.history import render_table

df = pd.DataFrame({'A':[1,-2]})
html = render_table(df)
print(html.split('\n')[0][:60])
print('tbody tr.selected td' in html)
print('<script>' in html)
PY`
- `streamlit run app.py --server.headless true & curl -s http://localhost:8501/healthz`


------
https://chatgpt.com/codex/tasks/task_e_68b860f3d1a88332bc0edf71e01c4e85