### PR TITLE
refactor: centralize table rendering helpers

### DIFF
--- a/tests/test_ui_tables.py
+++ b/tests/test_ui_tables.py
@@ -12,6 +12,7 @@ if str(ROOT) not in sys.path:
 import ui.history as history
 import ui.scan as scan
 import ui.table_utils as table_utils
+import ui.table_render as table_render
 
 
 def test_outcomes_summary_orders_columns(monkeypatch):
@@ -181,4 +182,11 @@ def test_style_negatives_marks_both_signs():
     html = styler.to_html()
     assert 'neg"' in html
     assert 'pos"' in html
+
+
+def test_render_table_wraps_html():
+    df = pd.DataFrame({"A": [1]})
+    html = table_render.render_table(df)
+    assert "<div class='table-wrapper'" in html
+    assert "<table" in html
 

--- a/ui/scan.py
+++ b/ui/scan.py
@@ -1,10 +1,8 @@
 import pandas as pd
 import streamlit as st
-from pandas.io.formats.style import Styler
 from utils.formatting import _bold, _usd, _pct, _safe
 from utils.scan import safe_run_scan
-from .history import _apply_dark_theme
-from .table_utils import _style_negatives
+from .table_render import render_table
 
 
 def build_why_buy_html(row: dict) -> str:
@@ -104,22 +102,14 @@ def render_scanner_tab():
             if "Ticker" in df_pass.columns:
                 order = ["Ticker"] + [c for c in df_pass.columns if c != "Ticker"]
                 df_pass = df_pass[order]
-            table_html = _apply_dark_theme(_style_negatives(df_pass)).to_html()
-            st.markdown(
-                f"<div class='table-wrapper' tabindex='0'>{table_html}</div>",
-                unsafe_allow_html=True,
-            )
+            st.markdown(render_table(df_pass), unsafe_allow_html=True)
             _render_why_buy_block(df_pass)
             with st.expander("Google-Sheet style view (optional)", expanded=False):
                 sf = _sheet_friendly(df_pass)
                 if "Ticker" in sf.columns:
                     order = ["Ticker"] + [c for c in sf.columns if c != "Ticker"]
                     sf = sf[order]
-                table_html = _apply_dark_theme(_style_negatives(sf)).to_html()
-                st.markdown(
-                    f"<div class='table-wrapper' tabindex='0'>{table_html}</div>",
-                    unsafe_allow_html=True,
-                )
+                st.markdown(render_table(sf), unsafe_allow_html=True)
 
     elif isinstance(st.session_state.get("last_pass"), pd.DataFrame) and not st.session_state["last_pass"].empty:
         df_pass: pd.DataFrame = st.session_state["last_pass"]
@@ -127,21 +117,13 @@ def render_scanner_tab():
         if "Ticker" in df_pass.columns:
             order = ["Ticker"] + [c for c in df_pass.columns if c != "Ticker"]
             df_pass = df_pass[order]
-        table_html = _apply_dark_theme(_style_negatives(df_pass)).to_html()
-        st.markdown(
-            f"<div class='table-wrapper' tabindex='0'>{table_html}</div>",
-            unsafe_allow_html=True,
-        )
+        st.markdown(render_table(df_pass), unsafe_allow_html=True)
         _render_why_buy_block(df_pass)
         with st.expander("Google-Sheet style view (optional)", expanded=False):
             sf = _sheet_friendly(df_pass)
             if "Ticker" in sf.columns:
                 order = ["Ticker"] + [c for c in sf.columns if c != "Ticker"]
                 sf = sf[order]
-            table_html = _apply_dark_theme(_style_negatives(sf)).to_html()
-            st.markdown(
-                f"<div class='table-wrapper' tabindex='0'>{table_html}</div>",
-                unsafe_allow_html=True,
-            )
+            st.markdown(render_table(sf), unsafe_allow_html=True)
     else:
         st.caption("No results yet. Press **RUN** to scan.")

--- a/ui/table_render.py
+++ b/ui/table_render.py
@@ -1,0 +1,132 @@
+import pandas as pd
+from pandas.io.formats.style import Styler
+
+from .table_utils import _style_negatives
+
+
+ROW_SELECT_JS = """
+<script>
+// Allow arrow-key row navigation within table wrappers
+(function() {
+  function onKey(e) {
+    const wrapper = e.target.closest('.table-wrapper');
+    if (!wrapper) return;
+    const rows = wrapper.querySelectorAll('tbody tr');
+    if (!rows.length) return;
+    let idx = Array.from(rows).findIndex(r => r.classList.contains('selected'));
+    if (e.key === 'ArrowDown') {
+      idx = Math.min(idx + 1, rows.length - 1);
+    } else if (e.key === 'ArrowUp') {
+      idx = Math.max(idx - 1, 0);
+    } else {
+      return;
+    }
+    e.preventDefault();
+    rows.forEach(r => r.classList.remove('selected'));
+    rows[idx].classList.add('selected');
+    rows[idx].scrollIntoView({block: 'nearest'});
+  }
+  document.addEventListener('keydown', onKey, true);
+})();
+</script>
+"""
+
+
+def _apply_dark_theme(
+    df: pd.DataFrame | Styler, colors: dict[str, str] | None = None
+) -> Styler:
+    """Apply a dark theme with inlined palette and scoped pos/neg styles."""
+    palette = {
+        "--table-bg": "#1f2937",
+        "--table-header-bg": "#374151",
+        "--table-row-alt": "#1e293b",
+        "--table-hover": "#2563eb",
+        "--table-hover-text": "#ffffff",
+        "--table-text": "#e5e7eb",
+        "--table-header-text": "#f9fafb",
+        "--table-border": "#4b5563",
+        "--table-pos": "#22c55e",
+        "--table-neg": "#ef4444",
+    }
+    if colors:
+        palette.update(colors)
+
+    base = df.style if isinstance(df, pd.DataFrame) else df
+    styles = [
+        {"selector": ":root", "props": list(palette.items())},
+        {
+            "selector": "th",
+            "props": [
+                ("background-color", "var(--table-header-bg)"),
+                ("color", "var(--table-header-text)"),
+                ("border-bottom", "1px solid var(--table-border)"),
+                ("font-weight", "600"),
+                ("text-align", "center"),
+                ("padding", "8px"),
+            ],
+        },
+        {
+            "selector": "td",
+            "props": [
+                ("background-color", "var(--table-bg)"),
+                ("color", "var(--table-text)"),
+                ("border-bottom", "1px solid var(--table-border)"),
+                ("padding", "8px"),
+            ],
+        },
+        {
+            "selector": "tbody tr:nth-child(even)",
+            "props": [("background-color", "var(--table-row-alt)")],
+        },
+        {
+            "selector": "tbody tr:hover",
+            "props": [
+                ("background-color", "var(--table-hover)"),
+                ("color", "var(--table-hover-text)"),
+            ],
+        },
+        {
+            "selector": "table",
+            "props": [
+                ("border-collapse", "separate"),
+                ("border-spacing", "0"),
+                ("border-radius", "8px"),
+                ("overflow", "hidden"),
+                ("width", "max-content"),
+                ("white-space", "nowrap"),
+            ],
+        },
+        {
+            "selector": "th:first-child",
+            "props": [
+                ("position", "sticky"),
+                ("left", "0"),
+                ("z-index", "2"),
+                ("background-color", "var(--table-header-bg)"),
+            ],
+        },
+        {
+            "selector": "td:first-child",
+            "props": [
+                ("position", "sticky"),
+                ("left", "0"),
+                ("background-color", "var(--table-bg)"),
+                ("z-index", "1"),
+            ],
+        },
+        {
+            "selector": "td.pos",
+            "props": [("color", "var(--table-pos)"), ("font-weight", "600")],
+        },
+        {
+            "selector": "td.neg",
+            "props": [("color", "var(--table-neg)"), ("font-weight", "600")],
+        },
+    ]
+    return base.set_table_styles(styles)
+
+
+def render_table(df: pd.DataFrame, *, colors: dict[str, str] | None = None) -> str:
+    """Return an HTML table wrapped for Streamlit rendering."""
+    html = _apply_dark_theme(_style_negatives(df), colors).to_html()
+    return f"<div class='table-wrapper' tabindex='0'>{html}</div>" + ROW_SELECT_JS


### PR DESCRIPTION
## Summary
- centralize dark theme, row selection JS, and HTML rendering into new `table_render` module
- update history and scan views to use shared `render_table`
- adjust tests to import and exercise new helpers

## Testing
- `pytest tests/test_ui_tables.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b86bc9095c8332ac4af990debd4145