### PR TITLE
refactor: remove unused history loader

### DIFF
--- a/tests/test_ui_tables.py
+++ b/tests/test_ui_tables.py
@@ -123,7 +123,6 @@ def test_render_history_tab_shows_extended_columns(monkeypatch):
     )
     monkeypatch.setattr(history, "load_outcomes", lambda: df_outcomes)
     monkeypatch.setattr(history, "latest_trading_day_recs", lambda _df: (df_last, "2024-01-01"))
-    monkeypatch.setattr(history, "load_history_df", lambda: pd.DataFrame())
 
     history.render_history_tab()
 

--- a/ui/history.py
+++ b/ui/history.py
@@ -231,22 +231,6 @@ def outcomes_summary(dfh: pd.DataFrame):
 def render_history_tab():
     df_out = load_outcomes()
 
-    # --- Historical PASS data across all runs ---
-    df_hist = load_history_df()
-    if df_hist.empty:
-        st.subheader("PASS history")
-        st.info("No historical pass files found.")
-    else:
-        st.subheader("PASS history")
-        if "Ticker" in df_hist.columns:
-            cols = ["Ticker"] + [c for c in df_hist.columns if c != "Ticker"]
-            df_hist = df_hist[cols]
-        table_html = _apply_dark_theme(_style_negatives(df_hist)).to_html()
-        st.markdown(
-            f"<div class='table-wrapper' tabindex='0'>{table_html}</div>",
-            unsafe_allow_html=True,
-        )
-
     # --- Latest recommendations based on most recent run_date ---
     df_last, date_str = latest_trading_day_recs(df_out)
     if date_str:


### PR DESCRIPTION
## Summary
- remove obsolete `load_history_df` call in history tab
- adjust tests for new data loading path

## Testing
- `pytest -q`
- `streamlit run app.py --server.headless true --server.port 8501`

------
https://chatgpt.com/codex/tasks/task_e_68b86f2a08a0833290dd392862d7ebad