### PR TITLE
Ensure styled tables render at full width

### DIFF
--- a/tests/test_ui_tables.py
+++ b/tests/test_ui_tables.py
@@ -47,7 +47,8 @@ def test_outcomes_summary_orders_columns(monkeypatch):
     history.outcomes_summary(df)
 
     assert html_calls
-    parsed = pd.read_html(html_calls[0], index_col=0)[0]
+    html = html_calls[0]
+    parsed = pd.read_html(html, index_col=0)[0]
     assert list(parsed.columns) == [
         "Ticker",
         "EvalDate",
@@ -66,6 +67,7 @@ def test_outcomes_summary_orders_columns(monkeypatch):
         "TP",
         "Notes",
     ]
+    assert "width: 100%" in html
 
 
 def test_render_history_tab_shows_extended_columns(monkeypatch):
@@ -128,7 +130,8 @@ def test_render_history_tab_shows_extended_columns(monkeypatch):
     history.render_history_tab()
 
     assert len(html_calls) >= 2
-    parsed = pd.read_html(html_calls[0], index_col=0)[0]
+    html = html_calls[0]
+    parsed = pd.read_html(html, index_col=0)[0]
     assert list(parsed.columns) == [
         "Ticker",
         "EvalDate",
@@ -149,6 +152,7 @@ def test_render_history_tab_shows_extended_columns(monkeypatch):
         "Notes",
         "Extra",
     ]
+    assert "width: 100%" in html
 
 
 def test_render_scanner_tab_shows_dataframe(monkeypatch):
@@ -173,6 +177,7 @@ def test_render_scanner_tab_shows_dataframe(monkeypatch):
     assert table_html is not None
     parsed = pd.read_html(table_html, index_col=0)[0]
     assert list(parsed.columns) == ["Ticker", "Price", "RelVol(TimeAdj63d)", "TP"]
+    assert "width: 100%" in table_html
 
 
 def test_style_negatives_marks_both_signs():

--- a/ui/history.py
+++ b/ui/history.py
@@ -67,7 +67,7 @@ def _apply_dark_theme(
                 ("border-spacing", "0"),
                 ("border-radius", "8px"),
                 ("overflow", "hidden"),
-                ("width", "max-content"),
+                ("width", "100%"),
                 ("white-space", "nowrap"),
             ],
         },

--- a/ui/layout.py
+++ b/ui/layout.py
@@ -210,7 +210,7 @@ def setup_page():
             max-width: 100%;
         }}
         .table-wrapper table {{
-            width: max-content;
+            width: 100%;
         }}
         </style>
         """,


### PR DESCRIPTION
## Summary
- render dark-themed tables at full width
- verify table HTML includes width: 100%

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b86bcf2d4883329119f9219840a55f