### PR TITLE
Ensure table row selection persists after reruns

### DIFF
--- a/ui/history.py
+++ b/ui/history.py
@@ -4,7 +4,7 @@ from pandas.io.formats.style import Styler
 from utils.io import list_pass_files
 from utils.outcomes import read_outcomes
 from utils.formatting import _usd, _safe
-from .table_utils import _style_negatives
+from .table_utils import _style_negatives, ROW_CLICK_JS
 
 
 def _apply_dark_theme(
@@ -61,6 +61,13 @@ def _apply_dark_theme(
             ],
         },
         {
+            "selector": "tbody tr.selected",
+            "props": [
+                ("background-color", "var(--table-hover)"),
+                ("color", "var(--table-hover-text)"),
+            ],
+        },
+        {
             "selector": "table",
             "props": [
                 ("border-collapse", "separate"),
@@ -98,7 +105,7 @@ def _apply_dark_theme(
             "props": [("color", "var(--table-neg)"), ("font-weight", "600")],
         },
     ]
-    return base.set_table_styles(styles)
+    return base.set_table_styles(styles).set_table_attributes('class="dark-table"')
 
 
 def load_history_df() -> pd.DataFrame:
@@ -266,6 +273,7 @@ def outcomes_summary(dfh: pd.DataFrame):
         f"<div class='table-wrapper' tabindex='0'>{table_html}</div>",
         unsafe_allow_html=True,
     )
+    st.markdown(ROW_CLICK_JS, unsafe_allow_html=True)
 
 
 def render_history_tab():
@@ -286,6 +294,7 @@ def render_history_tab():
             f"<div class='table-wrapper' tabindex='0'>{table_html}</div>",
             unsafe_allow_html=True,
         )
+        st.markdown(ROW_CLICK_JS, unsafe_allow_html=True)
 
     # --- Latest recommendations based on most recent run_date ---
     df_last, date_str = latest_trading_day_recs(df_out)
@@ -304,6 +313,7 @@ def render_history_tab():
                 f"<div class='table-wrapper' tabindex='0'>{table_html}</div>",
                 unsafe_allow_html=True,
             )
+            st.markdown(ROW_CLICK_JS, unsafe_allow_html=True)
     else:
         st.subheader("Trading day — recommendations")
         st.info("No pass files yet. Run the scanner (or wait for the next scheduled run).")

--- a/ui/scan.py
+++ b/ui/scan.py
@@ -4,7 +4,7 @@ from pandas.io.formats.style import Styler
 from utils.formatting import _bold, _usd, _pct, _safe
 from utils.scan import safe_run_scan
 from .history import _apply_dark_theme
-from .table_utils import _style_negatives
+from .table_utils import _style_negatives, ROW_CLICK_JS
 
 
 def build_why_buy_html(row: dict) -> str:
@@ -109,6 +109,7 @@ def render_scanner_tab():
                 f"<div class='table-wrapper' tabindex='0'>{table_html}</div>",
                 unsafe_allow_html=True,
             )
+            st.markdown(ROW_CLICK_JS, unsafe_allow_html=True)
             _render_why_buy_block(df_pass)
             with st.expander("Google-Sheet style view (optional)", expanded=False):
                 sf = _sheet_friendly(df_pass)
@@ -120,6 +121,7 @@ def render_scanner_tab():
                     f"<div class='table-wrapper' tabindex='0'>{table_html}</div>",
                     unsafe_allow_html=True,
                 )
+                st.markdown(ROW_CLICK_JS, unsafe_allow_html=True)
 
     elif isinstance(st.session_state.get("last_pass"), pd.DataFrame) and not st.session_state["last_pass"].empty:
         df_pass: pd.DataFrame = st.session_state["last_pass"]
@@ -132,6 +134,7 @@ def render_scanner_tab():
             f"<div class='table-wrapper' tabindex='0'>{table_html}</div>",
             unsafe_allow_html=True,
         )
+        st.markdown(ROW_CLICK_JS, unsafe_allow_html=True)
         _render_why_buy_block(df_pass)
         with st.expander("Google-Sheet style view (optional)", expanded=False):
             sf = _sheet_friendly(df_pass)
@@ -143,5 +146,6 @@ def render_scanner_tab():
                 f"<div class='table-wrapper' tabindex='0'>{table_html}</div>",
                 unsafe_allow_html=True,
             )
+            st.markdown(ROW_CLICK_JS, unsafe_allow_html=True)
     else:
         st.caption("No results yet. Press **RUN** to scan.")

--- a/ui/table_utils.py
+++ b/ui/table_utils.py
@@ -2,6 +2,26 @@ import pandas as pd
 from pandas.io.formats.style import Styler
 
 
+# JavaScript snippet that attaches click handlers to dark-themed tables.
+# Wrapped in an IIFE so it executes immediately on each Streamlit rerun.
+ROW_CLICK_JS = """
+<script>
+(function() {
+    document.querySelectorAll('table.dark-table').forEach(function(table) {
+        table.addEventListener('click', function(event) {
+            const row = event.target.closest('tr');
+            if (!row) return;
+            table.querySelectorAll('tr.selected').forEach(function(r) {
+                r.classList.remove('selected');
+            });
+            row.classList.add('selected');
+        });
+    });
+})();
+</script>
+"""
+
+
 def _style_negatives(df: pd.DataFrame) -> Styler:
     """Return a Styler adding class "neg" or "pos" to numeric cells."""
     classes = pd.DataFrame("", index=df.index, columns=df.columns)


### PR DESCRIPTION
## Summary
- Attach row-click handlers via immediately invoked script instead of relying on `DOMContentLoaded`
- Style selected rows and tag tables with `dark-table` class for consistent targeting
- Include row-click script after each rendered table so selection remains after Streamlit reruns

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b86bcb2bc483329ba01e119bab472b