### PR TITLE
Scope dark table variables to table instances

### DIFF
--- a/ui/dark_table_sample.html
+++ b/ui/dark_table_sample.html
@@ -1,0 +1,85 @@
+<style type="text/css">
+#T_34871  {
+  --table-bg: #1f2937;
+  --table-header-bg: #374151;
+  --table-row-alt: #1e293b;
+  --table-hover: #2563eb;
+  --table-hover-text: #ffffff;
+  --table-text: #e5e7eb;
+  --table-header-text: #f9fafb;
+  --table-border: #4b5563;
+  --table-pos: #22c55e;
+  --table-neg: #ef4444;
+  border-collapse: separate;
+  border-spacing: 0;
+  border-radius: 8px;
+  overflow: hidden;
+  width: max-content;
+  white-space: nowrap;
+}
+#T_34871 th {
+  background-color: var(--table-header-bg);
+  color: var(--table-header-text);
+  border-bottom: 1px solid var(--table-border);
+  font-weight: 600;
+  text-align: center;
+  padding: 8px;
+}
+#T_34871 td {
+  background-color: var(--table-bg);
+  color: var(--table-text);
+  border-bottom: 1px solid var(--table-border);
+  padding: 8px;
+}
+#T_34871 tbody tr:nth-child(even) {
+  background-color: var(--table-row-alt);
+}
+#T_34871 tbody tr:hover {
+  background-color: var(--table-hover);
+  color: var(--table-hover-text);
+}
+#T_34871 th:first-child {
+  position: sticky;
+  left: 0;
+  z-index: 2;
+  background-color: var(--table-header-bg);
+}
+#T_34871 td:first-child {
+  position: sticky;
+  left: 0;
+  background-color: var(--table-bg);
+  z-index: 1;
+}
+#T_34871 td.pos {
+  color: var(--table-pos);
+  font-weight: 600;
+}
+#T_34871 td.neg {
+  color: var(--table-neg);
+  font-weight: 600;
+}
+</style>
+<table id="T_34871" class="dark-table">
+  <thead>
+    <tr>
+      <th class="blank level0" >&nbsp;</th>
+      <th id="T_34871_level0_col0" class="col_heading level0 col0" >Ticker</th>
+      <th id="T_34871_level0_col1" class="col_heading level0 col1" >Change%</th>
+      <th id="T_34871_level0_col2" class="col_heading level0 col2" >Price</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th id="T_34871_level0_row0" class="row_heading level0 row0" >0</th>
+      <td id="T_34871_row0_col0" class="data row0 col0" >AAA</td>
+      <td id="T_34871_row0_col1" class="data row0 col1 pos" >0.050000</td>
+      <td id="T_34871_row0_col2" class="data row0 col2 pos" >10</td>
+    </tr>
+    <tr>
+      <th id="T_34871_level0_row1" class="row_heading level0 row1" >1</th>
+      <td id="T_34871_row1_col0" class="data row1 col0" >BBB</td>
+      <td id="T_34871_row1_col1" class="data row1 col1 neg" >-0.070000</td>
+      <td id="T_34871_row1_col2" class="data row1 col2 pos" >11</td>
+    </tr>
+  </tbody>
+</table>

--- a/ui/history.py
+++ b/ui/history.py
@@ -27,8 +27,16 @@ def _apply_dark_theme(
         palette.update(colors)
 
     base = df.style if isinstance(df, pd.DataFrame) else df
+    table_props = list(palette.items()) + [
+        ("border-collapse", "separate"),
+        ("border-spacing", "0"),
+        ("border-radius", "8px"),
+        ("overflow", "hidden"),
+        ("width", "max-content"),
+        ("white-space", "nowrap"),
+    ]
     styles = [
-        {"selector": ":root", "props": list(palette.items())},
+        {"selector": "", "props": table_props},
         {
             "selector": "th",
             "props": [
@@ -61,17 +69,6 @@ def _apply_dark_theme(
             ],
         },
         {
-            "selector": "table",
-            "props": [
-                ("border-collapse", "separate"),
-                ("border-spacing", "0"),
-                ("border-radius", "8px"),
-                ("overflow", "hidden"),
-                ("width", "max-content"),
-                ("white-space", "nowrap"),
-            ],
-        },
-        {
             "selector": "th:first-child",
             "props": [
                 ("position", "sticky"),
@@ -98,7 +95,7 @@ def _apply_dark_theme(
             "props": [("color", "var(--table-neg)"), ("font-weight", "600")],
         },
     ]
-    return base.set_table_styles(styles)
+    return base.set_table_styles(styles).set_table_attributes('class="dark-table"')
 
 
 def load_history_df() -> pd.DataFrame:

--- a/ui/layout.py
+++ b/ui/layout.py
@@ -30,6 +30,9 @@ def setup_page():
             --padding: 1rem;
             --font-size-base: 16px;
             --col-width: 33%;
+        }}
+
+        .dark-table {{
             --table-bg: #1f2937;
             --table-header-bg: #374151;
             --table-row-alt: #1e293b;
@@ -151,15 +154,17 @@ def setup_page():
         }}
 
         /* --- DataFrame tables --- */
-        /* Table container */
-        div[data-testid="stDataFrame"] {{
+        table.dark-table {{
             background-color: var(--table-bg);
             border: 1px solid var(--table-border);
             border-radius: 8px;
+            border-collapse: separate;
+            border-spacing: 0;
             overflow: hidden;
+            width: max-content;
         }}
         /* Header */
-        div[data-testid="stDataFrame"] thead th {{
+        table.dark-table thead th {{
             background-color: var(--table-header-bg);
             color: var(--table-header-text);
             font-weight: 600;
@@ -169,37 +174,30 @@ def setup_page():
             z-index: 1;
         }}
         /* Rows */
-        div[data-testid="stDataFrame"] tbody tr {{
+        table.dark-table tbody tr {{
             background-color: var(--table-bg);
             color: var(--table-text);
         }}
-        div[data-testid="stDataFrame"] tbody tr:nth-child(even) {{
+        table.dark-table tbody tr:nth-child(even) {{
             background-color: var(--table-row-alt);
         }}
         /* Hover effect */
-        div[data-testid="stDataFrame"] tbody tr:hover {{
+        table.dark-table tbody tr:hover {{
             background-color: var(--table-hover);
             color: var(--table-hover-text);
         }}
         /* Borders between cells */
-        div[data-testid="stDataFrame"] td,
-        div[data-testid="stDataFrame"] th {{
+        table.dark-table td,
+        table.dark-table th {{
             border-bottom: 1px solid var(--table-border);
             padding: 8px;
         }}
-        /* Rounded corners on the full table */
-        div[data-testid="stDataFrame"] table {{
-            border-collapse: separate;
-            border-spacing: 0;
-            border-radius: 8px;
-            overflow: hidden;
-        }}
         /* Positive / Negative number coloring */
-        td.pos {{
+        table.dark-table td.pos {{
             color: var(--table-pos) !important;
             font-weight: 600;
         }}
-        td.neg {{
+        table.dark-table td.neg {{
             color: var(--table-neg) !important;
             font-weight: 600;
         }}


### PR DESCRIPTION
## Summary
- Scope dark table palette variables to `.dark-table` instead of `:root`
- Update CSS to target `table.dark-table` elements
- Add generated sample table using new scoping

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b86bcbc4e4833299c110c26b7117fa