### PR TITLE
Ensure row selection script loads only once

### DIFF
--- a/ui/history.py
+++ b/ui/history.py
@@ -4,7 +4,7 @@ from pandas.io.formats.style import Styler
 from utils.io import list_pass_files
 from utils.outcomes import read_outcomes
 from utils.formatting import _usd, _safe
-from .table_utils import _style_negatives
+from .table_utils import _style_negatives, inject_row_select_js
 
 
 def _apply_dark_theme(
@@ -262,6 +262,7 @@ def outcomes_summary(dfh: pd.DataFrame):
     if cols:
         df_disp = df_disp[cols]
     table_html = _apply_dark_theme(_style_negatives(df_disp)).to_html()
+    table_html = inject_row_select_js(table_html)
     st.markdown(
         f"<div class='table-wrapper' tabindex='0'>{table_html}</div>",
         unsafe_allow_html=True,
@@ -282,6 +283,7 @@ def render_history_tab():
             cols = ["Ticker"] + [c for c in df_hist.columns if c != "Ticker"]
             df_hist = df_hist[cols]
         table_html = _apply_dark_theme(_style_negatives(df_hist)).to_html()
+        table_html = inject_row_select_js(table_html)
         st.markdown(
             f"<div class='table-wrapper' tabindex='0'>{table_html}</div>",
             unsafe_allow_html=True,
@@ -300,6 +302,7 @@ def render_history_tab():
             else:
                 df_show = df_last
             table_html = _apply_dark_theme(_style_negatives(df_show)).to_html()
+            table_html = inject_row_select_js(table_html)
             st.markdown(
                 f"<div class='table-wrapper' tabindex='0'>{table_html}</div>",
                 unsafe_allow_html=True,

--- a/ui/scan.py
+++ b/ui/scan.py
@@ -4,7 +4,7 @@ from pandas.io.formats.style import Styler
 from utils.formatting import _bold, _usd, _pct, _safe
 from utils.scan import safe_run_scan
 from .history import _apply_dark_theme
-from .table_utils import _style_negatives
+from .table_utils import _style_negatives, inject_row_select_js
 
 
 def build_why_buy_html(row: dict) -> str:
@@ -105,6 +105,7 @@ def render_scanner_tab():
                 order = ["Ticker"] + [c for c in df_pass.columns if c != "Ticker"]
                 df_pass = df_pass[order]
             table_html = _apply_dark_theme(_style_negatives(df_pass)).to_html()
+            table_html = inject_row_select_js(table_html)
             st.markdown(
                 f"<div class='table-wrapper' tabindex='0'>{table_html}</div>",
                 unsafe_allow_html=True,
@@ -116,6 +117,7 @@ def render_scanner_tab():
                     order = ["Ticker"] + [c for c in sf.columns if c != "Ticker"]
                     sf = sf[order]
                 table_html = _apply_dark_theme(_style_negatives(sf)).to_html()
+                table_html = inject_row_select_js(table_html)
                 st.markdown(
                     f"<div class='table-wrapper' tabindex='0'>{table_html}</div>",
                     unsafe_allow_html=True,
@@ -128,6 +130,7 @@ def render_scanner_tab():
             order = ["Ticker"] + [c for c in df_pass.columns if c != "Ticker"]
             df_pass = df_pass[order]
         table_html = _apply_dark_theme(_style_negatives(df_pass)).to_html()
+        table_html = inject_row_select_js(table_html)
         st.markdown(
             f"<div class='table-wrapper' tabindex='0'>{table_html}</div>",
             unsafe_allow_html=True,
@@ -139,6 +142,7 @@ def render_scanner_tab():
                 order = ["Ticker"] + [c for c in sf.columns if c != "Ticker"]
                 sf = sf[order]
             table_html = _apply_dark_theme(_style_negatives(sf)).to_html()
+            table_html = inject_row_select_js(table_html)
             st.markdown(
                 f"<div class='table-wrapper' tabindex='0'>{table_html}</div>",
                 unsafe_allow_html=True,

--- a/ui/table_utils.py
+++ b/ui/table_utils.py
@@ -1,6 +1,35 @@
 import pandas as pd
 from pandas.io.formats.style import Styler
 
+# JavaScript snippet enabling row selection. Injected only once per session.
+ROW_SELECT_JS = """
+<script id="row-select-js">
+document.addEventListener('click', function(e) {
+  const row = e.target.closest('tr');
+  if (!row) return;
+  const table = row.closest('table');
+  if (!table) return;
+  table.querySelectorAll('tr.selected').forEach(r => r.classList.remove('selected'));
+  row.classList.add('selected');
+});
+</script>
+<style id="row-select-style">
+table tr.selected {background-color: var(--table-hover); color: var(--table-hover-text);}
+</style>
+"""
+
+# Internal flag so the selection script is only emitted once.
+_row_select_script_injected = False
+
+
+def inject_row_select_js(table_html: str) -> str:
+    """Prepend row-selection script once, returning resulting HTML."""
+    global _row_select_script_injected
+    if not _row_select_script_injected and "row-select-js" not in table_html:
+        _row_select_script_injected = True
+        return ROW_SELECT_JS + table_html
+    return table_html
+
 
 def _style_negatives(df: pd.DataFrame) -> Styler:
     """Return a Styler adding class "neg" or "pos" to numeric cells."""


### PR DESCRIPTION
## Summary
- add ROW_SELECT_JS and helper to inject it once
- apply helper across table renderers in history and scan views
- test that the script appears a single time even when multiple tables render

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b86bcd7fa0833295c0aac03b9b2e62