### PR TITLE
Return all records for latest trading day

### DIFF
--- a/tests/test_history_load.py
+++ b/tests/test_history_load.py
@@ -29,15 +29,15 @@ def test_load_outcomes_missing_file(tmp_path, monkeypatch):
     assert list(df.columns) == outcomes.OUTCOLS
 
 
-def test_latest_trading_day_recs_filters_and_dedupes():
+def test_latest_trading_day_recs_filters_without_dedup():
     df = pd.DataFrame(
         {
-            "Ticker": ["AAA", "BBB", "AAA"],
-            "run_date": ["2023-01-01", "2023-01-02", "2023-01-02"],
+            "Ticker": ["AAA", "AAA", "BBB"],
+            "run_date": ["2023-01-02", "2023-01-02", "2023-01-01"],
         }
     )
 
-    latest, date_str = history.latest_trading_day_recs(df)
+    df_latest, date_str = history.latest_trading_day_recs(df)
     assert date_str == "2023-01-02"
-    assert set(latest["Ticker"]) == {"AAA", "BBB"}
-    assert len(latest) == 2
+    assert list(df_latest["Ticker"]) == ["AAA", "AAA"]
+    assert len(df_latest) == 2

--- a/ui/history.py
+++ b/ui/history.py
@@ -98,7 +98,7 @@ def _apply_dark_theme(
 
 @st.cache_data(show_spinner=False)
 def latest_trading_day_recs(df: pd.DataFrame) -> tuple[pd.DataFrame, str | None]:
-    """Return unique tickers for the most recent ``run_date``.
+    """Return all rows for the most recent ``run_date``.
 
     Parameters
     ----------
@@ -122,11 +122,7 @@ def latest_trading_day_recs(df: pd.DataFrame) -> tuple[pd.DataFrame, str | None]
     if pd.isna(latest):
         return pd.DataFrame(), None
 
-    df_latest = (
-        df[df["run_date"] == latest]
-        .drop_duplicates(subset=["Ticker"])
-        .reset_index(drop=True)
-    )
+    df_latest = df[df["run_date"] == latest].reset_index(drop=True)
     return df_latest, latest.date().isoformat()
 
 


### PR DESCRIPTION
## Summary
- Stop dropping duplicate tickers in `latest_trading_day_recs`
- Adjust unit test to confirm duplicates are preserved

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b870c681c483329a98f8f16e0f656b