### PR TITLE
Guard row navigation script from duplicate injection

### DIFF
--- a/tests/test_ui_tables.py
+++ b/tests/test_ui_tables.py
@@ -12,6 +12,7 @@ if str(ROOT) not in sys.path:
 import ui.history as history
 import ui.scan as scan
 import ui.table_utils as table_utils
+import ui.table_render as table_render
 
 
 def test_outcomes_summary_orders_columns(monkeypatch):
@@ -180,4 +181,13 @@ def test_style_negatives_marks_both_signs():
     html = styler.to_html()
     assert 'neg"' in html
     assert 'pos"' in html
+
+
+def test_render_table_injects_script_once(monkeypatch):
+    df = pd.DataFrame({"Ticker": ["AAA"], "Price": [1]})
+    monkeypatch.setattr(table_render, "_script_emitted", False)
+    html1 = table_render.render_table(df)
+    html2 = table_render.render_table(df)
+    combined = html1 + html2
+    assert combined.count('id="row-select-js"') == 1
 

--- a/ui/table_render.py
+++ b/ui/table_render.py
@@ -1,0 +1,38 @@
+import pandas as pd
+from pandas.io.formats.style import Styler
+from typing import Union
+
+ROW_SELECT_JS = """
+<script id="row-select-js">
+(function() {
+    if (window.__rowNavInit) return;
+    window.__rowNavInit = true;
+    document.addEventListener('click', function(e) {
+        const row = e.target.closest('tr[data-href]');
+        if (row && row.dataset.href) {
+            window.location.href = row.dataset.href;
+        }
+    });
+})();
+</script>
+"""
+
+_script_emitted = False
+
+def row_select_script() -> str:
+    """Return row-selection script, ensuring it is emitted only once."""
+    global _script_emitted
+    if _script_emitted:
+        return ""
+    _script_emitted = True
+    return ROW_SELECT_JS
+
+def render_table(df: Union[pd.DataFrame, Styler], *, include_script: bool = True) -> str:
+    """Return HTML for ``df`` with optional row-selection script.
+
+    The script is included only the first time this function is called
+    (or when ``include_script`` is False).
+    """
+    table_html = df.to_html()
+    script = row_select_script() if include_script else ""
+    return script + table_html


### PR DESCRIPTION
## Summary
- Add `ui/table_render.py` with a guarded `ROW_SELECT_JS` and helpers to inject it only once.
- Expose `row_select_script` and `render_table` so tables include navigation logic just once per app run.
- Test that calling `render_table` multiple times emits the script only once.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b870e043108332a785de8f8100d034