### PR TITLE
Prevent duplicate row-select script injection

### DIFF
--- a/tests/test_ui_tables.py
+++ b/tests/test_ui_tables.py
@@ -1,6 +1,7 @@
 import sys
 from pathlib import Path
 from contextlib import contextmanager
+import types
 
 import pandas as pd
 from pandas.io.formats.style import Styler
@@ -180,4 +181,21 @@ def test_style_negatives_marks_both_signs():
     html = styler.to_html()
     assert 'neg"' in html
     assert 'pos"' in html
+
+
+def test_inject_row_select_js_does_not_reinject(monkeypatch):
+    dummy_st = types.SimpleNamespace(session_state={})
+    monkeypatch.setattr(table_utils, "st", dummy_st)
+    monkeypatch.setattr(table_utils, "_row_select_js_injected", False)
+
+    html_with_script = "<table></table><script id='row-select-js'></script>"
+    first = table_utils.inject_row_select_js(html_with_script)
+    assert first == html_with_script
+    assert table_utils._row_select_js_injected is True
+    assert dummy_st.session_state["_row_select_js_injected"] is True
+
+    html_without_script = "<table></table>"
+    second = table_utils.inject_row_select_js(html_without_script)
+    assert second == html_without_script
+    assert "row-select-js" not in second
 

--- a/ui/table_utils.py
+++ b/ui/table_utils.py
@@ -1,5 +1,47 @@
 import pandas as pd
 from pandas.io.formats.style import Styler
+import streamlit as st
+
+
+_ROW_SELECT_JS_ID = "row-select-js"
+_ROW_SELECT_JS_FLAG = "_row_select_js_injected"
+_row_select_js_injected = False
+
+_ROW_SELECT_JS = f"""
+<script id="{_ROW_SELECT_JS_ID}">
+document.addEventListener('DOMContentLoaded', function () {{
+  const rows = window.parent.document.querySelectorAll('tbody tr');
+  rows.forEach(row => {{
+    row.addEventListener('click', () => {{
+      rows.forEach(r => r.classList.remove('selected'));
+      row.classList.add('selected');
+    }});
+  }});
+}});
+</script>
+"""
+
+
+def inject_row_select_js(table_html: str) -> str:
+    """Ensure the row select JS snippet is injected only once.
+
+    If the marker script is already present in ``table_html`` the session and
+    module level flags are still set so that subsequent calls will not inject
+    the snippet again.
+    """
+
+    global _row_select_js_injected
+    if _ROW_SELECT_JS_ID in table_html:
+        st.session_state[_ROW_SELECT_JS_FLAG] = True
+        _row_select_js_injected = True
+        return table_html
+
+    if _row_select_js_injected or st.session_state.get(_ROW_SELECT_JS_FLAG):
+        return table_html
+
+    st.session_state[_ROW_SELECT_JS_FLAG] = True
+    _row_select_js_injected = True
+    return f"{table_html}{_ROW_SELECT_JS}"
 
 
 def _style_negatives(df: pd.DataFrame) -> Styler:


### PR DESCRIPTION
## Summary
- Add `inject_row_select_js` to mark injection flags and avoid reinserting script
- Cover existing-script scenario with new unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b87112fe2883328492fd0f68826014