### PR TITLE
Display latest pass file in history tab and expand outcomes fields

### DIFF
--- a/tests/test_history_load.py
+++ b/tests/test_history_load.py
@@ -41,3 +41,19 @@ def test_latest_trading_day_recs_filters_and_dedupes():
     assert date_str == "2023-01-02"
     assert set(latest["Ticker"]) == {"AAA", "BBB"}
     assert len(latest) == 2
+
+
+def test_load_latest_pass_returns_newest(tmp_path, monkeypatch):
+    hist_dir = tmp_path / "history"
+    hist_dir.mkdir()
+    old = hist_dir / "pass_20240101.csv"
+    old.write_text("Ticker,run_date\nAAA,2024-01-01\n")
+    new = hist_dir / "pass_20240102.csv"
+    new.write_text("Ticker,run_date\nBBB,2024-01-02\n")
+
+    monkeypatch.setattr(history, "HISTORY_DIR", hist_dir)
+    history.load_latest_pass.clear()
+    df, date_str = history.load_latest_pass()
+
+    assert list(df["Ticker"]) == ["BBB"]
+    assert date_str == "2024-01-02"

--- a/tests/test_outcomes.py
+++ b/tests/test_outcomes.py
@@ -28,6 +28,7 @@ def test_upsert_assigns_run_date_and_dedupes(tmp_path):
             "Price": 3.0,
             "Change%": 4.5,
             "RelVol(TimeAdj63d)": 1.2,
+            "Hist21d_PassCount": 5,
         },
     ])
 
@@ -42,6 +43,7 @@ def test_upsert_assigns_run_date_and_dedupes(tmp_path):
     msft_row = result[result["Ticker"] == "MSFT"].iloc[0]
     assert msft_row["Change%"] == 4.5
     assert msft_row["RelVol(TimeAdj63d)"] == 1.2
+    assert msft_row["Hist21d_PassCount"] == 5
     # Ensure only one entry per ticker per run_date
     assert (
         result.groupby(["Ticker", "run_date"]).size().max() == 1

--- a/tests/test_ui_tables.py
+++ b/tests/test_ui_tables.py
@@ -69,7 +69,7 @@ def test_outcomes_summary_orders_columns(monkeypatch):
 
 
 def test_render_history_tab_shows_extended_columns(monkeypatch):
-    df_last = pd.DataFrame(
+    df_pass = pd.DataFrame(
         {
             "Ticker": ["AAA"],
             "EvalDate": ["2024-01-01"],
@@ -77,17 +77,8 @@ def test_render_history_tab_shows_extended_columns(monkeypatch):
             "Price": [1],
             "Change%": [0.05],
             "RelVol(TimeAdj63d)": [1.5],
-            "LastPrice": [1.1],
-            "LastPriceAt": ["2024-01-02"],
-            "PctToTarget": [0.2],
-            "EntryTimeET": ["09:30"],
-            "HitDateET": [pd.NA],
-            "Expiry": ["2024-02-01"],
-            "DTE": [10],
-            "BuyK": [1],
-            "SellK": [2],
-            "TP": [2],
-            "Notes": [""],
+            "RR_to_Res": [0.5],
+            "Hist21d_PassCount": [2],
             "Extra": [3],
         }
     )
@@ -122,7 +113,7 @@ def test_render_history_tab_shows_extended_columns(monkeypatch):
         }
     )
     monkeypatch.setattr(history, "load_outcomes", lambda: df_outcomes)
-    monkeypatch.setattr(history, "latest_trading_day_recs", lambda _df: (df_last, "2024-01-01"))
+    monkeypatch.setattr(history, "load_latest_pass", lambda: (df_pass, "2024-01-01"))
 
     history.render_history_tab()
 
@@ -135,17 +126,8 @@ def test_render_history_tab_shows_extended_columns(monkeypatch):
         "Price",
         "Change%",
         "RelVol(TimeAdj63d)",
-        "LastPrice",
-        "LastPriceAt",
-        "PctToTarget",
-        "EntryTimeET",
-        "HitDateET",
-        "Expiry",
-        "DTE",
-        "BuyK",
-        "SellK",
-        "TP",
-        "Notes",
+        "RR_to_Res",
+        "Hist21d_PassCount",
         "Extra",
     ]
 

--- a/utils/outcomes.py
+++ b/utils/outcomes.py
@@ -24,6 +24,39 @@ OUTCOLS = [
     "Price",
     "Change%",
     "RelVol(TimeAdj63d)",
+    "Resistance",
+    "TP",
+    "RR_to_Res",
+    "RR_to_TP",
+    "SupportType",
+    "SupportPrice",
+    "Risk$",
+    "TPReward$",
+    "TPReward%",
+    "ResReward$",
+    "ResReward%",
+    "DailyATR",
+    "DailyCap",
+    "Hist21d_PassCount",
+    "Hist21d_Max%",
+    "Hist21d_Examples",
+    "ResLookbackDays",
+    "Prices",
+    "Session",
+    "EntrySrc",
+    "VolSrc",
+    "OptExpiry",
+    "BuyK",
+    "SellK",
+    "Width",
+    "DebitMid",
+    "DebitCons",
+    "MaxProfitMid",
+    "MaxProfitCons",
+    "RR_Spread_Mid",
+    "RR_Spread_Cons",
+    "BreakevenMid",
+    "PricingNote",
     "LastPrice",
     "LastPriceAt",
     "PctToTarget",
@@ -32,9 +65,6 @@ OUTCOLS = [
     "result_status",
     "HitDateET",
     "Expiry",
-    "BuyK",
-    "SellK",
-    "TP",
     "Notes",
     "run_date",
 ]
@@ -112,7 +142,7 @@ def parse_date(s: Any) -> date | None:
 
 def _parse_expiry_from_passrow(row: pd.Series) -> str | None:
     raw = _first_nonempty(row.get("OptExpiry"), row.get("Expiry"))
-    if raw:
+    if raw is not None and not pd.isna(raw):
         return _to_date_str(raw)
     ev = _to_date_str(row.get("EvalDate"))
     if ev:
@@ -141,9 +171,39 @@ def upsert_and_backfill_outcomes(
         "Price",
         "Change%",
         "RelVol(TimeAdj63d)",
+        "Resistance",
+        "TP",
+        "RR_to_Res",
+        "RR_to_TP",
+        "SupportType",
+        "SupportPrice",
+        "Risk$",
+        "TPReward$",
+        "TPReward%",
+        "ResReward$",
+        "ResReward%",
+        "DailyATR",
+        "DailyCap",
+        "Hist21d_PassCount",
+        "Hist21d_Max%",
+        "Hist21d_Examples",
+        "ResLookbackDays",
+        "Prices",
+        "Session",
+        "EntrySrc",
+        "VolSrc",
+        "OptExpiry",
         "BuyK",
         "SellK",
-        "TP",
+        "Width",
+        "DebitMid",
+        "DebitCons",
+        "MaxProfitMid",
+        "MaxProfitCons",
+        "RR_Spread_Mid",
+        "RR_Spread_Cons",
+        "BreakevenMid",
+        "PricingNote",
         "EntryTimeET",
         "HitDateET",
         "Notes",
@@ -154,12 +214,39 @@ def upsert_and_backfill_outcomes(
 
     df_pass["Ticker"] = df_pass["Ticker"].astype(str).str.upper()
     df_pass["EvalDate"] = df_pass["EvalDate"].apply(_to_date_str)
-    df_pass["Price"] = df_pass["Price"].map(safe_float)
-    df_pass["Change%"] = df_pass["Change%"].map(safe_float)
-    df_pass["RelVol(TimeAdj63d)"] = df_pass["RelVol(TimeAdj63d)"].map(safe_float)
-    df_pass["BuyK"] = df_pass["BuyK"].map(safe_float)
-    df_pass["SellK"] = df_pass["SellK"].map(safe_float)
-    df_pass["TP"] = df_pass["TP"].map(safe_float)
+    num_cols = [
+        "Price",
+        "Change%",
+        "RelVol(TimeAdj63d)",
+        "Resistance",
+        "TP",
+        "RR_to_Res",
+        "RR_to_TP",
+        "SupportPrice",
+        "Risk$",
+        "TPReward$",
+        "TPReward%",
+        "ResReward$",
+        "ResReward%",
+        "DailyATR",
+        "DailyCap",
+        "Hist21d_PassCount",
+        "Hist21d_Max%",
+        "ResLookbackDays",
+        "BuyK",
+        "SellK",
+        "Width",
+        "DebitMid",
+        "DebitCons",
+        "MaxProfitMid",
+        "MaxProfitCons",
+        "RR_Spread_Mid",
+        "RR_Spread_Cons",
+        "BreakevenMid",
+    ]
+    for c in num_cols:
+        df_pass[c] = df_pass[c].map(safe_float)
+
     today_str = datetime.now(ZoneInfo("America/New_York")).date().isoformat()
     df_pass["run_date"] = df_pass["run_date"].apply(_to_date_str).fillna(today_str)
 


### PR DESCRIPTION
## Summary
- add `load_latest_pass()` to scan `data/history` for newest `pass_*.csv`
- show latest pass data in the history tab instead of filtering outcomes
- persist 21-day metrics and other pass columns in `outcomes.csv`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b870c4d7ec8332be95868a671480c0