### PR TITLE
Use session-state flag for row select JS injection

### DIFF
--- a/ui/history.py
+++ b/ui/history.py
@@ -2,7 +2,7 @@ import pandas as pd
 import streamlit as st
 from pandas.io.formats.style import Styler
 from utils.outcomes import read_outcomes
-from .table_utils import _style_negatives
+from .table_utils import _style_negatives, inject_row_select_js
 
 
 def _apply_dark_theme(
@@ -219,6 +219,7 @@ def outcomes_summary(dfh: pd.DataFrame):
             cols.insert(cols.index("Expiry") + 1, cols.pop(cols.index("DTE")))
         df_disp = df_disp[cols]
     table_html = _apply_dark_theme(_style_negatives(df_disp)).to_html()
+    table_html = inject_row_select_js(table_html)
     st.markdown(
         f"<div class='table-wrapper' tabindex='0'>{table_html}</div>",
         unsafe_allow_html=True,
@@ -241,6 +242,7 @@ def render_history_tab():
             else:
                 df_show = df_last
             table_html = _apply_dark_theme(_style_negatives(df_show)).to_html()
+            table_html = inject_row_select_js(table_html)
             st.markdown(
                 f"<div class='table-wrapper' tabindex='0'>{table_html}</div>",
                 unsafe_allow_html=True,

--- a/ui/scan.py
+++ b/ui/scan.py
@@ -4,7 +4,7 @@ from pandas.io.formats.style import Styler
 from utils.formatting import _bold, _usd, _pct, _safe
 from utils.scan import safe_run_scan
 from .history import _apply_dark_theme
-from .table_utils import _style_negatives
+from .table_utils import _style_negatives, inject_row_select_js
 
 
 def build_why_buy_html(row: dict) -> str:
@@ -105,6 +105,7 @@ def render_scanner_tab():
                 order = ["Ticker"] + [c for c in df_pass.columns if c != "Ticker"]
                 df_pass = df_pass[order]
             table_html = _apply_dark_theme(_style_negatives(df_pass)).to_html()
+            table_html = inject_row_select_js(table_html)
             st.markdown(
                 f"<div class='table-wrapper' tabindex='0'>{table_html}</div>",
                 unsafe_allow_html=True,
@@ -116,6 +117,7 @@ def render_scanner_tab():
                     order = ["Ticker"] + [c for c in sf.columns if c != "Ticker"]
                     sf = sf[order]
                 table_html = _apply_dark_theme(_style_negatives(sf)).to_html()
+                table_html = inject_row_select_js(table_html)
                 st.markdown(
                     f"<div class='table-wrapper' tabindex='0'>{table_html}</div>",
                     unsafe_allow_html=True,
@@ -128,6 +130,7 @@ def render_scanner_tab():
             order = ["Ticker"] + [c for c in df_pass.columns if c != "Ticker"]
             df_pass = df_pass[order]
         table_html = _apply_dark_theme(_style_negatives(df_pass)).to_html()
+        table_html = inject_row_select_js(table_html)
         st.markdown(
             f"<div class='table-wrapper' tabindex='0'>{table_html}</div>",
             unsafe_allow_html=True,
@@ -139,6 +142,7 @@ def render_scanner_tab():
                 order = ["Ticker"] + [c for c in sf.columns if c != "Ticker"]
                 sf = sf[order]
             table_html = _apply_dark_theme(_style_negatives(sf)).to_html()
+            table_html = inject_row_select_js(table_html)
             st.markdown(
                 f"<div class='table-wrapper' tabindex='0'>{table_html}</div>",
                 unsafe_allow_html=True,

--- a/ui/table_utils.py
+++ b/ui/table_utils.py
@@ -1,5 +1,28 @@
 import pandas as pd
+import streamlit as st
 from pandas.io.formats.style import Styler
+
+
+ROW_SELECT_JS = """
+<script>
+(function () {
+  const target = window.parent.document;
+  target.addEventListener('click', (e) => {
+    const row = e.target.closest('div.table-wrapper tbody tr');
+    if (!row) return;
+    const rows = row.parentElement.querySelectorAll('tr');
+    rows.forEach(r => r.classList.remove('selected'));
+    row.classList.add('selected');
+  });
+})();
+</script>
+<style>
+  .table-wrapper tr.selected {
+    background-color: var(--table-hover);
+    color: var(--table-hover-text);
+  }
+</style>
+"""
 
 
 def _style_negatives(df: pd.DataFrame) -> Styler:
@@ -10,4 +33,13 @@ def _style_negatives(df: pd.DataFrame) -> Styler:
         classes.loc[df[col] < 0, col] = "neg"
         classes.loc[df[col] > 0, col] = "pos"
     return df.style.set_td_classes(classes)
+
+
+def inject_row_select_js(html: str) -> str:
+    """Prepend row-select JavaScript once per Streamlit session."""
+    injected = st.session_state.setdefault("row_select_js_injected", False)
+    if not injected:
+        st.session_state["row_select_js_injected"] = True
+        return ROW_SELECT_JS + html
+    return html
 


### PR DESCRIPTION
## Summary
- Add JavaScript and helper to inject row-select script once per session
- Apply row-select injection when rendering history and scan tables

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b87110afc08332967cc0b75ee065db