### PR TITLE
Ensure row-select script is injected once in history tables

### DIFF
--- a/tests/test_ui_tables.py
+++ b/tests/test_ui_tables.py
@@ -150,6 +150,65 @@ def test_render_history_tab_shows_extended_columns(monkeypatch):
     ]
 
 
+def test_render_history_tab_injects_row_select_once(monkeypatch):
+    df_last = pd.DataFrame(
+        {
+            "Ticker": ["AAA"],
+            "EvalDate": ["2024-01-01"],
+            "run_date": ["2024-01-02"],
+            "Price": [1],
+            "Change%": [0.05],
+            "RelVol(TimeAdj63d)": [1.5],
+            "LastPrice": [1.1],
+            "LastPriceAt": ["2024-01-02"],
+            "PctToTarget": [0.2],
+            "EntryTimeET": ["09:30"],
+            "HitDateET": [pd.NA],
+            "Expiry": ["2024-02-01"],
+            "DTE": [10],
+            "BuyK": [1],
+            "SellK": [2],
+            "TP": [2],
+            "Notes": [""],
+        }
+    )
+
+    df_outcomes = pd.DataFrame(
+        {
+            "Ticker": ["AAA"],
+            "EvalDate": ["2024-01-01"],
+            "Price": [1],
+            "RelVol(TimeAdj63d)": [1.5],
+            "LastPrice": [1.1],
+            "LastPriceAt": ["2024-01-02"],
+            "PctToTarget": [0.2],
+            "EntryTimeET": ["09:30"],
+            "Status": ["OPEN"],
+            "HitDateET": [pd.NA],
+            "Expiry": ["2024-02-01"],
+            "BuyK": [1],
+            "SellK": [2],
+            "TP": [2],
+            "Notes": [""],
+        }
+    )
+
+    html_calls: list[str] = []
+    monkeypatch.setattr(history.st, "subheader", lambda *a, **k: None)
+    monkeypatch.setattr(history.st, "info", lambda *a, **k: None)
+    monkeypatch.setattr(history.st, "caption", lambda *a, **k: None)
+    monkeypatch.setattr(history.st, "markdown", lambda html, *a, **k: html_calls.append(html))
+    monkeypatch.setattr(history, "load_outcomes", lambda: df_outcomes)
+    monkeypatch.setattr(history, "latest_trading_day_recs", lambda _df: (df_last, "2024-01-01"))
+
+    history._row_select_injected = False
+    history.render_history_tab()
+
+    assert len(html_calls) == 2
+    total = sum(h.count("row-select-js") for h in html_calls)
+    assert total == 1
+
+
 def test_render_scanner_tab_shows_dataframe(monkeypatch):
     df = pd.DataFrame({"Ticker": ["AAA"], "Price": [1], "RelVol(TimeAdj63d)": [1], "TP": [2]})
 

--- a/ui/history.py
+++ b/ui/history.py
@@ -5,6 +5,22 @@ from utils.outcomes import read_outcomes
 from .table_utils import _style_negatives
 
 
+# --- Row select helper -----------------------------------------------------
+
+ROW_SELECT_JS = """<script id="row-select-js">
+document.addEventListener('DOMContentLoaded', function () {
+  document.querySelectorAll('.table-wrapper tr').forEach(function (row) {
+    row.addEventListener('click', function () {
+      row.classList.toggle('selected');
+    });
+  });
+});
+</script>
+"""
+
+_row_select_injected = False
+
+
 def _apply_dark_theme(
     df: pd.DataFrame | Styler, colors: dict[str, str] | None = None
 ) -> Styler:
@@ -93,7 +109,21 @@ def _apply_dark_theme(
             "props": [("color", "var(--table-neg)"), ("font-weight", "600")],
         },
     ]
-    return base.set_table_styles(styles).set_table_attributes('class="dark-table"')
+
+    styler = base.set_table_styles(styles).set_table_attributes('class="dark-table"')
+
+    orig_to_html = styler.to_html
+
+    def _to_html(*args, **kwargs):
+        html = orig_to_html(*args, **kwargs)
+        global _row_select_injected
+        if not _row_select_injected:
+            _row_select_injected = True
+            html = ROW_SELECT_JS + html
+        return html
+
+    styler.to_html = _to_html  # type: ignore[attr-defined]
+    return styler
 
 
 @st.cache_data(show_spinner=False)


### PR DESCRIPTION
## Summary
- Inject a reusable row-selection JavaScript snippet when styling tables, adding it only on the first render
- Add regression test verifying `history.render_history_tab` outputs the row-select script exactly once when two tables are rendered

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b87113fa5883329f61a5ceaf585d8c