### PR TITLE
Add idempotent row-select JS test

### DIFF
--- a/tests/test_ui_tables.py
+++ b/tests/test_ui_tables.py
@@ -191,3 +191,12 @@ def test_render_table_injects_script_once(monkeypatch):
     combined = html1 + html2
     assert combined.count('id="row-select-js"') == 1
 
+
+def test_inject_row_select_js_does_not_reinject(monkeypatch):
+    html = "<table></table>"
+    monkeypatch.setattr(table_utils.st, "session_state", {})
+    first = table_utils.inject_row_select_js(html)
+    second = table_utils.inject_row_select_js(html)
+    assert first.count("<script>") == 1
+    assert second.count("<script>") == 0
+


### PR DESCRIPTION
## Summary
- ensure `inject_row_select_js` only prepends its script once per session

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8723dce308332bb50057cf429d3a6