### PR TITLE
Aggregate pass history and split History tab layout

### DIFF
--- a/tests/test_pass_files.py
+++ b/tests/test_pass_files.py
@@ -6,6 +6,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from utils import io
+import ui.history as history
 
 
 def test_list_pass_files(tmp_path, monkeypatch):
@@ -33,3 +34,16 @@ def test_list_pass_files(tmp_path, monkeypatch):
     paths = io.list_pass_files()
     assert paths == sorted(paths)
     assert {p.name for p in paths} == {"pass_20230102.csv", "pass_20230101.psv", "pass_20230103.csv"}
+
+
+def test_load_pass_history(tmp_path, monkeypatch):
+    f1 = tmp_path / "pass_20230101.csv"
+    f1.write_text("Ticker,Price\nAAA,1\n")
+    f2 = tmp_path / "pass_20230102.psv"
+    f2.write_text("Ticker|Price\nBBB|2\n")
+
+    monkeypatch.setattr(history, "list_pass_files", lambda: [f1, f2])
+
+    df = history.load_pass_history()
+    assert list(df["Ticker"]) == ["AAA", "BBB"]
+    assert list(df["run_date"]) == ["20230101", "20230102"]

--- a/tests/test_ui_tables.py
+++ b/tests/test_ui_tables.py
@@ -70,7 +70,7 @@ def test_outcomes_summary_orders_columns(monkeypatch):
 
 
 def test_render_history_tab_shows_extended_columns(monkeypatch):
-    df_last = pd.DataFrame(
+    df_pass = pd.DataFrame(
         {
             "Ticker": ["AAA"],
             "EvalDate": ["2024-01-01"],
@@ -96,34 +96,21 @@ def test_render_history_tab_shows_extended_columns(monkeypatch):
     html_calls = []
     monkeypatch.setattr(history.st, "subheader", lambda *a, **k: None)
     monkeypatch.setattr(history.st, "info", lambda *a, **k: None)
-    monkeypatch.setattr(history.st, "caption", lambda *a, **k: None)
     monkeypatch.setattr(
         history.st,
         "markdown",
         lambda html_arg, *a, **k: html_calls.append(html_arg),
     )
+    monkeypatch.setattr(history.st, "session_state", {})
 
-    df_outcomes = pd.DataFrame(
-        {
-            "Ticker": ["AAA"],
-            "EvalDate": ["2024-01-01"],
-            "Price": [1],
-            "RelVol(TimeAdj63d)": [1.5],
-            "LastPrice": [1.1],
-            "LastPriceAt": ["2024-01-02"],
-            "PctToTarget": [0.2],
-            "EntryTimeET": ["09:30"],
-            "Status": ["OPEN"],
-            "HitDateET": [pd.NA],
-            "Expiry": ["2024-02-01"],
-            "BuyK": [1],
-            "SellK": [2],
-            "TP": [2],
-            "Notes": [""],
-        }
-    )
-    monkeypatch.setattr(history, "load_outcomes", lambda: df_outcomes)
-    monkeypatch.setattr(history, "latest_trading_day_recs", lambda _df: (df_last, "2024-01-01"))
+    @contextmanager
+    def dummy_col():
+        yield
+
+    monkeypatch.setattr(history.st, "columns", lambda *a, **k: (dummy_col(), dummy_col()))
+
+    monkeypatch.setattr(history, "load_pass_history", lambda: df_pass)
+    monkeypatch.setattr(history, "latest_trading_day_recs", lambda _df: (df_pass, "2024-01-02"))
 
     history.render_history_tab()
 
@@ -152,7 +139,7 @@ def test_render_history_tab_shows_extended_columns(monkeypatch):
 
 
 def test_render_history_tab_injects_row_select_once(monkeypatch):
-    df_last = pd.DataFrame(
+    df_pass = pd.DataFrame(
         {
             "Ticker": ["AAA"],
             "EvalDate": ["2024-01-01"],
@@ -174,33 +161,19 @@ def test_render_history_tab_injects_row_select_once(monkeypatch):
         }
     )
 
-    df_outcomes = pd.DataFrame(
-        {
-            "Ticker": ["AAA"],
-            "EvalDate": ["2024-01-01"],
-            "Price": [1],
-            "RelVol(TimeAdj63d)": [1.5],
-            "LastPrice": [1.1],
-            "LastPriceAt": ["2024-01-02"],
-            "PctToTarget": [0.2],
-            "EntryTimeET": ["09:30"],
-            "Status": ["OPEN"],
-            "HitDateET": [pd.NA],
-            "Expiry": ["2024-02-01"],
-            "BuyK": [1],
-            "SellK": [2],
-            "TP": [2],
-            "Notes": [""],
-        }
-    )
-
     html_calls: list[str] = []
     monkeypatch.setattr(history.st, "subheader", lambda *a, **k: None)
     monkeypatch.setattr(history.st, "info", lambda *a, **k: None)
-    monkeypatch.setattr(history.st, "caption", lambda *a, **k: None)
     monkeypatch.setattr(history.st, "markdown", lambda html, *a, **k: html_calls.append(html))
-    monkeypatch.setattr(history, "load_outcomes", lambda: df_outcomes)
-    monkeypatch.setattr(history, "latest_trading_day_recs", lambda _df: (df_last, "2024-01-01"))
+    monkeypatch.setattr(history.st, "session_state", {})
+
+    @contextmanager
+    def dummy_col():
+        yield
+
+    monkeypatch.setattr(history.st, "columns", lambda *a, **k: (dummy_col(), dummy_col()))
+    monkeypatch.setattr(history, "load_pass_history", lambda: df_pass)
+    monkeypatch.setattr(history, "latest_trading_day_recs", lambda _df: (df_pass, "2024-01-02"))
 
     history._row_select_injected = False
     history.render_history_tab()


### PR DESCRIPTION
## Summary
- Load all pass_*.csv/psv files into a consolidated DataFrame with run dates
- Display latest recommendations and full pass history side by side with horizontally scrollable tables
- Ensure `Ticker` is the lead column across history tables

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8748c6074833291f1e73380318c79