### PR TITLE
Expose table hover colors in dark theme

### DIFF
--- a/ui/history.py
+++ b/ui/history.py
@@ -22,15 +22,18 @@ _row_select_injected = False
 
 
 def _apply_dark_theme(
-    df: pd.DataFrame | Styler, colors: dict[str, str] | None = None
+    df: pd.DataFrame | Styler,
+    colors: dict[str, str] | None = None,
+    hover_color: str = "#2563eb",
+    hover_text_color: str = "#ffffff",
 ) -> Styler:
     """Apply a dark theme with inlined palette and scoped pos/neg styles."""
     palette = {
         "--table-bg": "#1f2937",
         "--table-header-bg": "#374151",
         "--table-row-alt": "#1e293b",
-        "--table-hover": "#2563eb",
-        "--table-hover-text": "#ffffff",
+        "--table-hover": hover_color,
+        "--table-hover-text": hover_text_color,
         "--table-text": "#e5e7eb",
         "--table-header-text": "#f9fafb",
         "--table-border": "#4b5563",

--- a/ui/layout.py
+++ b/ui/layout.py
@@ -1,7 +1,9 @@
 import streamlit as st
 
 
-def setup_page():
+def setup_page(
+    *, table_hover: str = "#2563eb", table_hover_text: str = "#ffffff"
+):
     st.set_page_config(
         page_title="Edge500",     # Title shown in browser tab
         page_icon="logo.png",     # Favicon (logo.png in repo root)
@@ -36,8 +38,8 @@ def setup_page():
             --table-bg: #1f2937;
             --table-header-bg: #374151;
             --table-row-alt: #1e293b;
-            --table-hover: #2563eb;
-            --table-hover-text: #ffffff;
+            --table-hover: {table_hover};
+            --table-hover-text: {table_hover_text};
             --table-text: #e5e7eb;
             --table-header-text: #f9fafb;
             --table-border: #4b5563;


### PR DESCRIPTION
## Summary
- allow overriding table hover colors through `setup_page`
- add matching hover palette options to `_apply_dark_theme`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b87497de488332a0edafc70215e6c5