### PR TITLE
Allow page scrolling when tables are active

### DIFF
--- a/ui/layout.py
+++ b/ui/layout.py
@@ -206,8 +206,9 @@ def setup_page():
         .table-wrapper {{
             overflow-x: auto;
             max-width: 100%;
-            overscroll-behavior: contain;
-            touch-action: pan-x;
+            /* Allow vertical scroll chaining while keeping horizontal containment */
+            overscroll-behavior-x: contain;
+            touch-action: pan-x pan-y;
         }}
         .table-wrapper table {{
             width: max-content;


### PR DESCRIPTION
## Summary
- relax table wrapper overscroll behavior so vertical swipes continue to scroll the page
- allow both vertical and horizontal gestures with `touch-action: pan-x pan-y`

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8749e55ec8332a04e92842a98d574