### PR TITLE
Normalize pass history run_date to date

### DIFF
--- a/tests/test_history_load.py
+++ b/tests/test_history_load.py
@@ -33,7 +33,11 @@ def test_latest_trading_day_recs_filters_without_dedup():
     df = pd.DataFrame(
         {
             "Ticker": ["AAA", "AAA", "BBB"],
-            "run_date": ["2023-01-02", "2023-01-02", "2023-01-01"],
+            "run_date": [
+                "2023-01-02 10:00",
+                "2023-01-02 15:30",
+                "2023-01-01 09:00",
+            ],
         }
     )
 

--- a/tests/test_pass_files.py
+++ b/tests/test_pass_files.py
@@ -7,6 +7,7 @@ if str(ROOT) not in sys.path:
 
 from utils import io
 import ui.history as history
+from datetime import date
 
 
 def test_list_pass_files(tmp_path, monkeypatch):
@@ -46,4 +47,4 @@ def test_load_pass_history(tmp_path, monkeypatch):
 
     df = history.load_pass_history()
     assert list(df["Ticker"]) == ["AAA", "BBB"]
-    assert list(df["run_date"]) == ["20230101", "20230102"]
+    assert list(df["run_date"]) == [date(2023, 1, 1), date(2023, 1, 2)]


### PR DESCRIPTION
## Summary
- normalize run_date values to date-only when loading pass history
- filter latest_trading_day_recs by normalized date to include all rows
- adjust tests for date handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b87a186b608332a7cadf6b3bf6e990