### PR TITLE
Hide DataFrame indices in UI tables

### DIFF
--- a/tests/test_ui_tables.py
+++ b/tests/test_ui_tables.py
@@ -48,7 +48,7 @@ def test_outcomes_summary_orders_columns(monkeypatch):
     history.outcomes_summary(df)
 
     assert html_calls
-    parsed = pd.read_html(html_calls[0], index_col=0)[0]
+    parsed = pd.read_html(html_calls[0])[0]
     assert list(parsed.columns) == [
         "Ticker",
         "EvalDate",
@@ -115,7 +115,7 @@ def test_render_history_tab_shows_extended_columns(monkeypatch):
     history.render_history_tab()
 
     assert len(html_calls) == 2
-    parsed = pd.read_html(html_calls[0], index_col=0)[0]
+    parsed = pd.read_html(html_calls[0])[0]
     assert list(parsed.columns) == [
         "Ticker",
         "EvalDate",
@@ -203,7 +203,7 @@ def test_render_scanner_tab_shows_dataframe(monkeypatch):
     scan.render_scanner_tab()
     table_html = next((h for h in html_calls if "<table" in h), None)
     assert table_html is not None
-    parsed = pd.read_html(table_html, index_col=0)[0]
+    parsed = pd.read_html(table_html)[0]
     assert list(parsed.columns) == ["Ticker", "Price", "RelVol(TimeAdj63d)", "TP"]
 
 

--- a/ui/history.py
+++ b/ui/history.py
@@ -44,7 +44,7 @@ def _apply_dark_theme(
     if colors:
         palette.update(colors)
 
-    base = df.style if isinstance(df, pd.DataFrame) else df
+    base = (df.style if isinstance(df, pd.DataFrame) else df).hide(axis="index")
     table_props = list(palette.items()) + [
         ("border-collapse", "separate"),
         ("border-spacing", "0"),
@@ -266,7 +266,7 @@ def outcomes_summary(dfh: pd.DataFrame):
         if "DTE" in cols and "Expiry" in cols:
             cols.insert(cols.index("Expiry") + 1, cols.pop(cols.index("DTE")))
         df_disp = df_disp[cols]
-    table_html = _apply_dark_theme(_style_negatives(df_disp)).to_html()
+    table_html = _apply_dark_theme(_style_negatives(df_disp)).to_html(index=False)
     table_html = inject_row_select_js(table_html)
     st.markdown(
         f"<div class='table-wrapper' tabindex='0'>{table_html}</div>",
@@ -287,7 +287,7 @@ def render_history_tab():
                 df_show = df_last[cols]
             else:
                 df_show = df_last
-            table_html = _apply_dark_theme(_style_negatives(df_show)).to_html()
+            table_html = _apply_dark_theme(_style_negatives(df_show)).to_html(index=False)
             table_html = inject_row_select_js(table_html)
             st.markdown(
                 f"<div class='table-wrapper' tabindex='0'>{table_html}</div>",
@@ -305,7 +305,7 @@ def render_history_tab():
         if "Ticker" in df_disp.columns:
             cols = ["Ticker"] + [c for c in df_disp.columns if c != "Ticker"]
             df_disp = df_disp[cols]
-        table_html = _apply_dark_theme(_style_negatives(df_disp)).to_html()
+        table_html = _apply_dark_theme(_style_negatives(df_disp)).to_html(index=False)
         table_html = inject_row_select_js(table_html)
         st.markdown(
             f"<div class='table-wrapper' tabindex='0'>{table_html}</div>",

--- a/ui/scan.py
+++ b/ui/scan.py
@@ -104,7 +104,7 @@ def render_scanner_tab():
             if "Ticker" in df_pass.columns:
                 order = ["Ticker"] + [c for c in df_pass.columns if c != "Ticker"]
                 df_pass = df_pass[order]
-            table_html = _apply_dark_theme(_style_negatives(df_pass)).to_html()
+            table_html = _apply_dark_theme(_style_negatives(df_pass)).to_html(index=False)
             table_html = inject_row_select_js(table_html)
             st.markdown(
                 f"<div class='table-wrapper' tabindex='0'>{table_html}</div>",
@@ -116,7 +116,7 @@ def render_scanner_tab():
                 if "Ticker" in sf.columns:
                     order = ["Ticker"] + [c for c in sf.columns if c != "Ticker"]
                     sf = sf[order]
-                table_html = _apply_dark_theme(_style_negatives(sf)).to_html()
+                table_html = _apply_dark_theme(_style_negatives(sf)).to_html(index=False)
                 table_html = inject_row_select_js(table_html)
                 st.markdown(
                     f"<div class='table-wrapper' tabindex='0'>{table_html}</div>",
@@ -129,7 +129,7 @@ def render_scanner_tab():
         if "Ticker" in df_pass.columns:
             order = ["Ticker"] + [c for c in df_pass.columns if c != "Ticker"]
             df_pass = df_pass[order]
-        table_html = _apply_dark_theme(_style_negatives(df_pass)).to_html()
+        table_html = _apply_dark_theme(_style_negatives(df_pass)).to_html(index=False)
         table_html = inject_row_select_js(table_html)
         st.markdown(
             f"<div class='table-wrapper' tabindex='0'>{table_html}</div>",
@@ -141,7 +141,7 @@ def render_scanner_tab():
             if "Ticker" in sf.columns:
                 order = ["Ticker"] + [c for c in sf.columns if c != "Ticker"]
                 sf = sf[order]
-            table_html = _apply_dark_theme(_style_negatives(sf)).to_html()
+            table_html = _apply_dark_theme(_style_negatives(sf)).to_html(index=False)
             table_html = inject_row_select_js(table_html)
             st.markdown(
                 f"<div class='table-wrapper' tabindex='0'>{table_html}</div>",


### PR DESCRIPTION
## Summary
- Hide DataFrame indices in `_apply_dark_theme` so table styling starts with Ticker and keeps the column sticky while scrolling
- Render history and scanner tables with `to_html(index=False)` to avoid index columns
- Update UI tests to read indexless HTML output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b87bc7138c8332aa861b437884f84b