### PR TITLE
Fix sticky column clipping in dark tables

### DIFF
--- a/ui/history.py
+++ b/ui/history.py
@@ -49,7 +49,7 @@ def _apply_dark_theme(
         ("border-collapse", "separate"),
         ("border-spacing", "0"),
         ("border-radius", "8px"),
-        ("overflow", "hidden"),
+        ("overflow", "visible"),
         ("width", "max-content"),
         ("white-space", "nowrap"),
     ]


### PR DESCRIPTION
## Summary
- allow sticky Ticker column to remain visible by using `overflow: visible` in history table styles
- rely on `.table-wrapper` for horizontal scrolling and clipping

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b87d957b34833281e21fa685878894