### PR TITLE
Fix sticky first column hover color in tables

### DIFF
--- a/ui/history.py
+++ b/ui/history.py
@@ -105,6 +105,13 @@ def _apply_dark_theme(
             ],
         },
         {
+            "selector": "tbody tr:hover td:first-child",
+            "props": [
+                ("background-color", "var(--table-hover)"),
+                ("z-index", "1"),
+            ],
+        },
+        {
             "selector": "td.pos",
             "props": [("color", "var(--table-pos)"), ("font-weight", "600")],
         },

--- a/ui/layout.py
+++ b/ui/layout.py
@@ -215,6 +215,14 @@ def setup_page(
         .table-wrapper table {{
             width: max-content;
         }}
+        .table-wrapper tbody tr:hover {{
+            background-color: var(--table-hover);
+            color: var(--table-hover-text);
+        }}
+        .table-wrapper tbody tr:hover td:first-child {{
+            background-color: var(--table-hover);
+            z-index: 1;
+        }}
         </style>
         """,
         unsafe_allow_html=True,


### PR DESCRIPTION
## Summary
- Highlight table rows through `.table-wrapper tbody tr:hover` and ensure sticky first column adopts hover color
- Update `_apply_dark_theme` to keep first column hover colors visible when index is removed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b87d96c2188332a571a0bf40b72865