### PR TITLE
Show outcomes in history tab

### DIFF
--- a/ui/history.py
+++ b/ui/history.py
@@ -289,6 +289,7 @@ def outcomes_summary(dfh: pd.DataFrame):
 def render_history_tab():
     df_pass = load_pass_history()
     df_last, date_str = latest_trading_day_recs(df_pass)
+    df_out = load_outcomes()
     if date_str:
         st.subheader(f"Trading day {date_str} recommendations")
         if df_last.empty:
@@ -309,17 +310,5 @@ def render_history_tab():
         st.subheader("Trading day — recommendations")
         st.info("No pass files yet. Run the scanner (or wait for the next scheduled run).")
 
-    st.subheader("Pass history")
-    if df_pass.empty:
-        st.info("No pass files yet. Run the scanner (or wait for the next scheduled run).")
-    else:
-        df_disp = df_pass.copy()
-        if "Ticker" in df_disp.columns:
-            cols = ["Ticker"] + [c for c in df_disp.columns if c != "Ticker"]
-            df_disp = df_disp[cols]
-        table_html = _apply_dark_theme(_style_negatives(df_disp)).to_html(index=False)
-        table_html = inject_row_select_js(table_html)
-        st.markdown(
-            f"<div class='table-wrapper' tabindex='0'>{table_html}</div>",
-            unsafe_allow_html=True,
-        )
+    st.subheader("Outcomes")
+    outcomes_summary(df_out)


### PR DESCRIPTION
## Summary
- Replace pass-history table with outcomes summary in the history tab
- Load outcomes data and display via `outcomes_summary`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b87feb24288332bc59a77ba7794565