### PR TITLE
Make table headers sticky in history tables

### DIFF
--- a/ui/dark_table_sample.html
+++ b/ui/dark_table_sample.html
@@ -13,9 +13,14 @@
   border-collapse: separate;
   border-spacing: 0;
   border-radius: 8px;
-  overflow: hidden;
   width: max-content;
   white-space: nowrap;
+}
+#T_34871 thead th {
+  position: sticky;
+  top: 0;
+  z-index: 3;
+  background-color: var(--table-header-bg);
 }
 #T_34871 th {
   background-color: var(--table-header-bg);
@@ -41,7 +46,7 @@
 #T_34871 th:first-child {
   position: sticky;
   left: 0;
-  z-index: 2;
+  z-index: 4;
   background-color: var(--table-header-bg);
 }
 #T_34871 td:first-child {

--- a/ui/history.py
+++ b/ui/history.py
@@ -61,6 +61,15 @@ def _apply_dark_theme(
     styles = [
         {"selector": "", "props": table_props},
         {
+            "selector": "thead th",
+            "props": [
+                ("position", "sticky"),
+                ("top", "0"),
+                ("z-index", "3"),
+                ("background-color", "var(--table-header-bg)"),
+            ],
+        },
+        {
             "selector": "th",
             "props": [
                 ("background-color", "var(--table-header-bg)"),
@@ -96,7 +105,7 @@ def _apply_dark_theme(
             "props": [
                 ("position", "sticky"),
                 ("left", "0"),
-                ("z-index", "2"),
+                ("z-index", "4"),
                 ("background-color", "var(--table-header-bg)"),
             ],
         },

--- a/ui/layout.py
+++ b/ui/layout.py
@@ -162,7 +162,6 @@ def setup_page(
             border-radius: 8px;
             border-collapse: separate;
             border-spacing: 0;
-            overflow: hidden;
             width: max-content;
         }}
         /* Header */
@@ -173,7 +172,13 @@ def setup_page(
             text-align: center;
             position: sticky;
             top: 0;
-            z-index: 1;
+            z-index: 3;
+        }}
+        table.dark-table th:first-child {{
+            position: sticky;
+            left: 0;
+            z-index: 4;
+            background-color: var(--table-header-bg);
         }}
         /* Rows */
         table.dark-table tbody tr {{


### PR DESCRIPTION
## Summary
- Keep history table headers visible by making thead sticky and bumping first-cell z-index
- Remove overflow from dark-table CSS and adjust z-index so sticky headers aren't clipped
- Update sample table styling for sticky header demonstration

## Testing
- `pytest -q`
- `python - <<'PY'
import pandas as pd
from ui.history import _apply_dark_theme

html = _apply_dark_theme(pd.DataFrame({'A':[1,2],'B':[3,4]})).to_html()
print('thead th rule present?', 'thead th' in html)
print('z-index 4 present?', 'z-index: 4' in html)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b8821f86e0833296a8dccda5729cd4