### PR TITLE
Clarify sticky header implementation in tables

### DIFF
--- a/ui/history.py
+++ b/ui/history.py
@@ -60,6 +60,7 @@ def _apply_dark_theme(
     ]
     styles = [
         {"selector": "", "props": table_props},
+        # Ensure header row stays visible while scrolling
         {
             "selector": "thead th",
             "props": [

--- a/ui/layout.py
+++ b/ui/layout.py
@@ -202,7 +202,7 @@ def setup_page(*, table_hover: str = "#2563eb", table_hover_text: str = "#ffffff
         .table-wrapper {{
             position: relative;
             overflow-x: auto;
-            overflow-y: visible;
+            overflow-y: visible; /* avoid new scrolling context so headers stay sticky */
             max-width: 100%;
             /* Allow vertical scroll chaining while keeping horizontal containment */
             overscroll-behavior-x: contain;


### PR DESCRIPTION
## Summary
- explain sticky header styling in `_apply_dark_theme`
- comment `.table-wrapper` overflow to preserve sticky headers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b88b70c4188332ab691591a96507f9