### PR TITLE
fix: make dataframe headers sticky

### DIFF
--- a/tests/test_layout_sticky_headers.py
+++ b/tests/test_layout_sticky_headers.py
@@ -6,6 +6,7 @@ def test_setup_page_includes_sticky_dataframe_css(monkeypatch):
     monkeypatch.setattr(layout.st, "markdown", lambda html, *a, **k: calls.append(html))
     layout.setup_page()
     css_call = next((c for c in calls if '<style>' in c), '')
-    assert 'div[data-testid="stDataFrame"] thead th' in css_call
+    assert 'div[data-testid="stDataFrame"] [role="columnheader"]' in css_call
+    assert 'overflow-y: auto' in css_call
     assert 'position: sticky' in css_call
-    assert 'tbody td:first-child' in css_call
+    assert '[role="row"] [role="gridcell"]:first-child' in css_call

--- a/ui/layout.py
+++ b/ui/layout.py
@@ -200,6 +200,10 @@ def setup_page(*, table_hover: str = "#2563eb", table_hover_text: str = "#ffffff
         }}
 
         /* Streamlit DataFrame styling and sticky headers */
+        div[data-testid="stDataFrame"] > div {{
+            position: relative;
+            overflow-y: auto;
+        }}
         div[data-testid="stDataFrame"] table {{
             background-color: var(--table-bg);
             border: 1px solid var(--table-border);
@@ -208,7 +212,8 @@ def setup_page(*, table_hover: str = "#2563eb", table_hover_text: str = "#ffffff
             border-spacing: 0;
             width: max-content;
         }}
-        div[data-testid="stDataFrame"] thead th {{
+        div[data-testid="stDataFrame"] thead th,
+        div[data-testid="stDataFrame"] [role="columnheader"] {{
             position: sticky;
             top: 0;
             z-index: 3;
@@ -216,36 +221,45 @@ def setup_page(*, table_hover: str = "#2563eb", table_hover_text: str = "#ffffff
             color: var(--table-header-text);
             padding: 8px;
         }}
-        div[data-testid="stDataFrame"] tbody td {{
+        div[data-testid="stDataFrame"] tbody td,
+        div[data-testid="stDataFrame"] [role="row"] [role="gridcell"] {{
             background-color: var(--table-bg);
             color: var(--table-text);
             border-bottom: 1px solid var(--table-border);
             padding: 8px;
         }}
-        div[data-testid="stDataFrame"] tbody tr:nth-child(even) td {{
+        div[data-testid="stDataFrame"] tbody tr:nth-child(even) td,
+        div[data-testid="stDataFrame"] [role="row"]:nth-child(even) [role="gridcell"] {{
             background-color: var(--table-row-alt);
         }}
-        div[data-testid="stDataFrame"] tbody tr:hover td {{
+        div[data-testid="stDataFrame"] tbody tr:hover td,
+        div[data-testid="stDataFrame"] [role="row"]:hover [role="gridcell"] {{
             background-color: var(--table-hover);
             color: var(--table-hover-text);
         }}
         /* Sticky first column */
         div[data-testid="stDataFrame"] tbody td:first-child,
-        div[data-testid="stDataFrame"] thead th:first-child {{
+        div[data-testid="stDataFrame"] thead th:first-child,
+        div[data-testid="stDataFrame"] [role="row"] [role="gridcell"]:first-child,
+        div[data-testid="stDataFrame"] [role="columnheader"]:first-child {{
             position: sticky;
             left: 0;
         }}
-        div[data-testid="stDataFrame"] thead th:first-child {{
+        div[data-testid="stDataFrame"] thead th:first-child,
+        div[data-testid="stDataFrame"] [role="columnheader"]:first-child {{
             z-index: 4;
         }}
-        div[data-testid="stDataFrame"] tbody td:first-child {{
+        div[data-testid="stDataFrame"] tbody td:first-child,
+        div[data-testid="stDataFrame"] [role="row"] [role="gridcell"]:first-child {{
             z-index: 2;
             background-color: var(--table-bg);
         }}
-        div[data-testid="stDataFrame"] tbody tr:nth-child(even) td:first-child {{
+        div[data-testid="stDataFrame"] tbody tr:nth-child(even) td:first-child,
+        div[data-testid="stDataFrame"] [role="row"]:nth-child(even) [role="gridcell"]:first-child {{
             background-color: var(--table-row-alt);
         }}
-        div[data-testid="stDataFrame"] tbody tr:hover td:first-child {{
+        div[data-testid="stDataFrame"] tbody tr:hover td:first-child,
+        div[data-testid="stDataFrame"] [role="row"]:hover [role="gridcell"]:first-child {{
             background-color: var(--table-hover);
             color: var(--table-hover-text);
         }}


### PR DESCRIPTION
## Summary
- update DataFrame CSS to target real header elements and scroll container
- extend test to check sticky header selectors

## Testing
- `python -m pytest tests/test_layout_sticky_headers.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8a67518688332b3e726f5da5f3d14