### PR TITLE
Fix sticky headers for Streamlit DataFrames

### DIFF
--- a/tests/test_layout_sticky_headers.py
+++ b/tests/test_layout_sticky_headers.py
@@ -1,0 +1,11 @@
+import ui.layout as layout
+
+def test_setup_page_includes_sticky_dataframe_css(monkeypatch):
+    calls = []
+    monkeypatch.setattr(layout.st, "set_page_config", lambda *a, **k: None)
+    monkeypatch.setattr(layout.st, "markdown", lambda html, *a, **k: calls.append(html))
+    layout.setup_page()
+    css_call = next((c for c in calls if '<style>' in c), '')
+    assert 'div[data-testid="stDataFrame"] th[role="columnheader"]' in css_call
+    assert 'position: sticky' in css_call
+    assert 'th[role="rowheader"]' in css_call

--- a/ui/layout.py
+++ b/ui/layout.py
@@ -32,7 +32,8 @@ def setup_page(*, table_hover: str = "#2563eb", table_hover_text: str = "#ffffff
             --col-width: 33%;
         }}
 
-        .dark-table {{
+        .dark-table,
+        div[data-testid="stDataFrame"] {{
             --table-bg: #1f2937;
             --table-header-bg: #374151;
             --table-row-alt: #1e293b;
@@ -196,6 +197,58 @@ def setup_page(*, table_hover: str = "#2563eb", table_hover_text: str = "#ffffff
         table.dark-table td.neg {{
             color: var(--table-neg) !important;
             font-weight: 600;
+        }}
+
+        /* Streamlit DataFrame styling and sticky headers */
+        div[data-testid="stDataFrame"] > div:first-child {{
+            position: relative;
+        }}
+        div[data-testid="stDataFrame"] th[role="columnheader"] {{
+            position: sticky;
+            top: 0;
+            z-index: 3;
+            background-color: var(--table-header-bg);
+            color: var(--table-header-text);
+            padding: 8px;
+        }}
+        div[data-testid="stDataFrame"] td,
+        div[data-testid="stDataFrame"] th {{
+            border-bottom: 1px solid var(--table-border);
+        }}
+        div[data-testid="stDataFrame"] td {{
+            background-color: var(--table-bg);
+            color: var(--table-text);
+            padding: 8px;
+        }}
+        div[data-testid="stDataFrame"] tbody tr:nth-child(even) td {{
+            background-color: var(--table-row-alt);
+        }}
+        div[data-testid="stDataFrame"] tbody tr:hover td {{
+            background-color: var(--table-hover);
+            color: var(--table-hover-text);
+        }}
+        /* Sticky first column */
+        div[data-testid="stDataFrame"] th[role="rowheader"],
+        div[data-testid="stDataFrame"] td:first-child {{
+            position: sticky;
+            left: 0;
+        }}
+        div[data-testid="stDataFrame"] th[role="rowheader"] {{
+            z-index: 4;
+            background-color: var(--table-header-bg);
+            color: var(--table-header-text);
+            padding: 8px;
+        }}
+        div[data-testid="stDataFrame"] td:first-child {{
+            z-index: 2;
+            background-color: var(--table-bg);
+        }}
+        div[data-testid="stDataFrame"] tbody tr:nth-child(even) td:first-child {{
+            background-color: var(--table-row-alt);
+        }}
+        div[data-testid="stDataFrame"] tbody tr:hover td:first-child {{
+            background-color: var(--table-hover);
+            color: var(--table-hover-text);
         }}
 
         /* Scrollable wrapper for custom HTML tables */


### PR DESCRIPTION
## Summary
- ensure Streamlit-rendered tables keep column headers and first column fixed while scrolling
- adjust tests to cover new selectors for sticky headers and first column

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b8a45b19ac83329c702150654050c5