### PR TITLE
Make table headers sticky across devices

### DIFF
--- a/ui/layout.py
+++ b/ui/layout.py
@@ -164,11 +164,15 @@ def setup_page(*, table_hover: str = "#2563eb", table_hover_text: str = "#ffffff
             width: max-content;
         }}
         /* Header */
-        table.dark-table th:first-child {{
+        table.dark-table thead th {{
             position: sticky;
-            left: 0;
-            z-index: 4;
+            top: 0;
+            z-index: 3;
             background-color: var(--table-header-bg);
+        }}
+        table.dark-table thead th:first-child {{
+            left: 0;
+            z-index: 5;
         }}
         /* Rows */
         table.dark-table tbody tr {{
@@ -268,10 +272,16 @@ def setup_page(*, table_hover: str = "#2563eb", table_hover_text: str = "#ffffff
         .table-wrapper {{
             position: relative;
             overflow-x: auto;
-            overflow-y: visible;
+            overflow-y: auto;
         }}
         .table-wrapper table {{
             width: max-content;
+        }}
+        .table-wrapper thead th {{
+            position: sticky;
+            top: 0;
+            z-index: 2;
+            background-color: var(--table-header-bg);
         }}
         .table-wrapper tbody tr:hover {{
             background-color: var(--table-hover);


### PR DESCRIPTION
## Summary
- Keep custom table headers fixed on scroll for desktop and mobile
- Allow HTML table wrappers to scroll vertically with sticky headers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8b292d27483329bf1d22a8efee7e9