### PR TITLE
test: cover sticky headers for custom tables

### DIFF
--- a/tests/test_layout_sticky_headers.py
+++ b/tests/test_layout_sticky_headers.py
@@ -10,3 +10,13 @@ def test_setup_page_includes_sticky_dataframe_css(monkeypatch):
     assert 'overflow-y: auto' in css_call
     assert 'position: sticky' in css_call
     assert '[role="row"] [role="gridcell"]:first-child' in css_call
+
+
+def test_setup_page_includes_table_wrapper_sticky_header_css(monkeypatch):
+    calls = []
+    monkeypatch.setattr(layout.st, "set_page_config", lambda *a, **k: None)
+    monkeypatch.setattr(layout.st, "markdown", lambda html, *a, **k: calls.append(html))
+    layout.setup_page()
+    css_call = next((c for c in calls if '<style>' in c), '')
+    assert '.table-wrapper thead th' in css_call
+    assert 'position: sticky' in css_call


### PR DESCRIPTION
## Summary
- add regression test ensuring layout.setup_page emits sticky header CSS for `.table-wrapper` tables

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8c0ebd94483329bec5383ea471512