### PR TITLE
fix: inject sticky helper per page

### DIFF
--- a/tests/test_layout_sticky_headers.py
+++ b/tests/test_layout_sticky_headers.py
@@ -4,12 +4,13 @@ def test_setup_page_includes_sticky_dataframe_css(monkeypatch):
     calls = []
     monkeypatch.setattr(layout.st, "set_page_config", lambda *a, **k: None)
     monkeypatch.setattr(layout.st, "markdown", lambda html, *a, **k: calls.append(html))
-    monkeypatch.setattr(layout.st, "session_state", {})
     layout.setup_page()
     css_call = next((c for c in calls if '<style>' in c), '')
-    assert 'div[data-testid="stDataFrame"] .sticky-scroll' in css_call
-    assert 'div[data-testid="stDataFrame"] [role="columnheader"]' in css_call
+    assert 'div[data-testid="stDataFrame"] {' in css_call
+    assert 'position: relative' in css_call
     assert 'overflow: auto' in css_call
+    assert 'div[data-testid="stDataFrame"] thead th' in css_call
+    assert 'div[data-testid="stDataFrame"] [role="columnheader"]' in css_call
     assert 'position: sticky' in css_call
 
 
@@ -17,20 +18,16 @@ def test_setup_page_includes_table_wrapper_sticky_header_css(monkeypatch):
     calls = []
     monkeypatch.setattr(layout.st, "set_page_config", lambda *a, **k: None)
     monkeypatch.setattr(layout.st, "markdown", lambda html, *a, **k: calls.append(html))
-    monkeypatch.setattr(layout.st, "session_state", {})
     layout.setup_page()
     css_call = next((c for c in calls if '<style>' in c), '')
     assert '.table-wrapper thead th' in css_call
     assert 'position: sticky' in css_call
 
 
-def test_setup_page_injects_sticky_helper_once(monkeypatch):
+def test_setup_page_injects_sticky_helper(monkeypatch):
     calls: list[str] = []
-    state: dict[str, bool] = {}
     monkeypatch.setattr(layout.st, "set_page_config", lambda *a, **k: None)
     monkeypatch.setattr(layout.st, "markdown", lambda html, *a, **k: calls.append(html))
-    monkeypatch.setattr(layout.st, "session_state", state)
-    layout.setup_page()
     layout.setup_page()
     js_calls = [c for c in calls if "__stickyAudit__" in c]
     assert len(js_calls) == 1

--- a/ui/layout.py
+++ b/ui/layout.py
@@ -205,29 +205,27 @@ def setup_page(*, table_hover: str = "#2563eb", table_hover_text: str = "#ffffff
         }}
 
         /* Streamlit DataFrame styling and sticky headers */
-        /* Reset root overflow so sticky uses inner scroll container */
+        /* Root container override for scroll behavior */
         div[data-testid="stDataFrame"] {{
-            overflow: visible !important;
+            position: relative;
+            overflow: auto !important;
         }}
 
         /* Actual scroll container (identified by JS helper) */
-        div[data-testid="stDataFrame"] .sticky-scroll {{
-            position: relative;
-            overflow: auto !important;
+        div[data-testid="stDataFrame"].sticky-scroll {{
             border: 1px solid var(--table-border);
             border-radius: 10px;
         }}
 
         /* Ensure table rendering works well with sticky headers */
-        div[data-testid="stDataFrame"] .sticky-scroll table {{
+        div[data-testid="stDataFrame"].sticky-scroll table {{
             border-collapse: separate;
             border-spacing: 0;
         }}
 
         /* Sticky header cells (native <th> and grid role headers) */
         div[data-testid="stDataFrame"] thead th,
-        div[data-testid="stDataFrame"] [role="columnheader"],
-        div[data-testid="stDataFrame"] .sticky-header {{
+        div[data-testid="stDataFrame"] [role="columnheader"] {{
             position: sticky;
             top: 0;
             z-index: 5; /* above rows and hover backgrounds */
@@ -237,15 +235,15 @@ def setup_page(*, table_hover: str = "#2563eb", table_hover_text: str = "#ffffff
         }}
 
         /* Row striping and base background */
-        div[data-testid="stDataFrame"] .sticky-scroll tbody tr td {{
+        div[data-testid="stDataFrame"].sticky-scroll tbody tr td {{
             background: var(--table-bg);
         }}
-        div[data-testid="stDataFrame"] .sticky-scroll tbody tr:nth-child(even) td {{
+        div[data-testid="stDataFrame"].sticky-scroll tbody tr:nth-child(even) td {{
             background: var(--table-row-alt);
         }}
 
         /* Hover highlight that does not cover the header */
-        div[data-testid="stDataFrame"] .sticky-scroll tbody tr:hover td {{
+        div[data-testid="stDataFrame"].sticky-scroll tbody tr:hover td {{
             background: var(--table-hover);
             color: var(--table-hover-text);
         }}
@@ -278,10 +276,8 @@ def setup_page(*, table_hover: str = "#2563eb", table_hover_text: str = "#ffffff
         unsafe_allow_html=True,
     )
 
-    if "_sticky_js_injected" not in st.session_state:
-        helper_js = Path(__file__).with_name("sticky_df_helper.js").read_text()
-        st.markdown(f"<script>{helper_js}</script>", unsafe_allow_html=True)
-        st.session_state["_sticky_js_injected"] = True
+    helper_js = Path(__file__).with_name("sticky_df_helper.js").read_text()
+    st.markdown(f"<script>{helper_js}</script>", unsafe_allow_html=True)
 
     st.markdown(
         """

--- a/ui/sticky_df_helper.js
+++ b/ui/sticky_df_helper.js
@@ -89,8 +89,4 @@ window.__STICKY_DEBUG__ = window.__STICKY_DEBUG__ ?? false;
   }
 
   init();
-
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', init, { once: true });
-  }
 })();


### PR DESCRIPTION
## Summary
- remove session_state guard and always inject sticky helper script
- simplify sticky DataFrame helper and rely on client-side idempotence
- adjust sticky header CSS and tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b993846e248332ab72e27e9efc63d9