### PR TITLE
fix: inject sticky helper via components

### DIFF
--- a/tests/test_layout_sticky_headers.py
+++ b/tests/test_layout_sticky_headers.py
@@ -1,20 +1,25 @@
 import ui.layout as layout
 
+
 def test_setup_page_includes_sticky_dataframe_css(monkeypatch):
     calls = []
+    html_calls = []
     monkeypatch.setattr(layout.st, "set_page_config", lambda *a, **k: None)
     monkeypatch.setattr(layout.st, "markdown", lambda html, *a, **k: calls.append(html))
+    monkeypatch.setattr(layout.components.v1, "html", lambda html, *a, **k: html_calls.append(html))
     layout.setup_page()
     css_call = next((c for c in calls if '<style>' in c), '')
     assert 'div[data-testid="stDataFrame"] [role="columnheader"]' in css_call
     assert 'overflow: auto' in css_call
     assert 'position: sticky' in css_call
+    assert len(html_calls) == 1
 
 
 def test_setup_page_includes_table_wrapper_sticky_header_css(monkeypatch):
     calls = []
     monkeypatch.setattr(layout.st, "set_page_config", lambda *a, **k: None)
     monkeypatch.setattr(layout.st, "markdown", lambda html, *a, **k: calls.append(html))
+    monkeypatch.setattr(layout.components.v1, "html", lambda *a, **k: None)
     layout.setup_page()
     css_call = next((c for c in calls if '<style>' in c), '')
     assert '.table-wrapper thead th' in css_call

--- a/ui/layout.py
+++ b/ui/layout.py
@@ -1,4 +1,11 @@
 import streamlit as st
+from pathlib import Path
+from streamlit import components
+
+
+def _inject_sticky_helper():
+    helper_js = Path(__file__).with_name("sticky_df_helper.js").read_text()
+    components.v1.html(f"<script>{helper_js}</script>", height=0, width=0, scrolling=False)
 
 
 def setup_page(*, table_hover: str = "#2563eb", table_hover_text: str = "#ffffff"):
@@ -229,21 +236,25 @@ def setup_page(*, table_hover: str = "#2563eb", table_hover_text: str = "#ffffff
         }}
 
         /* Row striping and base background */
-        div[data-testid="stDataFrame"] tbody tr td {{
+        div[data-testid="stDataFrame"].sticky-scroll tbody tr td,
+        div[data-testid="stDataFrame"] .sticky-scroll tbody tr td {{
             background: var(--table-bg);
         }}
-        div[data-testid="stDataFrame"] tbody tr:nth-child(even) td {{
+        div[data-testid="stDataFrame"].sticky-scroll tbody tr:nth-child(even) td,
+        div[data-testid="stDataFrame"] .sticky-scroll tbody tr:nth-child(even) td {{
             background: var(--table-row-alt);
         }}
 
         /* Hover highlight that does not cover the header */
-        div[data-testid="stDataFrame"] tbody tr:hover td {{
+        div[data-testid="stDataFrame"].sticky-scroll tbody tr:hover td,
+        div[data-testid="stDataFrame"] .sticky-scroll tbody tr:hover td {{
             background: var(--table-hover);
             color: var(--table-hover-text);
         }}
 
         /* Optional: subtle border around the scrolling frame so it reads as a card */
-        div[data-testid="stDataFrame"] > div {{
+        div[data-testid="stDataFrame"].sticky-scroll,
+        div[data-testid="stDataFrame"] .sticky-scroll {{
             border: 1px solid var(--table-border);
             border-radius: 10px;
         }}
@@ -275,6 +286,8 @@ def setup_page(*, table_hover: str = "#2563eb", table_hover_text: str = "#ffffff
         """,
         unsafe_allow_html=True,
     )
+
+    _inject_sticky_helper()
 
     st.markdown(
         """

--- a/ui/sticky_df_helper.js
+++ b/ui/sticky_df_helper.js
@@ -1,0 +1,39 @@
+(function() {
+  if (window.__STICKY_READY__) return;
+  window.__STICKY_READY__ = true;
+
+  const CLASS = 'sticky-scroll';
+
+  function findScrollNode(el) {
+    const walkers = el.querySelectorAll('div');
+    for (const node of walkers) {
+      const style = getComputedStyle(node);
+      if (/(auto|scroll)/.test(style.overflowY + style.overflowX)) {
+        return node;
+      }
+    }
+    return el;
+  }
+
+  function audit() {
+    const frames = document.querySelectorAll('div[data-testid="stDataFrame"]');
+    frames.forEach(el => {
+      const scrollNode = findScrollNode(el);
+      const root = el.closest('div[data-testid="stDataFrame"]') ?? el;
+      root.classList.add(CLASS);
+      scrollNode.classList.add(CLASS);
+    });
+    return frames.length;
+  }
+
+  window.__stickyAudit__ = audit;
+
+  let timer;
+  const observer = new MutationObserver(() => {
+    clearTimeout(timer);
+    timer = setTimeout(audit, 100);
+  });
+  observer.observe(document.documentElement, { childList: true, subtree: true });
+
+  audit();
+})();


### PR DESCRIPTION
## Summary
- inject sticky helper using components.v1.html
- mark both DataFrame root and scroll node with `sticky-scroll`
- scope DataFrame CSS to either root or inner scroll targets
- test component injection and sticky selectors

## Testing
- `pytest`

## Acceptance Checklist
- [ ] Hard refresh app → in console `typeof window.__stickyAudit__ === "function"`.
- [ ] Running `window.__stickyAudit__()` returns a number (count of processed tables) without errors.
- [ ] Each st.dataframe scrolls with header pinned vertically and during horizontal scroll.
- [ ] No visual regressions outside tables.


------
https://chatgpt.com/codex/tasks/task_e_68b99b2c9ec08332b956fcc7365d49f2