### PR TITLE
Fix sticky DataFrame headers in Streamlit

### DIFF
--- a/ui/sticky_df_helper.js
+++ b/ui/sticky_df_helper.js
@@ -1,39 +1,63 @@
-(function() {
-  if (window.__STICKY_READY__) return;
-  window.__STICKY_READY__ = true;
+// ui/sticky_df_helper.js
+(function () {
+  const PWIN = window.parent || window;
+  const DOC  = (window.parent && window.parent.document) ? window.parent.document : document;
 
-  const CLASS = 'sticky-scroll';
+  if (PWIN.__STICKY_READY__) {
+    PWIN.__stickyAudit__?.();
+    return;
+  }
+  PWIN.__STICKY_READY__ = true;
 
-  function findScrollNode(el) {
-    const walkers = el.querySelectorAll('div');
-    for (const node of walkers) {
-      const style = getComputedStyle(node);
-      if (/(auto|scroll)/.test(style.overflowY + style.overflowX)) {
-        return node;
-      }
+  const DEBUG = PWIN.__STICKY_DEBUG__ ?? false;
+  const log = (...args) => DEBUG && console.log('[sticky]', ...args);
+
+  function findScrollNode(root) {
+    // Try to find the div that actually scrolls; fallback to root.
+    const nodes = root.querySelectorAll('div, section');
+    for (const el of nodes) {
+      const cs = getComputedStyle(el);
+      if ((cs.overflowY === 'auto' || cs.overflowY === 'scroll')) return el;
     }
-    return el;
+    return root;
   }
 
-  function audit() {
-    const frames = document.querySelectorAll('div[data-testid="stDataFrame"]');
-    frames.forEach(el => {
-      const scrollNode = findScrollNode(el);
-      const root = el.closest('div[data-testid="stDataFrame"]') ?? el;
-      root.classList.add(CLASS);
-      scrollNode.classList.add(CLASS);
+  function audit(root) {
+    if (!root || !(root instanceof Element)) return;
+    const scrollNode = findScrollNode(root);
+
+    // Mark both so CSS can style either target
+    root.classList.add('sticky-scroll');
+    scrollNode.classList.add('sticky-scroll');
+
+    // Ensure headers are sticky and visually on top
+    const headers = root.querySelectorAll('thead th,[role="columnheader"]');
+    headers.forEach(h => {
+      h.style.position = 'sticky';
+      h.style.top = '0px';
+      h.style.zIndex = '3';
     });
-    return frames.length;
   }
 
-  window.__stickyAudit__ = audit;
+  function apply() {
+    const roots = DOC.querySelectorAll('div[data-testid="stDataFrame"]');
+    roots.forEach(audit);
+    return roots.length;
+  }
 
-  let timer;
-  const observer = new MutationObserver(() => {
-    clearTimeout(timer);
-    timer = setTimeout(audit, 100);
-  });
-  observer.observe(document.documentElement, { childList: true, subtree: true });
+  // Expose for manual retries
+  PWIN.__stickyAudit__ = apply;
 
-  audit();
+  // Debounced global observer on parent DOM to catch re-renders
+  if (!PWIN.__stickyObserver__) {
+    PWIN.__stickyObserver__ = new MutationObserver(() => {
+      clearTimeout(PWIN.__stickyPending__);
+      PWIN.__stickyPending__ = setTimeout(apply, 80);
+    });
+    PWIN.__stickyObserver__.observe(DOC.documentElement, { childList: true, subtree: true });
+  }
+
+  const init = () => { log('helper loaded; processed', apply()); };
+  if (DOC.readyState === 'loading') DOC.addEventListener('DOMContentLoaded', init, { once: true });
+  else init();
 })();


### PR DESCRIPTION
## Summary
- Inject sticky helper JS into the parent document for accurate DataFrame detection
- Revise DataFrame CSS to style root/inner scroll nodes and keep headers pinned
- Rework sticky helper to operate on the parent DOM and expose a global audit function

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9a4a398808332bb5a4365e69e28a3