### PR TITLE
fix: run sticky helper in parent window + robust DF audit

### DIFF
--- a/ui/sticky_df_helper.js
+++ b/ui/sticky_df_helper.js
@@ -1,63 +1,95 @@
-// ui/sticky_df_helper.js
-(function () {
-  const PWIN = window.parent || window;
-  const DOC  = (window.parent && window.parent.document) ? window.parent.document : document;
+// Sticky DataFrame/Table helper – runs in the PARENT page
+(function (PWIN) {
+  try {
+    if (!PWIN) return;
+    if (PWIN.__STICKY_READY__) { PWIN.__stickyAudit__?.(); return; }
+    PWIN.__STICKY_READY__ = true;
 
-  if (PWIN.__STICKY_READY__) {
-    PWIN.__stickyAudit__?.();
-    return;
-  }
-  PWIN.__STICKY_READY__ = true;
+    const DOC = PWIN.document;
+    PWIN.__STICKY_DEBUG__ = PWIN.__STICKY_DEBUG__ ?? false;
+    const STYLE_ID = "sticky-v3-css";
+    const log = (...a) => { if (PWIN.__STICKY_DEBUG__) console.log(...a); };
 
-  const DEBUG = PWIN.__STICKY_DEBUG__ ?? false;
-  const log = (...args) => DEBUG && console.log('[sticky]', ...args);
-
-  function findScrollNode(root) {
-    // Try to find the div that actually scrolls; fallback to root.
-    const nodes = root.querySelectorAll('div, section');
-    for (const el of nodes) {
-      const cs = getComputedStyle(el);
-      if ((cs.overflowY === 'auto' || cs.overflowY === 'scroll')) return el;
+    function ensureCSS() {
+      if (DOC.getElementById(STYLE_ID)) return;
+      const s = DOC.createElement("style");
+      s.id = STYLE_ID;
+      s.textContent = `
+        /* Pin table headers */
+        table thead th, table thead td { position: sticky; top: 0; z-index: 3; background: inherit; }
+        /* Scroll wrapper the helper will tag */
+        .sticky-scroll { overflow: auto; }
+      `;
+      DOC.head.appendChild(s);
     }
-    return root;
+
+    function findScrollNode(el) {
+      let n = el?.parentElement;
+      const hasScroll = (e) => {
+        const cs = PWIN.getComputedStyle(e);
+        return /(auto|scroll)/.test(cs.overflow) || /(auto|scroll)/.test(cs.overflowY);
+      };
+      while (n && n !== DOC.documentElement) {
+        if (hasScroll(n)) return n;
+        n = n.parentElement;
+      }
+      return null;
+    }
+
+    function auditTable(tbl) {
+      if (!tbl || !(tbl instanceof PWIN.Element)) return;
+      const wrap = findScrollNode(tbl) || tbl;
+      wrap.classList.add("sticky-scroll");
+      tbl.querySelectorAll("thead th, thead td").forEach((h) => {
+        h.style.position = "sticky";
+        h.style.top = "0px";
+        h.style.zIndex = "3";
+        // keep current theme color
+        h.style.background = PWIN.getComputedStyle(h).backgroundColor || "inherit";
+      });
+    }
+
+    function collectTables() {
+      // Streamlit DF containers + any plain tables your app renders
+      const roots = DOC.querySelectorAll('div[data-testid="stDataFrame"], .table-wrapper, table.dark-table, table');
+      const tables = [];
+      roots.forEach((r) => {
+        if (r.tagName?.toLowerCase() === "table") {
+          tables.push(r);
+        } else {
+          r.querySelectorAll("table").forEach((t) => tables.push(t));
+        }
+      });
+      return tables;
+    }
+
+    function apply() {
+      ensureCSS();
+      const tables = collectTables();
+      tables.forEach(auditTable);
+      log("[sticky] processed tables:", tables.length);
+      return tables.length;
+    }
+
+    // Debounced observer across the whole parent page
+    if (!PWIN.__stickyObserver__) {
+      PWIN.__stickyObserver__ = new PWIN.MutationObserver(() => {
+        clearTimeout(PWIN.__stickyPending__);
+        PWIN.__stickyPending__ = PWIN.setTimeout(apply, 80);
+      });
+      PWIN.__stickyObserver__.observe(DOC.documentElement, { childList: true, subtree: true });
+    }
+
+    // Expose manual hook
+    PWIN.__stickyAudit__ = apply;
+
+    // Initial run (and also on DOM ready just in case)
+    if (DOC.readyState === "loading") {
+      DOC.addEventListener("DOMContentLoaded", apply, { once: false });
+    }
+    apply();
+  } catch (e) {
+    try { console.log("[sticky] helper crashed:", e); } catch {}
   }
+})(window.parent || window);
 
-  function audit(root) {
-    if (!root || !(root instanceof Element)) return;
-    const scrollNode = findScrollNode(root);
-
-    // Mark both so CSS can style either target
-    root.classList.add('sticky-scroll');
-    scrollNode.classList.add('sticky-scroll');
-
-    // Ensure headers are sticky and visually on top
-    const headers = root.querySelectorAll('thead th,[role="columnheader"]');
-    headers.forEach(h => {
-      h.style.position = 'sticky';
-      h.style.top = '0px';
-      h.style.zIndex = '3';
-    });
-  }
-
-  function apply() {
-    const roots = DOC.querySelectorAll('div[data-testid="stDataFrame"]');
-    roots.forEach(audit);
-    return roots.length;
-  }
-
-  // Expose for manual retries
-  PWIN.__stickyAudit__ = apply;
-
-  // Debounced global observer on parent DOM to catch re-renders
-  if (!PWIN.__stickyObserver__) {
-    PWIN.__stickyObserver__ = new MutationObserver(() => {
-      clearTimeout(PWIN.__stickyPending__);
-      PWIN.__stickyPending__ = setTimeout(apply, 80);
-    });
-    PWIN.__stickyObserver__.observe(DOC.documentElement, { childList: true, subtree: true });
-  }
-
-  const init = () => { log('helper loaded; processed', apply()); };
-  if (DOC.readyState === 'loading') DOC.addEventListener('DOMContentLoaded', init, { once: true });
-  else init();
-})();


### PR DESCRIPTION
## Summary
- inject sticky helper script into parent Streamlit page and bootstrap audit hook from `setup_page`
- overhaul sticky helper to operate on parent DOM, tag scroll wrappers, pin headers and expose global rerun hook

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9b4f380808332a40eb9ad1590be4a