### PR TITLE
fix: strengthen sticky header layering

### DIFF
--- a/ui/sticky_df_helper.js
+++ b/ui/sticky_df_helper.js
@@ -1,139 +1,120 @@
 // Sticky DataFrame/Table helper – runs in the PARENT page
 (function (PWIN) {
   try {
-    if (!PWIN) return;
-    if (PWIN.__STICKY_READY__) { PWIN.__stickyAudit__?.(); return; }
-    PWIN.__STICKY_READY__ = true;
+    const TOP = PWIN;
+    const log = (...a) => { try { TOP.console.log(...a); } catch {} };
 
-    const DOC = PWIN.document;
-    PWIN.__STICKY_DEBUG__ = PWIN.__STICKY_DEBUG__ ?? false;
-    const STYLE_ID = "sticky-v3-css";
-    const log = (...a) => { if (PWIN.__STICKY_DEBUG__) console.log(...a); };
-
-    function ensureCSS(doc = DOC) {
-      if (doc.getElementById(STYLE_ID)) return;
-      const s = doc.createElement("style");
-      s.id = STYLE_ID;
+    // --- CSS per-document ---
+    function ensureCSS(doc) {
+      const id = '__sticky_css__';
+      if (doc.getElementById(id)) return;
+      const s = doc.createElement('style'); s.id = id;
       s.textContent = `
-        table.dark-table.sticky-scroll, table.sticky-scroll { border-collapse: separate; }
-        .sticky-scroll {
-          position: relative;
-          overflow: auto !important;
-          z-index: 0;
-        }
-        .sticky-scroll thead th,
-        .sticky-scroll thead td,
-        [role="columnheader"] {
-          position: sticky !important;
-          top: 0 !important;
-          z-index: 5 !important;
+        .sticky-scroll { position: relative !important; overflow: auto !important; z-index: 0; }
+        .sticky-scroll thead th, .sticky-scroll thead td, [role="columnheader"] {
+          position: sticky !important; top: 0 !important; z-index: 6 !important;
           backdrop-filter: saturate(140%);
         }
       `;
       doc.head && doc.head.appendChild(s);
     }
 
+    // --- find first scrolling/clipping ancestor in the element's own context ---
     function findScrollNode(el) {
-      if (!el) return null;
-      const doc = el.ownerDocument || DOC;
-      const win = doc.defaultView || window;
-      let n = el.parentElement;
-      const hasScroll = (e) => {
-        const cs = win.getComputedStyle(e);
-        return /(auto|scroll)/.test(cs.overflow) || /(auto|scroll)/.test(cs.overflowY);
+      const DOC = el?.ownerDocument;
+      const WIN = DOC?.defaultView || TOP;
+      if (!DOC) return null;
+      const isClip = (e) => {
+        const cs = WIN.getComputedStyle(e);
+        return /(auto|scroll|hidden)/.test(cs.overflowY) || /(auto|scroll|hidden)/.test(cs.overflow);
       };
-      while (n && n !== doc.documentElement) {
-        if (hasScroll(n)) return n;
+      let n = el.parentElement;
+      while (n && n !== DOC.documentElement) {
+        if (isClip(n)) return n;
         n = n.parentElement;
       }
       return null;
     }
 
+    // --- auditors ---
     function auditTable(tbl) {
-      if (!tbl) return;
+      const DOC = tbl.ownerDocument, WIN = DOC.defaultView;
       const wrap = findScrollNode(tbl) || tbl;
-      wrap.classList.add("sticky-scroll");
-      tbl.querySelectorAll("thead th, thead td").forEach((h) => {
-        const W = (h.ownerDocument?.defaultView) || window;
-        const bg =
-          W.getComputedStyle(h).backgroundColor ||
-          W.getComputedStyle(h.parentElement || tbl).backgroundColor ||
-          "inherit";
-        h.style.position = "sticky";
-        h.style.top = "0px";
-        h.style.zIndex = "5";
-        h.style.background = bg;
+      wrap.classList.add('sticky-scroll');
+      if (WIN.getComputedStyle(wrap).position === 'static') wrap.style.position = 'relative';
+      if (!/auto|scroll/.test(WIN.getComputedStyle(wrap).overflow + WIN.getComputedStyle(wrap).overflowY)) {
+        wrap.style.overflow = 'auto';
+      }
+      tbl.querySelectorAll('thead th, thead td').forEach((h) => {
+        const bg = WIN.getComputedStyle(h).backgroundColor;
+        h.style.position = 'sticky'; h.style.top = '0px'; h.style.zIndex = '6';
+        h.style.background = (bg === 'rgba(0, 0, 0, 0)' ? '#101425' : bg);
       });
-    }
-
-    function collectRoots(doc = DOC) {
-      return [...doc.querySelectorAll(
-        'div[data-testid="stDataFrame"], .table-wrapper, table.dark-table, table'
-      )];
+      return 1;
     }
 
     function auditStreamlitDF(root) {
-      if (!root) return;
-      (findScrollNode(root) || root).classList.add('sticky-scroll');
+      const DOC = root.ownerDocument, WIN = DOC.defaultView;
       const headers = root.querySelectorAll('[role="columnheader"]');
+      if (!headers.length) return 0;
+      const wrap = findScrollNode(root) || root;
+      wrap.classList.add('sticky-scroll');
+      if (WIN.getComputedStyle(wrap).position === 'static') wrap.style.position = 'relative';
+      if (!/auto|scroll/.test(WIN.getComputedStyle(wrap).overflow + WIN.getComputedStyle(wrap).overflowY)) {
+        wrap.style.overflow = 'auto';
+      }
       headers.forEach((h) => {
-        const W = (h.ownerDocument?.defaultView) || window;
-        const cs = W.getComputedStyle(h);
-        const bg = cs.backgroundColor ||
-          W.getComputedStyle(h.parentElement || root).backgroundColor ||
-          'inherit';
-        h.style.position = 'sticky';
-        h.style.top = '0px';
-        h.style.zIndex = '5';
-        h.style.background = bg;
+        const bg = WIN.getComputedStyle(h).backgroundColor;
+        h.style.position = 'sticky'; h.style.top = '0px'; h.style.zIndex = '6';
+        h.style.background = (bg === 'rgba(0, 0, 0, 0)' ? '#101425' : bg);
       });
+      return 1;
     }
 
-    function applyInDoc(doc) {
-      ensureCSS(doc);
+    // --- per-document driver ---
+    function applyInDoc(DOC, WIN) {
+      ensureCSS(DOC);
+
       let count = 0;
-      collectRoots(doc).forEach((r) => {
-        if (r.tagName?.toLowerCase() === 'table') {
-          auditTable(r); count++;
-        } else {
-          const innerTables = r.querySelectorAll('table');
-          if (innerTables.length) {
-            innerTables.forEach((t) => { auditTable(t); count++; });
-          } else {
-            auditStreamlitDF(r); count++;
-          }
-        }
-      });
+
+      // 1) regular tables
+      DOC.querySelectorAll('table.dark-table, .table-wrapper table, table').forEach(t => { count += auditTable(t) });
+
+      // 2) virtualized Streamlit DFs
+      DOC.querySelectorAll('div[data-testid="stDataFrame"]').forEach(r => { count += auditStreamlitDF(r) });
+
       return count;
     }
 
+    // --- top-level driver: walk same-origin iframes as well ---
     function apply() {
-      let total = applyInDoc(DOC);
-      DOC.querySelectorAll('iframe').forEach((ifr) => {
+      let total = 0;
+      total += applyInDoc(document, window);
+
+      document.querySelectorAll('iframe').forEach((ifr, i) => {
         try {
-          const d = ifr.contentDocument;
-          if (d) total += applyInDoc(d);
-        } catch (_) {}
+          const d = ifr.contentDocument, w = ifr.contentWindow;
+          if (d && w) total += applyInDoc(d, w);
+        } catch { /* cross-origin, ignore */ }
       });
-      log('[sticky] TOTAL roots:', total);
+
+      log('[sticky] total processed roots:', total);
       return total;
     }
 
+    // MutationObserver (debounced)
     if (!PWIN.__stickyObserver__) {
       PWIN.__stickyObserver__ = new PWIN.MutationObserver(() => {
         clearTimeout(PWIN.__stickyPending__);
         PWIN.__stickyPending__ = PWIN.setTimeout(apply, 80);
       });
-      PWIN.__stickyObserver__.observe(DOC.documentElement, { childList: true, subtree: true });
+      PWIN.__stickyObserver__.observe(document.documentElement, { childList: true, subtree: true });
     }
 
+    // Expose manual hook + initial run
     PWIN.__stickyAudit__ = apply;
-
-    if (DOC.readyState === "loading") {
-      DOC.addEventListener("DOMContentLoaded", apply, { once: false });
-    }
+    if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', apply, { once: true });
     apply();
-  } catch (e) {
-    try { console.log("[sticky] helper crashed:", e); } catch {}
-  }
+  } catch (e) { try { console.log('[sticky] crashed:', e); } catch {} }
 })(window.parent || window);
+


### PR DESCRIPTION
## Summary
- replace sticky helper with version that injects CSS per document
- audit both HTML tables and Streamlit DataFrames across same-origin iframes
- use ownerDocument.defaultView to avoid cross-context style errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9db0f178483329aa1df55ab0d1db7