### PR TITLE
feat(ui): sticky headers for data tables

### DIFF
--- a/tests/test_layout_sticky_headers.py
+++ b/tests/test_layout_sticky_headers.py
@@ -15,12 +15,13 @@ def test_setup_page_includes_sticky_dataframe_css(monkeypatch):
     assert len(html_calls) == 1
 
 
-def test_setup_page_includes_table_wrapper_sticky_header_css(monkeypatch):
+def test_setup_page_includes_table_wrap_sticky_header_css(monkeypatch):
     calls = []
+    html_calls = []
     monkeypatch.setattr(layout.st, "set_page_config", lambda *a, **k: None)
     monkeypatch.setattr(layout.st, "markdown", lambda html, *a, **k: calls.append(html))
-    monkeypatch.setattr(layout.components.v1, "html", lambda *a, **k: None)
+    monkeypatch.setattr(layout.components.v1, "html", lambda html, *a, **k: html_calls.append(html))
     layout.setup_page()
-    css_call = next((c for c in calls if '<style>' in c), '')
-    assert '.table-wrapper thead th' in css_call
-    assert 'position: sticky' in css_call
+    injected = ''.join(html_calls)
+    assert 'table-wrap' in injected
+    assert 'position: sticky' in injected

--- a/ui/layout.py
+++ b/ui/layout.py
@@ -275,25 +275,14 @@ def setup_page(*, table_hover: str = "#2563eb", table_hover_text: str = "#ffffff
         }}
 
         /* Scrollable wrapper for custom HTML tables */
-        .table-wrapper {{
-            position: relative;
-            overflow-x: auto;
-            overflow-y: auto;
-        }}
-        .table-wrapper table {{
+        .table-wrap table {{
             width: max-content;
         }}
-        .table-wrapper thead th {{
-            position: sticky;
-            top: 0;
-            z-index: 2;
-            background-color: var(--table-header-bg);
-        }}
-        .table-wrapper tbody tr:hover {{
+        .table-wrap tbody tr:hover {{
             background-color: var(--table-hover);
             color: var(--table-hover-text);
         }}
-        .table-wrapper tbody tr:hover td:first-child {{
+        .table-wrap tbody tr:hover td:first-child {{
             background-color: var(--table-hover);
             z-index: 1;
         }}
@@ -307,18 +296,9 @@ def setup_page(*, table_hover: str = "#2563eb", table_hover_text: str = "#ffffff
     st.markdown(
         """
         <script>
-          try { window.parent.__stickyAudit__?.(); } catch (e) {}
-        </script>
-        """,
-        unsafe_allow_html=True,
-    )
-
-    st.markdown(
-        """
-        <script>
         document.addEventListener('keydown', function(event) {
             const active = document.activeElement;
-            if (active && active.classList.contains('table-wrapper')) {
+            if (active && active.classList.contains('table-wrap')) {
                 const scrollAmount = 40;
                 if (event.key === 'ArrowRight') {
                     active.scrollLeft += scrollAmount;

--- a/ui/sticky_df_helper.js
+++ b/ui/sticky_df_helper.js
@@ -1,120 +1,143 @@
-// Sticky DataFrame/Table helper – runs in the PARENT page
-(function (PWIN) {
-  try {
-    const TOP = PWIN;
-    const log = (...a) => { try { TOP.console.log(...a); } catch {} };
+/*!  
+ * sticky_df_helper.js
+ * Makes HTML/Pandas/Streamlit tables have sticky headers (and optional sticky first column).
+ * Safe to include multiple times; it self-guards and re-applies to dynamic tables.
+ */
+(function StickyDFHelper () {
+  const STYLE_ID = '__sticky_df_css__';
+  const WRAP_CLASS = 'table-wrap';
+  const TABLE_CLASS = 'sticky-table';
+  const FIRST_COL_STICKY = false; // <- set true if you also want the first column sticky
 
-    // --- CSS per-document ---
-    function ensureCSS(doc) {
-      const id = '__sticky_css__';
-      if (doc.getElementById(id)) return;
-      const s = doc.createElement('style'); s.id = id;
-      s.textContent = `
-        .sticky-scroll { position: relative !important; overflow: auto !important; z-index: 0; }
-        .sticky-scroll thead th, .sticky-scroll thead td, [role="columnheader"] {
-          position: sticky !important; top: 0 !important; z-index: 6 !important;
-          backdrop-filter: saturate(140%);
-        }
-      `;
-      doc.head && doc.head.appendChild(s);
+  // ---------- CSS injection ----------
+  function injectCSS(doc) {
+    if (!doc || doc.getElementById(STYLE_ID)) return;
+
+    const css = `
+    /* Scroll container */
+    .${WRAP_CLASS} { max-height: 72vh; overflow: auto; }
+
+    /* Ensure sticky works reliably with borders */
+    .${WRAP_CLASS} table { border-collapse: separate !important; border-spacing: 0 !important; }
+
+    /* Sticky header cells */
+    .${WRAP_CLASS} thead th {
+      position: sticky; top: 0; z-index: 10;
+      background: #374151 !important; /* Tailwind gray-700 to match UI */
+      background-clip: padding-box;
     }
 
-    // --- find first scrolling/clipping ancestor in the element's own context ---
-    function findScrollNode(el) {
-      const DOC = el?.ownerDocument;
-      const WIN = DOC?.defaultView || TOP;
-      if (!DOC) return null;
-      const isClip = (e) => {
-        const cs = WIN.getComputedStyle(e);
-        return /(auto|scroll|hidden)/.test(cs.overflowY) || /(auto|scroll|hidden)/.test(cs.overflow);
-      };
-      let n = el.parentElement;
-      while (n && n !== DOC.documentElement) {
-        if (isClip(n)) return n;
-        n = n.parentElement;
+    /* Optional: sticky first column */
+    ${FIRST_COL_STICKY ? `
+    .${WRAP_CLASS} tbody td:first-child, .${WRAP_CLASS} thead th:first-child { position: sticky; left: 0; }
+    .${WRAP_CLASS} tbody td:first-child { z-index: 5; }
+    .${WRAP_CLASS} thead th:first-child { z-index: 11; }
+    ` : ''}
+
+    /* Prevent clipping of sticky layers when nested in flex/grid containers */
+    .${WRAP_CLASS}, .${WRAP_CLASS} * { overflow: visible; }
+    `.trim();
+
+    const style = doc.createElement('style');
+    style.id = STYLE_ID;
+    style.textContent = css;
+    doc.head && doc.head.appendChild(style);
+  }
+
+  // ---------- DOM utils ----------
+  function isWrapped(table) {
+    return table && table.parentElement && table.parentElement.classList.contains(WRAP_CLASS);
+  }
+
+  function wrapTable(table, doc) {
+    if (!table || isWrapped(table)) return;
+
+    const wrapper = doc.createElement('div');
+    wrapper.className = WRAP_CLASS;
+
+    // Keep current size to avoid layout jumps
+    const rect = table.getBoundingClientRect();
+    if (rect.width) wrapper.style.width = rect.width + 'px';
+
+    table.parentNode.insertBefore(wrapper, table);
+    wrapper.appendChild(table);
+  }
+
+  // Heuristic: which tables should we enhance?
+  function isEnhanceableTable(table) {
+    if (!(table instanceof HTMLTableElement)) return false;
+    if (table.classList.contains(TABLE_CLASS)) return false; // already processed
+    const hasThead = !!table.querySelector('thead');
+    const hasTh = !!table.querySelector('thead th');
+    const rows = table.querySelectorAll('tbody tr').length;
+    return hasThead && hasTh && rows >= 2;
+  }
+
+  function enhanceTable(table, doc) {
+    if (!isEnhanceableTable(table)) return;
+    wrapTable(table, doc);
+    table.classList.add(TABLE_CLASS);
+  }
+
+  function enhanceAllTables(doc) {
+    injectCSS(doc);
+    const tables = doc.querySelectorAll('table');
+    tables.forEach(t => enhanceTable(t, doc));
+  }
+
+  // ---------- Mutation observer for dynamic tables ----------
+  function observe(doc) {
+    if (!doc || doc.__sticky_df_observing__) return;
+    doc.__sticky_df_observing__ = true;
+
+    const obs = new MutationObserver(mutations => {
+      for (const m of mutations) {
+        m.addedNodes.forEach(node => {
+          if (node instanceof HTMLTableElement) {
+            enhanceTable(node, doc);
+          } else if (node instanceof HTMLElement) {
+            node.querySelectorAll && node.querySelectorAll('table').forEach(t => enhanceTable(t, doc));
+          }
+        });
       }
-      return null;
-    }
+    });
 
-    // --- auditors ---
-    function auditTable(tbl) {
-      const DOC = tbl.ownerDocument, WIN = DOC.defaultView;
-      const wrap = findScrollNode(tbl) || tbl;
-      wrap.classList.add('sticky-scroll');
-      if (WIN.getComputedStyle(wrap).position === 'static') wrap.style.position = 'relative';
-      if (!/auto|scroll/.test(WIN.getComputedStyle(wrap).overflow + WIN.getComputedStyle(wrap).overflowY)) {
-        wrap.style.overflow = 'auto';
+    obs.observe(doc.body || doc, { childList: true, subtree: true });
+    doc.__sticky_df_observer__ = obs;
+  }
+
+  // ---------- Same-origin iframe support (e.g., Streamlit) ----------
+  function enhanceSameOriginIframes(rootDoc) {
+    const iframes = rootDoc.querySelectorAll('iframe');
+    iframes.forEach(ifr => {
+      try {
+        const doc = ifr.contentDocument;
+        if (!doc) return;
+        enhanceAllTables(doc);
+        observe(doc);
+      } catch (_e) {
+        // Cross-origin; skip silently
       }
-      tbl.querySelectorAll('thead th, thead td').forEach((h) => {
-        const bg = WIN.getComputedStyle(h).backgroundColor;
-        h.style.position = 'sticky'; h.style.top = '0px'; h.style.zIndex = '6';
-        h.style.background = (bg === 'rgba(0, 0, 0, 0)' ? '#101425' : bg);
-      });
-      return 1;
-    }
+    });
+  }
 
-    function auditStreamlitDF(root) {
-      const DOC = root.ownerDocument, WIN = DOC.defaultView;
-      const headers = root.querySelectorAll('[role="columnheader"]');
-      if (!headers.length) return 0;
-      const wrap = findScrollNode(root) || root;
-      wrap.classList.add('sticky-scroll');
-      if (WIN.getComputedStyle(wrap).position === 'static') wrap.style.position = 'relative';
-      if (!/auto|scroll/.test(WIN.getComputedStyle(wrap).overflow + WIN.getComputedStyle(wrap).overflowY)) {
-        wrap.style.overflow = 'auto';
-      }
-      headers.forEach((h) => {
-        const bg = WIN.getComputedStyle(h).backgroundColor;
-        h.style.position = 'sticky'; h.style.top = '0px'; h.style.zIndex = '6';
-        h.style.background = (bg === 'rgba(0, 0, 0, 0)' ? '#101425' : bg);
-      });
-      return 1;
-    }
+  // ---------- Public init (idempotent) ----------
+  function init(doc) {
+    const d = doc || document;
+    injectCSS(d);
+    enhanceAllTables(d);
+    observe(d);
+    enhanceSameOriginIframes(d);
+  }
 
-    // --- per-document driver ---
-    function applyInDoc(DOC, WIN) {
-      ensureCSS(DOC);
+  // Auto-run on current document
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => init(document), { once: true });
+  } else {
+    init(document);
+  }
 
-      let count = 0;
-
-      // 1) regular tables
-      DOC.querySelectorAll('table.dark-table, .table-wrapper table, table').forEach(t => { count += auditTable(t) });
-
-      // 2) virtualized Streamlit DFs
-      DOC.querySelectorAll('div[data-testid="stDataFrame"]').forEach(r => { count += auditStreamlitDF(r) });
-
-      return count;
-    }
-
-    // --- top-level driver: walk same-origin iframes as well ---
-    function apply() {
-      let total = 0;
-      total += applyInDoc(document, window);
-
-      document.querySelectorAll('iframe').forEach((ifr, i) => {
-        try {
-          const d = ifr.contentDocument, w = ifr.contentWindow;
-          if (d && w) total += applyInDoc(d, w);
-        } catch { /* cross-origin, ignore */ }
-      });
-
-      log('[sticky] total processed roots:', total);
-      return total;
-    }
-
-    // MutationObserver (debounced)
-    if (!PWIN.__stickyObserver__) {
-      PWIN.__stickyObserver__ = new PWIN.MutationObserver(() => {
-        clearTimeout(PWIN.__stickyPending__);
-        PWIN.__stickyPending__ = PWIN.setTimeout(apply, 80);
-      });
-      PWIN.__stickyObserver__.observe(document.documentElement, { childList: true, subtree: true });
-    }
-
-    // Expose manual hook + initial run
-    PWIN.__stickyAudit__ = apply;
-    if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', apply, { once: true });
-    apply();
-  } catch (e) { try { console.log('[sticky] crashed:', e); } catch {} }
-})(window.parent || window);
+  // Expose minimal API (optional)
+  window.StickyDF = { init, version: '1.0.0' };
+})();
 


### PR DESCRIPTION
## Summary
- add helper to auto-wrap tables and inject sticky header CSS
- observe DOM and iframes to reapply sticky behavior dynamically
- include helper and update layout to use new table wrapper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b9e4ddc9948332bd87f7c1b6e77125