### PR TITLE
Ensure empty-history schema and harden smoke install

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -18,14 +18,29 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-      - name: Install deps
+      - name: Install deps (wheel-first with retries)
+        env:
+          PIP_DISABLE_PIP_VERSION_CHECK: "1"
+          PIP_DEFAULT_TIMEOUT: "60"
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt || {
-            echo "First install failed, retrying once…"
-            pip install pandas==2.2.3
-            pip install -r requirements.txt
-          }
+          python -m pip install -U pip
+          set -e
+          tries=3
+          for i in $(seq 1 $tries); do
+            echo "Attempt $i/$tries: installing requirements"
+            if pip install --only-binary=:all: -r requirements.txt; then
+              break
+            fi
+            echo "Wheel-only failed, falling back to normal resolver"
+            if pip install -r requirements.txt; then
+              break
+            fi
+            if [ "$i" -eq "$tries" ]; then
+              echo "Dependency install failed after $tries attempts"
+              exit 1
+            fi
+            sleep 5
+          done
       - name: Import smoke
         run: |
           python - <<'PY'


### PR DESCRIPTION
## Summary
- maintain uniform schema with a datetime `date` column even when history is empty
- add wheel-first dependency install with retries in smoke CI

## Testing
- `pip install -r requirements.txt` *(failed: Could not find a version that satisfies the requirement pandas==2.2.3)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb130a105883329079039dea4f65de