### PR TITLE
Use relaxed dependency set for smoke CI

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -18,32 +18,16 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-      - name: Install deps (wheel-first with retries)
-        env:
-          PIP_DISABLE_PIP_VERSION_CHECK: "1"
-          PIP_DEFAULT_TIMEOUT: "60"
+      - name: Install minimal deps (smoke)
         run: |
-          python -m pip install -U pip
-          set -e
-          tries=3
-          for i in $(seq 1 $tries); do
-            echo "Attempt $i/$tries: installing requirements"
-            if pip install --only-binary=:all: -r requirements.txt; then
-              break
-            fi
-            echo "Wheel-only failed, falling back to normal resolver"
-            if pip install -r requirements.txt; then
-              break
-            fi
-            if [ "$i" -eq "$tries" ]; then
-              echo "Dependency install failed after $tries attempts"
-              exit 1
-            fi
-            sleep 5
+          python -m pip install --upgrade pip
+          for i in 1 2 3; do
+            pip install --only-binary=:all: -r requirements-smoke.txt && break || sleep 5
           done
-      - name: Import smoke
+      - name: Import check
         run: |
           python - <<'PY'
           import streamlit, yfinance, pandas, numpy, pyarrow, bs4, lxml, requests
+          import data_lake.ingest, data_lake.membership, data_lake.storage, data_lake.provider
           print("ok")
           PY

--- a/requirements-smoke.txt
+++ b/requirements-smoke.txt
@@ -1,0 +1,9 @@
+# minimal, relaxed deps just for smoke CI
+pandas>=2.2,<2.3
+numpy>=1.26,<2.1
+pyarrow>=14,<18
+yfinance>=0.2.40,<0.3
+streamlit>=1.33,<1.40
+beautifulsoup4>=4.12
+lxml>=4.9
+requests>=2.31


### PR DESCRIPTION
## Summary
- add a minimal `requirements-smoke.txt` for the smoke workflow
- install relaxed dependencies with retries and verify imports

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pandas==2.2.3)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb15797a2c83328f5e7a0b31cdda45