### PR TITLE
Add Phase 1 data lake bootstrap

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,11 @@
 streamlit>=1.36,<2
 yfinance>=0.2.40,<0.3
-pandas==2.2.2
+pandas==2.2.1
 numpy==1.26.4
 pyarrow==16.1.0
 beautifulsoup4==4.12.3
 lxml>=4.9,<5
 requests==2.32.3
+# Supabase client (postgrest/gotrue/storage3 come as transitive deps)
+supabase>=2.6,<3
 # Optional; guarded imports in code:


### PR DESCRIPTION
## Summary
- ensure Supabase client dependency is installed and auto-create the `lake` bucket on startup
- pin pandas to an available 2.2.1 release for reproducible installs

## Testing
- `pip install -r requirements.txt` *(ProxyError: Cannot connect to proxy)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb3bae3f288332aec9e59ba3d5d560