### PR TITLE
fix: handle Supabase list_buckets APIResponse

### DIFF
--- a/data_lake/storage.py
+++ b/data_lake/storage.py
@@ -35,7 +35,12 @@ class Storage:
             self.client = create_client(url, key)
             # Ensure a public bucket named 'lake' exists; create if missing.
             try:
-                names = {b.get("name") for b in self.client.storage.list_buckets() or []}
+                resp = self.client.storage.list_buckets()
+                data = getattr(resp, "data", None) or []
+                names = {
+                    (getattr(b, "name", None) or (b.get("name") if isinstance(b, dict) else None))
+                    for b in data
+                }
                 if "lake" not in names:
                     self.client.storage.create_bucket("lake", public=True)
             except Exception:


### PR DESCRIPTION
## Summary
- normalize Supabase `list_buckets` response and ensure `lake` bucket creation

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pandas==2.2.1; Cannot connect to proxy)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb3f405f688332b6bd43be199c115f