### PR TITLE
Add Phase 1 data lake bootstrap

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,7 +10,8 @@ from ui.debugger import render_debugger_tab
 
 # Dynamically import the data lake tab from ui/pages/90_Data_Lake_Phase1.py
 _spec = importlib.util.spec_from_file_location(
-    "ui.pages.data_lake_phase1", Path("ui/pages/90_Data_Lake_Phase1.py")
+    "ui.pages.data_lake_phase1",
+    Path(__file__).with_name("ui") / "pages" / "90_Data_Lake_Phase1.py",
 )
 _module = importlib.util.module_from_spec(_spec)
 assert _spec and _spec.loader


### PR DESCRIPTION
## Summary
- sanitize membership change dates to ignore footnotes and fall back to separate year/month/day columns
- load data lake tab via a path relative to `app.py` so it works regardless of the current working directory

## Testing
- `pip install -r requirements.txt`
- `pip install pandas_market_calendars` *(fails: Could not find a version that satisfies the requirement pandas_market_calendars)*
- `pytest` *(ModuleNotFoundError: No module named 'pandas_market_calendars')*


------
https://chatgpt.com/codex/tasks/task_e_68bb527fefa08332b5c28e77159ce4a1