### PR TITLE
Add Phase 1 data lake bootstrap

### DIFF
--- a/tests/test_market_calendar.py
+++ b/tests/test_market_calendar.py
@@ -1,0 +1,11 @@
+from utils import market_calendar as mc
+
+
+def test_trading_days_between_excludes_weekend():
+    days = mc.trading_days_between("2024-07-05", "2024-07-08")
+    assert [d.strftime("%Y-%m-%d") for d in days] == ["2024-07-05", "2024-07-08"]
+
+
+def test_is_trading_day_handles_weekend():
+    assert mc.is_trading_day("2024-07-05")
+    assert not mc.is_trading_day("2024-07-06")

--- a/tests/test_nyse_calendar.py
+++ b/tests/test_nyse_calendar.py
@@ -2,7 +2,10 @@ import sys
 from datetime import date
 from pathlib import Path
 
-import pandas_market_calendars as mcal
+try:  # pragma: no cover - optional dependency
+    import pandas_market_calendars as mcal  # type: ignore
+except Exception:  # pragma: no cover - library missing
+    mcal = None
 import pytest
 
 ROOT = Path(__file__).resolve().parents[1]

--- a/utils/market_calendar.py
+++ b/utils/market_calendar.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+"""Trading day utilities with optional market calendar support."""
+
+import pandas as pd
+
+try:  # pragma: no cover - optional dependency
+    import pandas_market_calendars as mcal  # type: ignore
+except Exception:  # pragma: no cover - library missing
+    mcal = None
+
+
+def trading_days_between(start, end, tz: str = "America/New_York") -> pd.DatetimeIndex:
+    """Return trading days between ``start`` and ``end`` in timezone ``tz``."""
+    if mcal:
+        cal = mcal.get_calendar("XNYS")
+        sched = cal.schedule(start_date=start, end_date=end)
+        return pd.DatetimeIndex(sched.index.tz_convert(tz).normalize().unique())
+    return pd.bdate_range(start=start, end=end, tz=tz)
+
+
+def is_trading_day(ts, tz: str = "America/New_York") -> bool:
+    """Return ``True`` if ``ts`` falls on a trading day in timezone ``tz``."""
+    days = trading_days_between(
+        pd.Timestamp(ts, tz=tz).date(),
+        pd.Timestamp(ts, tz=tz).date(),
+        tz=tz,
+    )
+    return len(days) > 0


### PR DESCRIPTION
## Summary
- add market_calendar utility with optional pandas_market_calendars import and Mon–Fri fallback
- guard pandas_market_calendars import in nyse calendar tests and add coverage for wrapper

## Testing
- `pip install -r requirements.txt`
- `python -c "import streamlit, yfinance, pandas, numpy, pyarrow, bs4, lxml, requests; print('deps-ok')"`
- `python - <<'PY'
import streamlit, yfinance, pandas, numpy, pyarrow, bs4, lxml, requests
import data_lake.ingest, data_lake.membership, data_lake.storage, data_lake.provider
print("ok")
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb5c3e07fc8332ba0c895dae5d1ec5