### PR TITLE
Stabilize Phase-1 build & cloud deploy

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -41,7 +41,7 @@ jobs:
           if [ "$ok" -ne 1 ]; then
             echo "Dependency install failed after $tries attempts"; exit 1
           fi
-          python -c "import streamlit, yfinance, pandas, numpy, pyarrow, bs4, lxml, requests; print('deps-ok')"
+          python -c "import streamlit, yfinance, pandas, numpy, pyarrow, bs4, lxml, requests; print('ok')"
       - name: Import check
         run: |
           python - <<'PY'

--- a/data_lake/membership.py
+++ b/data_lake/membership.py
@@ -131,34 +131,15 @@ def build_membership(storage: Storage) -> str:
     date_candidates = [c for c, s in norm.items() if "date" in s]
     if not date_candidates:
         raise RuntimeError("membership 'changes' table missing a Date column")
-    if len(date_candidates) > 1:
-        # unify by taking the first non-null across date-like columns
-        changes["Date"] = changes[date_candidates].bfill(axis=1).iloc[:, 0]
-    else:
-        if date_candidates[0] != "Date":
-            changes = changes.rename(columns={date_candidates[0]: "Date"})
-    added_candidates = [c for c, s in norm.items() if "add" in s]
-    removed_candidates = [c for c, s in norm.items() if "remov" in s]
-    if not added_candidates or not removed_candidates:
-        raise RuntimeError(
-            "membership 'changes' table missing Added/Removed-like columns"
-        )
-    added_col, removed_col = added_candidates[0], removed_candidates[0]
-    changes = changes.rename(columns={added_col: "Added", removed_col: "Removed"})[
-        ["Date", "Added", "Removed"]
-    ]
-    # Build a single 'Date' series even if there are duplicate date-like columns
-    date_like = changes.loc[
-        :,
-        [c for c in changes.columns if re.search(r"(?<![a-z])date(?![a-z])", str(c).lower())]
-    ]
-    if date_like.shape[1] == 0:
-        raise RuntimeError("membership 'changes' table missing a Date column")
-    cleaned = date_like.apply(
-        lambda s: s.astype(str).str.replace(r"\[.*?\]", "", regex=True).str.strip()
+    cleaned = (
+        changes[date_candidates]
+        .apply(lambda s: s.astype(str).str.replace(r"\[.*?\]", "", regex=True).str.strip())
     )
     date_series = cleaned.bfill(axis=1).iloc[:, 0]
-    changes["Date"] = pd.to_datetime(date_series, errors="coerce", infer_datetime_format=True)
+    changes = changes.drop(columns=date_candidates)
+    changes["Date"] = pd.to_datetime(
+        date_series, errors="coerce", infer_datetime_format=True
+    )
     if changes["Date"].isna().all():
         # Fallback: separate year/month/day columns if present
         norm_cols = {c: re.sub(r"\s+", " ", str(c)).strip().lower() for c in changes.columns}
@@ -171,6 +152,16 @@ def build_membership(storage: Storage) -> str:
                 errors="coerce",
             )
     changes = changes.dropna(subset=["Date"])
+    added_candidates = [c for c, s in norm.items() if "add" in s]
+    removed_candidates = [c for c, s in norm.items() if "remov" in s]
+    if not added_candidates or not removed_candidates:
+        raise RuntimeError(
+            "membership 'changes' table missing Added/Removed-like columns"
+        )
+    added_col, removed_col = added_candidates[0], removed_candidates[0]
+    changes = changes.rename(columns={added_col: "Added", removed_col: "Removed"})[
+        ["Date", "Added", "Removed"]
+    ]
     records: List[dict] = []
     for _, row in changes.iterrows():
         d = row["Date"].date()

--- a/data_lake/provider.py
+++ b/data_lake/provider.py
@@ -23,14 +23,18 @@ def get_daily_adjusted(
     if df.empty:
         df = pd.DataFrame(
             {
-                "Open": pd.Series(dtype="float64"),
-                "High": pd.Series(dtype="float64"),
-                "Low": pd.Series(dtype="float64"),
-                "Close": pd.Series(dtype="float64"),
-                "Adj Close": pd.Series(dtype="float64"),
-                "Volume": pd.Series(dtype="int64"),
+                "date": pd.Series(dtype="datetime64[ns]"),
+                "open": pd.Series(dtype="float64"),
+                "high": pd.Series(dtype="float64"),
+                "low": pd.Series(dtype="float64"),
+                "close": pd.Series(dtype="float64"),
+                "adj_close": pd.Series(dtype="float64"),
+                "volume": pd.Series(dtype="int64"),
+                "ticker": pd.Series(dtype="object"),
             }
         )
+        df["ticker"] = ticker
+        return df[["date", "open", "high", "low", "close", "adj_close", "volume", "ticker"]]
     df = df.reset_index()
     if "Date" in df.columns:
         df = df.rename(columns={"Date": "date"})

--- a/requirements-smoke.txt
+++ b/requirements-smoke.txt
@@ -1,9 +1,9 @@
 # minimal, relaxed deps just for smoke CI
 pandas>=2.2,<2.3
-numpy>=1.26,<2.1
-pyarrow>=14,<18
+numpy>=1.26,<1.27
+pyarrow>=16,<17
 yfinance>=0.2.40,<0.3
 streamlit>=1.33,<1.40
 beautifulsoup4>=4.12
-lxml>=4.9
+lxml>=4.9,<5
 requests>=2.31

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,3 @@ lxml>=4.9,<5
 requests==2.32.3
 # Supabase client (postgrest/gotrue/storage3 come as transitive deps)
 supabase>=2.6,<3
-# Optional; guarded imports in code:

--- a/tests/test_nyse_calendar.py
+++ b/tests/test_nyse_calendar.py
@@ -3,8 +3,7 @@ from datetime import date
 from pathlib import Path
 
 import pytest
-pytest.importorskip("pandas_market_calendars", reason="optional dependency")
-import pandas_market_calendars as mcal  # type: ignore
+mcal = pytest.importorskip("pandas_market_calendars", reason="optional")
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
@@ -13,14 +12,12 @@ if str(ROOT) not in sys.path:
 from utils import nyse_calendar
 
 
-@pytest.mark.skipif(mcal is None, reason="pandas_market_calendars not installed")
 def test_compute_year_has_known_holidays():
     hols = nyse_calendar._compute_year(2024)
     assert "2024-07-04" in hols
     assert "2024-12-25" in hols
 
 
-@pytest.mark.skipif(mcal is None, reason="pandas_market_calendars not installed")
 def test_previous_trading_day_across_holidays(monkeypatch, tmp_path):
     cache_file = tmp_path / "nyse_holidays_cache.json"
     override_file = tmp_path / "nyse_holidays_override.json"


### PR DESCRIPTION
## Summary
- Harden storage layer to auto-create Supabase `lake` bucket and surface diagnostics
- Handle empty price fetches gracefully and expose diagnostics UI with error handling
- Simplify optional calendar test and relax smoke-test dependencies
- Consolidate membership date parsing to drop duplicate columns and avoid ambiguous Series errors

## Testing
- `pytest -q`
- `python - <<'PY'
from data_lake.membership import build_membership
from data_lake.storage import Storage
st = Storage()
try:
    build_membership(st)
except Exception as e:
    print(e)
PY` *(fails: HTTPSConnectionPool(host='en.wikipedia.org', port=443): Max retries exceeded with url: /wiki/List_of_S%26P_500_companies (Caused by ProxyError('Unable to connect to proxy', OSError('Tunnel connection failed: 403 Forbidden'))))*


------
https://chatgpt.com/codex/tasks/task_e_68bb8ae5cba883328a57bcc38621cbad