### PR TITLE
Stabilize Phase-1 build & cloud deploy

### DIFF
--- a/data_lake/membership.py
+++ b/data_lake/membership.py
@@ -151,6 +151,8 @@ def build_membership(storage: Storage) -> str:
                 {"year": changes[y], "month": changes[m], "day": changes[d]},
                 errors="coerce",
             )
+    if "Date" not in changes.columns:
+        raise RuntimeError("membership 'changes' table missing a parsable Date column")
     changes = changes.dropna(subset=["Date"])
     added_candidates = [c for c, s in norm.items() if "add" in s]
     removed_candidates = [c for c, s in norm.items() if "remov" in s]


### PR DESCRIPTION
## Summary
- fall back to SUPABASE_URL/KEY environment variables when Streamlit secrets are absent
- guard membership build when Date column missing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb9ad3ca308332b6d34f1efefc3f76