### PR TITLE
fix: normalize membership change fields

### DIFF
--- a/data_lake/storage.py
+++ b/data_lake/storage.py
@@ -62,7 +62,12 @@ class Storage:
 
     def write_bytes(self, path: str, data: bytes) -> str:
         if self.mode == "supabase":
-            self.bucket.upload(path, io.BytesIO(data), {"upsert": True})
+            import tempfile
+
+            with tempfile.NamedTemporaryFile() as tmp:
+                tmp.write(data)
+                tmp.flush()
+                self.bucket.upload(path, tmp.name, {"upsert": True})
             return path
         p = (LOCAL_ROOT / path)
         p.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- coerce membership change Date/Added/Removed cells to scalars before processing
- upload bytes to supabase via temporary file instead of file-like object

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bba2cd93448332a65b78be111a6b3d