### PR TITLE
Improve Supabase storage key handling and diagnostics

### DIFF
--- a/data_lake/storage.py
+++ b/data_lake/storage.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import os, io, json, pathlib, tempfile
+import os, io, json, base64, pathlib, tempfile
 from typing import Optional, Tuple
 
 try:
@@ -26,39 +26,67 @@ def _supabase_creds() -> Optional[Tuple[str, str]]:
     return None
 
 
+def _classify_key(k: str) -> str:
+    """Classify the Supabase key and validate header and payload structure."""
+    if not k:
+        return "missing"
+    if k.startswith("sb_"):
+        return "publishable"
+    parts = k.split(".")
+    if len(parts) != 3:
+        return "not_jwt"
+
+    def _b64json(segment: str) -> dict:
+        padded = segment + "=" * (-len(segment) % 4)
+        return json.loads(base64.urlsafe_b64decode(padded).decode())
+
+    try:
+        _b64json(parts[0])  # validate header
+        payload = _b64json(parts[1])
+        return str(payload.get("role", "unknown"))
+    except Exception:
+        return "invalid_jwt"
+
+
 class Storage:
     def __init__(self) -> None:
         creds = _supabase_creds()
+        key = creds[1] if creds else ""
+        self.key_role = _classify_key(key)
         self.creds_present = bool(creds)
+        self.error: Optional[str] = None
         self.mode: StorageMode = "supabase" if (create_client and creds) else "local"
         self.bucket_exists = False
         if self.mode == "supabase":
-            url, key = creds  # type: ignore
-            self.client = create_client(url, key)
-            # Ensure a public bucket named 'lake' exists; create if missing.
-            try:
-                resp = self.client.storage.list_buckets()
-                data = getattr(resp, "data", None) or []
-                names = {
-                    (getattr(b, "name", None) or (b.get("name") if isinstance(b, dict) else None))
-                    for b in data
-                }
-                self.bucket_exists = "lake" in names
-                if not self.bucket_exists:
-                    self.client.storage.create_bucket("lake", public=True)
-                    self.bucket_exists = True
-            except Exception:
-                # Ignore errors from older SDKs or insufficient permissions
-                self.bucket_exists = False
-            self.bucket = self.client.storage.from_("lake")
+            if self.key_role not in {"service_role", "anon"}:
+                self.error = f"invalid key role: {self.key_role}"
+                self.mode = "local"
+                LOCAL_ROOT.mkdir(parents=True, exist_ok=True)
+            else:
+                url = creds[0]  # type: ignore
+                self.client = create_client(url, key)
+                # Ensure a public bucket named 'lake' exists; create if missing.
+                try:
+                    resp = self.client.storage.list_buckets()
+                    data = resp.data or []
+                    names = {b.name for b in data}
+                    self.bucket_exists = "lake" in names
+                    if not self.bucket_exists:
+                        self.client.storage.create_bucket("lake", public=True)
+                        self.bucket_exists = True
+                except Exception:
+                    # Ignore errors from older SDKs or insufficient permissions
+                    self.bucket_exists = False
+                self.bucket = self.client.storage.from_("lake")
         else:
             LOCAL_ROOT.mkdir(parents=True, exist_ok=True)
 
     def info(self) -> str:
-        bucket_status = "n/a"
+        info = f"storage: {self.mode} (key:{self.key_role})"
         if self.mode == "supabase":
             bucket_status = "ok" if self.bucket_exists else "missing"
-        return f"storage: {self.mode} (bucket: {bucket_status})"
+            info += f" (bucket:{bucket_status})"
+        return info
 
     def write_bytes(self, path: str, data: bytes) -> str:
         if self.mode == "supabase":
@@ -66,7 +94,7 @@ class Storage:
             opts = {
                 "cache-control": "3600",
                 "content-type": "application/octet-stream",
-                "upsert": "true",
+                "x-upsert": "true",
             }
             # Upload via temp file path (API accepts str path or file-like)
             tmp = tempfile.NamedTemporaryFile(delete=False)

--- a/tests/test_storage_key.py
+++ b/tests/test_storage_key.py
@@ -1,0 +1,31 @@
+from data_lake.storage import _classify_key
+import base64, json
+
+
+def _b64(data: dict) -> str:
+    return base64.urlsafe_b64encode(json.dumps(data).encode()).decode().rstrip("=")
+
+
+def make_jwt(role: str) -> str:
+    header = _b64({"alg": "HS256"})
+    payload = _b64({"role": role})
+    return f"{header}.{payload}.sig"
+
+def test_classify_service_role():
+    token = make_jwt("service_role")
+    assert _classify_key(token) == "service_role"
+
+def test_classify_publishable():
+    assert _classify_key("sb_test") == "publishable"
+
+def test_classify_not_jwt():
+    assert _classify_key("notajwt") == "not_jwt"
+
+def test_classify_invalid_jwt():
+    assert _classify_key("a.b.c") == "invalid_jwt"
+
+
+def test_classify_invalid_header():
+    payload = base64.urlsafe_b64encode(json.dumps({"role": "service_role"}).encode()).decode().rstrip("=")
+    token = f"x.{payload}.y"  # invalid header segment
+    assert _classify_key(token) == "invalid_jwt"

--- a/ui/pages/90_Data_Lake_Phase1.py
+++ b/ui/pages/90_Data_Lake_Phase1.py
@@ -16,6 +16,15 @@ def render_data_lake_tab() -> None:
     st.subheader("Data Lake (Phase 1)")
     storage = Storage()
     st.info(storage.info())
+    if storage.mode == "local" and storage.key_role in {
+        "publishable",
+        "not_jwt",
+        "invalid_jwt",
+    }:
+        st.error(
+            "Supabase key is not a JWT. Use Legacy → service_role (or anon with policies)."
+        )
+        return
     if storage.mode == "local":
         st.caption("Using local .lake/ fallback")
     with st.expander("Diagnostics"):


### PR DESCRIPTION
## Summary
- Add `_classify_key` helper and track key role and bucket status in storage diagnostics
- Use `x-upsert` header for Supabase uploads and fall back to local when key is invalid
- Surface key issues in Data Lake UI and add unit tests for key classification
- Validate JWT header in key classifier to reject malformed tokens

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbb7d170fc8332a0b1cb7da3d0be51