### PR TITLE
Handle dict responses from list_buckets

### DIFF
--- a/data_lake/storage.py
+++ b/data_lake/storage.py
@@ -69,7 +69,11 @@ class Storage:
                 try:
                     resp = self.client.storage.list_buckets()
                     data = resp.data or []
-                    names = {b.name for b in data}
+                    names = set()
+                    for b in data:
+                        name = b.get("name") if isinstance(b, dict) else getattr(b, "name", None)
+                        if name:
+                            names.add(name)
                     self.bucket_exists = "lake" in names
                     if not self.bucket_exists:
                         self.client.storage.create_bucket("lake", public=True)

--- a/tests/test_storage_buckets.py
+++ b/tests/test_storage_buckets.py
@@ -1,0 +1,41 @@
+import pytest
+from types import SimpleNamespace
+
+from data_lake.storage import Storage
+
+
+def make_storage(monkeypatch, buckets):
+    """Create a Storage instance with a fake Supabase client."""
+    import data_lake.storage as storage
+
+    class FakeAPI:
+        def __init__(self, buckets):
+            self._buckets = buckets
+            self.created = False
+        def list_buckets(self):
+            return SimpleNamespace(data=self._buckets)
+        def create_bucket(self, name, public=True):
+            self.created = True
+        def from_(self, name):
+            return SimpleNamespace(name=name)
+
+    fake_client = SimpleNamespace(storage=FakeAPI(buckets))
+
+    monkeypatch.setattr(storage, "_supabase_creds", lambda: ("url", "key"))
+    monkeypatch.setattr(storage, "_classify_key", lambda _: "service_role")
+    monkeypatch.setattr(storage, "create_client", lambda url, key: fake_client)
+
+    store = Storage()
+    return store, fake_client.storage
+
+
+def test_creates_bucket_when_missing(monkeypatch):
+    store, api = make_storage(monkeypatch, [{"name": "foo"}])
+    assert api.created is True
+    assert store.bucket_exists is True
+
+
+def test_detects_existing_bucket(monkeypatch):
+    store, api = make_storage(monkeypatch, [{"name": "lake"}])
+    assert api.created is False
+    assert store.bucket_exists is True


### PR DESCRIPTION
## Summary
- handle dictionary items returned by `list_buckets`
- test bucket creation with dict responses

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbbac7b030833282cd794eeb57959d