### PR TITLE
fix: warn on invalid Supabase keys

### DIFF
--- a/ui/pages/90_Data_Lake_Phase1.py
+++ b/ui/pages/90_Data_Lake_Phase1.py
@@ -19,11 +19,7 @@ def render_data_lake_tab() -> None:
         st.caption(storage.info())
         if st.button("Run Supabase self-test"):
             st.json(storage.selftest())
-    if storage.mode == "supabase" and storage.key_info.get("kind") in {
-        "publishable",
-        "not_jwt",
-        "invalid_jwt",
-    }:
+    if storage.key_info.get("kind") in {"publishable", "not_jwt", "invalid_jwt"}:
         st.error(
             "Supabase key is not a valid JWT (service_role/anon). Use Legacy API Keys. Skipping remote writes."
         )


### PR DESCRIPTION
## Summary
- warn and stop when Supabase key isn't service_role or anon

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc327a81ac8332b28037695f48fa86