### PR TITLE
Use string file_options for Supabase uploads

### DIFF
--- a/data_lake/storage.py
+++ b/data_lake/storage.py
@@ -104,19 +104,15 @@ class Storage:
 
     def write_bytes(self, path: str, data: bytes) -> str:
         if self.mode == "supabase":
-            # storage3 expects string header values; bools break httpx header building.
-            opts = {
-                "cache-control": "3600",
-                "content-type": "application/octet-stream",
-                "x-upsert": "true",
-            }
+            # storage3 expects string option values; bools break httpx header building.
+            file_opts = {"upsert": "true", "contentType": "application/octet-stream"}
             # Upload via temp file path (API accepts str path or file-like)
             tmp = tempfile.NamedTemporaryFile(delete=False)
             try:
                 tmp.write(data)
                 tmp.flush()
                 tmp.close()
-                self.bucket.upload(path, tmp.name, opts)
+                self.bucket.upload(path, tmp.name, file_options=file_opts)
             finally:
                 try:
                     os.unlink(tmp.name)
@@ -158,13 +154,13 @@ class Storage:
                 self.client.storage.create_bucket("lake", public=True)
                 info["created_lake"] = True
             bkt = self.client.storage.from_("lake")
-            opts = {"cache-control": "60", "content-type": "text/plain", "x-upsert": "true"}
+            file_opts = {"upsert": "true", "contentType": "text/plain"}
             tmp = tempfile.NamedTemporaryFile(delete=False)
             tmp.write(b"ping")
             tmp.flush()
             tmp.close()
             path = "diagnostics/ping.txt"
-            bkt.upload(path, tmp.name, opts)
+            bkt.upload(path, tmp.name, file_options=file_opts)
             read = bkt.download(path)
             bkt.remove([path])
             info["write_read_ok"] = read == b"ping"


### PR DESCRIPTION
## Summary
- switch Supabase uploads to use `file_options` with string values
- adjust self-test to upload with string file options

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc55dc44cc8332b0d277a998204a23