### PR TITLE
fix: use hyphenated content-type key

### DIFF
--- a/data_lake/storage.py
+++ b/data_lake/storage.py
@@ -105,7 +105,7 @@ class Storage:
     def write_bytes(self, path: str, data: bytes) -> str:
         if self.mode == "supabase":
             # storage3 expects string option values; bools break httpx header building.
-            file_opts = {"upsert": "true", "contentType": "application/octet-stream"}
+            file_opts = {"upsert": "true", "content-type": "application/octet-stream"}
             # Upload via temp file path (API accepts str path or file-like)
             tmp = tempfile.NamedTemporaryFile(delete=False)
             try:
@@ -154,7 +154,7 @@ class Storage:
                 self.client.storage.create_bucket("lake", public=True)
                 info["created_lake"] = True
             bkt = self.client.storage.from_("lake")
-            file_opts = {"upsert": "true", "contentType": "text/plain"}
+            file_opts = {"upsert": "true", "content-type": "text/plain"}
             tmp = tempfile.NamedTemporaryFile(delete=False)
             tmp.write(b"ping")
             tmp.flush()


### PR DESCRIPTION
## Summary
- use `content-type` in Supabase file options so uploaded objects retain correct MIME type

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc574974b08332b716f6f475a28cb3