### PR TITLE
Add prices coverage panel and storage prefix listing

### DIFF
--- a/data_lake/provider.py
+++ b/data_lake/provider.py
@@ -3,9 +3,14 @@
 from __future__ import annotations
 
 from datetime import date
+from typing import Iterable
 
 import pandas as pd
 import yfinance as yf
+
+from .schemas import IngestJob
+from .ingest import ingest_batch
+from .storage import Storage
 
 
 def get_daily_adjusted(
@@ -52,3 +57,19 @@ def get_daily_adjusted(
     )
     df["ticker"] = ticker
     return df[["date", "open", "high", "low", "close", "adj_close", "volume", "ticker"]]
+
+
+def ingest(
+    storage: Storage,
+    tickers: Iterable[str],
+    start: date | str = "1990-01-01",
+    end: date | None = None,
+    progress_cb=None,
+):
+    """Ingest a collection of tickers into storage."""
+    if end is None:
+        end = date.today()
+    jobs: list[IngestJob] = [
+        {"ticker": t, "start": str(start), "end": str(end)} for t in tickers
+    ]
+    return ingest_batch(storage, jobs, progress_cb=progress_cb)

--- a/data_lake/storage.py
+++ b/data_lake/storage.py
@@ -158,6 +158,31 @@ class Storage:
                 return False
         return (LOCAL_ROOT / path).exists()
 
+    def list_prefix(self, prefix: str) -> list[str]:
+        """Return flat list of object names under a prefix."""
+        if self.mode == "supabase":
+            try:
+                try:
+                    resp = self.bucket.list(prefix)
+                except TypeError:
+                    resp = self.bucket.list(path=prefix)
+                items = getattr(resp, "data", resp) or []
+                names = []
+                for it in items:
+                    if isinstance(it, dict):
+                        name = it.get("name")
+                    else:
+                        name = getattr(it, "name", None)
+                    if name:
+                        names.append(name)
+                return names
+            except Exception:
+                return []
+        base = LOCAL_ROOT / prefix
+        if not base.exists():
+            return []
+        return [p.name for p in base.iterdir() if p.is_file()]
+
     def selftest(self) -> dict:
         info = {"mode": self.mode, "key_info": self.key_info, "bucket": "lake"}
         try:


### PR DESCRIPTION
## Summary
- add `list_prefix` helper to `Storage` for listing objects under a prefix
- allow provider `ingest` to accept explicit tickers
- expose a Prices coverage panel in the Data Lake tab with option to ingest missing tickers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf0b60ef408332b863355ecb312e72