### PR TITLE
feat: add historical coverage panel and storage helpers

### DIFF
--- a/tests/test_membership_historical_tickers.py
+++ b/tests/test_membership_historical_tickers.py
@@ -1,0 +1,18 @@
+import pandas as pd
+
+from data_lake import membership
+
+
+def test_historical_tickers_union(monkeypatch):
+    df = pd.DataFrame(
+        [
+            {"ticker": "AAA", "start_date": "2000-01-01", "end_date": "2001-01-01"},
+            {"ticker": "BBB", "start_date": "2000-01-01", "end_date": None},
+            {"ticker": "AAA", "start_date": "2002-01-01", "end_date": None},
+        ]
+    )
+
+    monkeypatch.setattr(membership, "load_membership", lambda storage=None: df)
+
+    assert membership.historical_tickers() == ["AAA", "BBB"]
+


### PR DESCRIPTION
## Summary
- expose membership utilities for loading historical tickers
- harden Supabase storage bootstrap and add prefix helpers
- show price coverage scope with one-click ingest of missing symbols

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf0ddf997c8332b7fc6aa57f69aecc