### PR TITLE
Fix coverage & ingest by paginating Supabase list; stop reprocessing

### DIFF
--- a/tests/test_storage_list_all.py
+++ b/tests/test_storage_list_all.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+from data_lake import storage
+
+
+def test_list_all_local_paginates(tmp_path, monkeypatch):
+    monkeypatch.setattr(storage, "LOCAL_ROOT", tmp_path)
+    st = storage.Storage()
+    base = tmp_path / "prices"
+    base.mkdir(parents=True, exist_ok=True)
+    for i in range(150):
+        (base / f"{i}.parquet").write_text("x")
+    items = st.list_all("prices")
+    assert len(items) == 150
+    assert Path(items[-1]).suffix == ".parquet"


### PR DESCRIPTION
## Summary
- add `Storage.list_all` to page through Supabase storage listings
- use new helper in Data Lake Phase 1 UI to compute coverage and skip already-ingested tickers
- add test ensuring `list_all` returns all local files

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf303703c8833283ba5d039efdcf36