### PR TITLE
Fix coverage & ingest by paginating Supabase list; stop reprocessing

### DIFF
--- a/data_lake/storage.py
+++ b/data_lake/storage.py
@@ -170,7 +170,7 @@ class Storage:
         offset = 0
         while True:
             try:
-                batch = self.bucket.list(
+                resp = self.bucket.list(
                     prefix,
                     {
                         "limit": 1000,
@@ -179,12 +179,13 @@ class Storage:
                     },
                 )
             except TypeError:
-                batch = self.bucket.list(
+                resp = self.bucket.list(
                     path=prefix,
                     limit=1000,
                     offset=offset,
                     sortBy={"column": "name", "order": "asc"},
                 )
+            batch = getattr(resp, "data", resp) or []
             if not batch:
                 break
             items.extend(

--- a/tests/test_storage_list_all.py
+++ b/tests/test_storage_list_all.py
@@ -13,3 +13,25 @@ def test_list_all_local_paginates(tmp_path, monkeypatch):
     items = st.list_all("prices")
     assert len(items) == 150
     assert Path(items[-1]).suffix == ".parquet"
+
+
+def test_list_all_handles_apiresponse():
+    """Ensure list_all unwraps APIResponse-style results."""
+
+    st = storage.Storage()
+    st.mode = "supabase"
+
+    class APIResp:
+        def __init__(self, data):
+            self.data = data
+
+    class Bucket:
+        def list(self, *args, **kwargs):
+            return APIResp([
+                {"name": "a.parquet"},
+                {"name": "b.parquet"},
+            ])
+
+    st.bucket = Bucket()
+    items = st.list_all("prices")
+    assert items == ["prices/a.parquet", "prices/b.parquet"]


### PR DESCRIPTION
## Summary
- add `Storage.list_all` to page through Supabase storage listings
- use new helper in Data Lake Phase 1 UI to compute coverage and skip already-ingested tickers
- add test ensuring `list_all` returns all local files
- handle Supabase APIResponse in list_all pagination

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf3634601c8332b26172b6ede433a6