### PR TITLE
Add gap scanner with time-to-hit replay and engine utilities

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,22 +1,22 @@
 import importlib.util
 from pathlib import Path
-
 import streamlit as st
-
 from ui.layout import setup_page, render_header
 from ui.scan import render_scanner_tab
 from ui.history import render_history_tab
 from ui.debugger import render_debugger_tab
-
-# Dynamically import the data lake tab from ui/pages/90_Data_Lake_Phase1.py
-_spec = importlib.util.spec_from_file_location(
-    "ui.pages.data_lake_phase1",
-    Path(__file__).with_name("ui") / "pages" / "90_Data_Lake_Phase1.py",
-)
-_module = importlib.util.module_from_spec(_spec)
+# Dynamically import the data lake tab
+_spec = importlib.util.spec_from_file_location("ui.pages.data_lake_phase1", Path("ui/pages/90_Data_Lake_Phase1.py"))
+_mod = importlib.util.module_from_spec(_spec)
 assert _spec and _spec.loader
-_spec.loader.exec_module(_module)
-render_data_lake_tab = _module.render_data_lake_tab
+_spec.loader.exec_module(_mod)
+render_data_lake_tab = _mod.render_data_lake_tab
+# Dynamically import the Gap Scanner page
+_spec2 = importlib.util.spec_from_file_location("ui.pages.yday_vol_signal_open", Path("ui/pages/45_YdayVolSignal_Open.py"))
+_mod2 = importlib.util.module_from_spec(_spec2)
+assert _spec2 and _spec2.loader
+_spec2.loader.exec_module(_mod2)
+render_gap_scanner = _mod2.page
 
 # Initialize page and global layout/CSS
 setup_page()
@@ -25,18 +25,16 @@ setup_page()
 render_header()
 
 # Create tabs once with unique variable names
-tab_scanner, tab_history, tab_lake, tab_debug = st.tabs(
-    ["🔍 Scanner", "📈 History & Outcomes", "💧 Data Lake (Phase 1)", "🐞 Debugger"]
+tab_scanner, tab_gap, tab_history, tab_lake, tab_debug = st.tabs(
+    ["🔍 Scanner", "⚡ Gap Scanner", "📈 History & Outcomes", "💧 Data Lake (Phase 1)", "🐞 Debugger"]
 )
-
 with tab_scanner:
     render_scanner_tab()
-
+with tab_gap:
+    render_gap_scanner()
 with tab_history:
     render_history_tab()
-
 with tab_lake:
     render_data_lake_tab()
-
 with tab_debug:
     render_debugger_tab()

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -1,0 +1,1 @@
+# Engine package

--- a/engine/features.py
+++ b/engine/features.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+import pandas as pd
+
+
+def true_range(df: pd.DataFrame) -> pd.Series:
+    prev_close = df['close'].shift(1)
+    return pd.concat([
+        df['high'] - df['low'],
+        (df['high'] - prev_close).abs(),
+        (df['low']  - prev_close).abs()
+    ], axis=1).max(axis=1)
+
+
+def atr(df: pd.DataFrame, window: int = 21, method: str = "sma") -> pd.Series:
+    tr = true_range(df)
+    if method == "ema":
+        return tr.ewm(span=window, adjust=False, min_periods=window).mean()
+    return tr.rolling(window, min_periods=window).mean()
+
+
+def up_days_ratio(close: pd.Series, window: int = 21) -> pd.Series:
+    up = (close > close.shift(1)).astype(float)
+    return up.rolling(window, min_periods=window).mean()
+
+
+def rolling_mean(series: pd.Series, window: int) -> pd.Series:
+    return series.rolling(window, min_periods=window).mean()
+
+
+def pct_change(series: pd.Series, n: int) -> pd.Series:
+    return series.pct_change(n)
+
+
+def gap_from_prev_close(df: pd.DataFrame) -> pd.Series:
+    """(Open_t / Close_{t-1} - 1), aligned on t."""
+    return df['open'] / df['close'].shift(1) - 1

--- a/engine/replay.py
+++ b/engine/replay.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+import pandas as pd
+from typing import Sequence, Dict, Any
+
+
+def time_to_hit(
+    df: pd.DataFrame,
+    entry_ts: pd.Timestamp,
+    entry_price: float,
+    tps: Sequence[float],
+    horizon: int = 30,
+) -> Dict[str, Any]:
+    """
+    Evaluate when each TP (% gain) is first hit using next days' HIGHs
+    starting from entry date (inclusive). Returns {tp_2_days: int|None, ...}
+    """
+    out: Dict[str, Any] = {}
+    if entry_ts not in df.index:
+        return {f"tp_{int(tp*100)}_days": None for tp in tps}
+    highs = df['high'].loc[entry_ts:].iloc[:horizon]
+    for tp in tps:
+        target = entry_price * (1 + tp)
+        hit = highs[highs >= target]
+        out[f"tp_{int(tp*100)}_days"] = int((hit.index[0] - entry_ts).days) if len(hit) else None
+    return out

--- a/engine/universe.py
+++ b/engine/universe.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+import pandas as pd
+
+
+def members_on_date(members_df: pd.DataFrame, date: pd.Timestamp) -> pd.DataFrame:
+    """
+    members_df columns: ['ticker','start_date','end_date'] (strings or datetimes).
+    Return rows active on 'date'. Treat null end_date as active.
+    """
+    m = members_df.copy()
+    if m['start_date'].dtype == object:
+        m['start_date'] = pd.to_datetime(m['start_date'], errors='coerce')
+    if 'end_date' in m.columns:
+        if m['end_date'].dtype == object:
+            m['end_date'] = pd.to_datetime(m['end_date'], errors='coerce')
+    else:
+        m['end_date'] = pd.NaT
+    return m[(m['start_date'] <= date) & ((m['end_date'].isna()) | (date <= m['end_date']))]

--- a/ui/pages/45_YdayVolSignal_Open.py
+++ b/ui/pages/45_YdayVolSignal_Open.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+import io
+import pandas as pd
+import streamlit as st
+from data_lake.storage import Storage
+from engine.features import atr
+from engine.universe import members_on_date
+from engine.replay import time_to_hit
+
+
+@st.cache_data(show_spinner=False)
+def _load_members(storage: Storage) -> pd.DataFrame:
+    data = storage.read_bytes("membership/sp500_members.parquet")
+    df = pd.read_parquet(io.BytesIO(data))
+    return df
+
+
+@st.cache_data(show_spinner=False)
+def _load_prices(storage: Storage, ticker: str) -> pd.DataFrame:
+    data = storage.read_bytes(f"prices/{ticker}.parquet")
+    df = pd.read_parquet(io.BytesIO(data))
+    if 'date' in df.columns:
+        df['date'] = pd.to_datetime(df['date'], errors='coerce')
+        df = df.dropna(subset=['date']).set_index('date').sort_index()
+    else:
+        df = df.copy()
+        df.index = pd.to_datetime(df.index, errors='coerce')
+        df = df.sort_index()
+    return df
+
+
+def render_page() -> None:
+    st.subheader("⚡ Yesterday Close+Volume → Buy Next Open")
+    storage = Storage()
+    st.caption(storage.info())
+
+    # ---- Inputs ----
+    D = st.date_input("Entry day (D)", value=pd.Timestamp.today().normalize())
+    D = pd.Timestamp(D)
+    min_close_up_pct = st.number_input("Min close-up on D-1 (%)", value=3.0, step=0.5, format="%.2f") / 100.0
+    vol_window       = st.number_input("Volume lookback (sessions)", value=63, min_value=5, step=5)
+    min_vol_mult     = st.number_input(
+        "Min volume multiple (vs lookback avg)",
+        min_value=0.10, value=1.50, step=0.10, format="%.2f",
+        help="1.30 = yesterday's volume ≥ 1.30× average over the lookback window (ending on D-1)."
+    )
+    min_gap_on_open  = st.number_input("Min gap at D open vs D-1 close (%)", value=0.0, step=0.1, format="%.2f") / 100.0
+
+    st.markdown("**Optional filters (all computed as of D-1)**")
+    col1, col2, col3 = st.columns(3)
+    with col1:
+        use_atr_abs = st.checkbox("Min ATR(21) $", value=False)
+        min_atr_abs = st.number_input("ATR(21) ≥ ($)", value=0.50, step=0.10, format="%.2f") if use_atr_abs else None
+    with col2:
+        use_atr_pct = st.checkbox("Min ATR% of price", value=False)
+        min_atr_pct = st.number_input("ATR(21) ≥ (% of close)", value=0.50, step=0.10, format="%.2f")/100.0 if use_atr_pct else None
+    with col3:
+        use_ret21 = st.checkbox("Min 21-day return", value=False)
+        min_ret21 = st.number_input("Ret21 ≥ (%)", value=0.0, step=0.5, format="%.2f")/100.0 if use_ret21 else None
+
+    col4, col5 = st.columns(2)
+    with col4:
+        use_dollar_liq = st.checkbox("Min avg $ volume (20d)", value=False)
+        min_avg_dol_vol = st.number_input("Avg $ vol 20d ≥", value=10_000_000, step=1_000_000) if use_dollar_liq else None
+    with col5:
+        min_price = st.number_input("Min close price on D-1 ($)", value=5.0, step=0.5, format="%.2f")
+
+    tps = st.multiselect("TP set", options=[0.02,0.03,0.04,0.05,0.08,0.10], default=[0.02,0.04])
+    horizon = st.number_input("Horizon (days)", value=30, step=5)
+
+    if st.button("Run scan"):
+        members = _load_members(storage)
+        active = members_on_date(members, D)
+        if active.empty:
+            st.warning("No active S&P members on selected date.")
+            return
+
+        rows = []
+        tickers = active['ticker'].unique().tolist()
+        prog = st.progress(0.0, text=f"Scanning {len(tickers)} tickers…")
+
+        for i, ticker in enumerate(tickers, 1):
+            prog.progress(i/len(tickers), text=f"{i}/{len(tickers)} {ticker}")
+            try:
+                df = _load_prices(storage, ticker)
+                if D not in df.index:
+                    continue
+                s_loc = df.index.get_loc(D) - 1
+                if s_loc < 1:
+                    continue
+                S = df.index[s_loc]  # signal day = D-1
+                # --- metrics as of S ---
+                close_S      = float(df.loc[S, 'close'])
+                close_Sm1    = float(df.iloc[s_loc-1]['close'])
+                ret1d_S      = (close_S / close_Sm1) - 1.0
+                avg_vol_S    = df['volume'].rolling(int(vol_window), min_periods=int(vol_window)).mean().loc[S]
+                if pd.isna(avg_vol_S) or avg_vol_S <= 0:
+                    continue
+                vol_mult_S   = float(df.loc[S, 'volume']) / float(avg_vol_S)
+                atr21        = atr(df, 21).loc[S]
+                atr_pct_S    = (atr21 / close_S) if close_S > 0 else pd.NA
+                ret21_S      = df['close'].pct_change(21).loc[S]
+                avg_dol_20_S = (df['close']*df['volume']).rolling(20, min_periods=20).mean().loc[S]
+
+                # --- mandatory filters ---
+                if close_S < float(min_price): 
+                    continue
+                if ret1d_S < float(min_close_up_pct):
+                    continue
+                if vol_mult_S < float(min_vol_mult):
+                    continue
+
+                # --- optional filters ---
+                if use_atr_abs and (pd.isna(atr21) or atr21 < float(min_atr_abs)):
+                    continue
+                if use_atr_pct and (pd.isna(atr_pct_S) or atr_pct_S < float(min_atr_pct)):
+                    continue
+                if use_ret21 and (pd.isna(ret21_S) or ret21_S < float(min_ret21)):
+                    continue
+                if use_dollar_liq and (pd.isna(avg_dol_20_S) or avg_dol_20_S < float(min_avg_dol_vol)):
+                    continue
+
+                # --- entry at D open if gap condition passes ---
+                open_D = float(df.loc[D, 'open'])
+                if open_D < close_S * (1 + float(min_gap_on_open)):
+                    continue
+
+                hits = time_to_hit(df, D, open_D, tps, int(horizon))
+                rows.append({
+                    "ticker": ticker,
+                    "signal_day": pd.to_datetime(S).date(),
+                    "entry_day": pd.to_datetime(D).date(),
+                    "ret1d_S": ret1d_S,
+                    "vol_mult_S": vol_mult_S,
+                    "ATR21_$": float(atr21) if pd.notna(atr21) else None,
+                    "ATR21_%": float(atr_pct_S) if pd.notna(atr_pct_S) else None,
+                    "ret21_S": float(ret21_S) if pd.notna(ret21_S) else None,
+                    "avg_dollar_vol_20_S": float(avg_dol_20_S) if pd.notna(avg_dol_20_S) else None,
+                    "close_S": close_S,
+                    "open_D": open_D,
+                    **hits
+                })
+            except Exception:
+                continue
+
+        if not rows:
+            st.warning("No matches for the selected filters.")
+        else:
+            out = pd.DataFrame(rows).sort_values(["vol_mult_S","ret1d_S"], ascending=[False, False])
+            st.dataframe(out, use_container_width=True)
+            st.download_button(
+                "Download CSV",
+                out.to_csv(index=False).encode(),
+                file_name=f"yday_vol_signal_{D.date()}.csv",
+                mime="text/csv",
+            )
+
+
+def page():
+    render_page()


### PR DESCRIPTION
## Summary
- add ATR, gap, and other rolling utilities in `engine.features`
- evaluate time-to-hit targets via new `engine.replay`
- implement gap scanner Streamlit page and wire into app navigation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c031fe14a08332856849701fcc2d33