### PR TITLE
fix: cache price bytes to avoid re-download

### DIFF
--- a/ui/pages/45_YdayVolSignal_Open.py
+++ b/ui/pages/45_YdayVolSignal_Open.py
@@ -33,8 +33,14 @@ def _prices_from_bytes(ticker: str, blob: bytes) -> pd.DataFrame:
     return df
 
 
+@st.cache_data(show_spinner=False, hash_funcs={Storage: lambda _: None})
+def _price_bytes(storage: Storage, ticker: str) -> bytes:
+    """Cached download of the price parquet (keyed by ticker)."""
+    return storage.read_bytes(f"prices/{ticker}.parquet")
+
+
 def _load_prices(storage: Storage, ticker: str) -> pd.DataFrame:
-    blob = storage.read_bytes(f"prices/{ticker}.parquet")
+    blob = _price_bytes(storage, ticker)
     return _prices_from_bytes(ticker, blob)
 
 


### PR DESCRIPTION
## Summary
- cache price parquet bytes inside a cached function to avoid repeated downloads

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c03fd706e883329ced0ce88ab2f382