### PR TITLE
Fix date conversions in members_on_date and add regression test

### DIFF
--- a/engine/universe.py
+++ b/engine/universe.py
@@ -8,11 +8,12 @@ def members_on_date(members_df: pd.DataFrame, date: pd.Timestamp) -> pd.DataFram
     Return rows active on 'date'. Treat null end_date as active.
     """
     m = members_df.copy()
-    if m['start_date'].dtype == object:
-        m['start_date'] = pd.to_datetime(m['start_date'], errors='coerce')
+    m['start_date'] = pd.to_datetime(m['start_date'], errors='coerce')
     if 'end_date' in m.columns:
-        if m['end_date'].dtype == object:
-            m['end_date'] = pd.to_datetime(m['end_date'], errors='coerce')
+        m['end_date'] = pd.to_datetime(m['end_date'], errors='coerce')
     else:
         m['end_date'] = pd.NaT
-    return m[(m['start_date'] <= date) & ((m['end_date'].isna()) | (date <= m['end_date']))]
+    return m[
+        (m['start_date'] <= date)
+        & ((m['end_date'].isna()) | (date <= m['end_date']))
+    ]

--- a/tests/test_universe_members_on_date.py
+++ b/tests/test_universe_members_on_date.py
@@ -1,0 +1,19 @@
+import pandas as pd
+
+from engine.universe import members_on_date
+
+
+def test_members_on_date_string_dtype():
+    df = pd.DataFrame(
+        {
+            "ticker": ["AAA", "BBB"],
+            "start_date": pd.Series(["2020-01-01", "2020-07-01"], dtype="string"),
+            "end_date": pd.Series(["2020-06-30", pd.NA], dtype="string"),
+        }
+    )
+
+    res = members_on_date(df, pd.Timestamp("2020-05-01"))
+    assert res["ticker"].tolist() == ["AAA"]
+
+    res = members_on_date(df, pd.Timestamp("2020-08-01"))
+    assert res["ticker"].tolist() == ["BBB"]


### PR DESCRIPTION
## Summary
- ensure `members_on_date` always converts `start_date` and `end_date` to datetime
- add regression test for `members_on_date` handling of pandas string dtype

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0428671d08332b439e8157e6b495f