### PR TITLE
Add debug mode to gap scanner and helper

### DIFF
--- a/engine/universe.py
+++ b/engine/universe.py
@@ -17,3 +17,9 @@ def members_on_date(members_df: pd.DataFrame, date: pd.Timestamp) -> pd.DataFram
         (m['start_date'] <= date)
         & ((m['end_date'].isna()) | (date <= m['end_date']))
     ]
+
+
+def missing_dates(df: pd.DataFrame, dates: list[pd.Timestamp]) -> list[pd.Timestamp]:
+    """Return list of dates from ``dates`` missing in ``df``'s index."""
+    idx = pd.DatetimeIndex(df.index)
+    return [pd.Timestamp(d) for d in dates if pd.Timestamp(d) not in idx]


### PR DESCRIPTION
## Summary
- add debug toggle and stage/near-miss reporting to gap scanner
- capture tickers missing D or D-1 data
- expose `missing_dates` helper in universe module

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c04cbf20408332b3f3d491271e31e5