### PR TITLE
Fix Streamlit cache hashing + date coercion in gap scanner

### DIFF
--- a/engine/universe.py
+++ b/engine/universe.py
@@ -1,15 +1,22 @@
 from __future__ import annotations
 import pandas as pd
+import pandas.api.types as pdt
 
 
-def members_on_date(m: pd.DataFrame, date) -> pd.DataFrame:
-    """Return members active on `date`. Robust to string date columns."""
-    df = m.copy()
-    D = pd.to_datetime(date).normalize()
-    for col in ("start_date", "end_date"):
-        if col in df.columns:
-            df[col] = pd.to_datetime(df[col], errors="coerce")
-        else:
-            df[col] = pd.NaT
-    mask = (df["start_date"] <= D) & (df["end_date"].isna() | (D <= df["end_date"]))
-    return df.loc[mask].copy()
+def members_on_date(m: pd.DataFrame, date: pd.Timestamp) -> pd.DataFrame:
+    """Return members active on ``date``. Be defensive about dtypes."""
+    date = pd.to_datetime(date)
+    df = m
+    if not pdt.is_datetime64_any_dtype(df["start_date"]):
+        df = df.copy()
+        df["start_date"] = pd.to_datetime(df["start_date"], errors="coerce")
+    if "end_date" not in df.columns:
+        if df is m:
+            df = df.copy()
+        df["end_date"] = pd.NaT
+    elif not pdt.is_datetime64_any_dtype(df["end_date"]):
+        if df is m:
+            df = df.copy()
+        df["end_date"] = pd.to_datetime(df["end_date"], errors="coerce")
+    mask = (df["start_date"] <= date) & (df["end_date"].isna() | (date <= df["end_date"]))
+    return df.loc[mask]


### PR DESCRIPTION
## Summary
- avoid hashing custom `Storage` in `_load_members` via leading underscore param and normalize tickers/dates
- convert UI date to `Timestamp` before filtering memberships and prices
- harden `members_on_date` against string/absent date columns

## Testing
- `python -m py_compile engine/universe.py ui/pages/45_YdayVolSignal_Open.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c051dbf2bc8332a2706e522592d6ca