### PR TITLE
Fix cache hashing and sanitize tickers

### DIFF
--- a/data_lake/ingest.py
+++ b/data_lake/ingest.py
@@ -20,10 +20,11 @@ MAX_RETRIES = 3
 
 def _fetch(job: IngestJob) -> pd.DataFrame:
     ticker = job["ticker"]
+    yf_symbol = str(ticker).strip().lstrip("$").replace(".", "-")
     start, end = job["start"], job["end"]
     for attempt in range(MAX_RETRIES):
         try:
-            df = yf.Ticker(ticker).history(
+            df = yf.Ticker(yf_symbol).history(
                 interval="1d", start=start, end=end, auto_adjust=True, actions=True
             )
             break
@@ -35,6 +36,7 @@ def _fetch(job: IngestJob) -> pd.DataFrame:
     if df.empty:
         df = pd.DataFrame({
             # yfinance's canonical column names
+            "Date": pd.Series(dtype="datetime64[ns]"),
             "Open": pd.Series(dtype="float64"),
             "High": pd.Series(dtype="float64"),
             "Low": pd.Series(dtype="float64"),

--- a/engine/universe.py
+++ b/engine/universe.py
@@ -3,7 +3,7 @@ import pandas as pd
 import pandas.api.types as pdt
 
 
-def members_on_date(m: pd.DataFrame, date: pd.Timestamp) -> pd.DataFrame:
+def members_on_date(m: pd.DataFrame, date) -> pd.DataFrame:
     """Return members active on ``date``. Be defensive about dtypes."""
     date = pd.to_datetime(date)
     df = m


### PR DESCRIPTION
## Summary
- avoid Streamlit caching errors by ignoring `Storage` objects and normalizing membership data
- coerce dates when filtering universe and show active member count on scan
- sanitize tickers for yfinance calls and ensure empty downloads use a consistent schema

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c058db04b08332945724d9991e9df8