### PR TITLE
Refactor price history helper and date coercion

### DIFF
--- a/engine/universe.py
+++ b/engine/universe.py
@@ -1,22 +1,15 @@
 from __future__ import annotations
+
 import pandas as pd
-import pandas.api.types as pdt
 
 
-def members_on_date(m: pd.DataFrame, date) -> pd.DataFrame:
-    """Return members active on ``date``. Be defensive about dtypes."""
+def members_on_date(m: pd.DataFrame, date: pd.Timestamp) -> pd.DataFrame:
+    """Return members active on ``date`` with safe date handling."""
+    m = m.copy()
+    m["start_date"] = pd.to_datetime(m["start_date"], errors="coerce")
+    if "end_date" in m.columns and m["end_date"].notna().any():
+        m["end_date"] = pd.to_datetime(m["end_date"], errors="coerce")
+    else:
+        m["end_date"] = pd.NaT
     date = pd.to_datetime(date)
-    df = m
-    if not pdt.is_datetime64_any_dtype(df["start_date"]):
-        df = df.copy()
-        df["start_date"] = pd.to_datetime(df["start_date"], errors="coerce")
-    if "end_date" not in df.columns:
-        if df is m:
-            df = df.copy()
-        df["end_date"] = pd.NaT
-    elif not pdt.is_datetime64_any_dtype(df["end_date"]):
-        if df is m:
-            df = df.copy()
-        df["end_date"] = pd.to_datetime(df["end_date"], errors="coerce")
-    mask = (df["start_date"] <= date) & (df["end_date"].isna() | (date <= df["end_date"]))
-    return df.loc[mask]
+    return m[(m["start_date"] <= date) & (m["end_date"].isna() | (date <= m["end_date"]))]

--- a/swing_options_screener.py
+++ b/swing_options_screener.py
@@ -72,7 +72,7 @@ def _fmt_ts(ts):
 def _get_history(ticker):
     # UNADJUSTED daily (aligns better with Finviz)
     start = pd.Timestamp.today() - pd.DateOffset(months=16)
-    return fetch_history(ticker, start=start, auto_adjust=False)
+    return fetch_history(ticker, start=start)
 
 def _atr_from_ohlc(df, win):
     hl  = df['High'] - df['Low']

--- a/ui/debugger.py
+++ b/ui/debugger.py
@@ -121,7 +121,6 @@ def diagnose_ticker(
         df = fetch_history(
             symbol,
             start=pd.Timestamp.today() - pd.DateOffset(months=6),
-            auto_adjust=False,
         )
 
     entry = prev_close = today_vol = None

--- a/ui/pages/45_YdayVolSignal_Open.py
+++ b/ui/pages/45_YdayVolSignal_Open.py
@@ -43,8 +43,8 @@ def _price_bytes(_storage: Storage, ticker: str) -> bytes:
     return _storage.read_bytes(f"prices/{ticker}.parquet")
 
 
-def _load_prices(storage: Storage, ticker: str) -> pd.DataFrame:
-    blob = _price_bytes(storage, ticker)
+def _load_prices(_storage: Storage, ticker: str) -> pd.DataFrame:
+    blob = _price_bytes(_storage, ticker)
     return _prices_from_bytes(ticker, blob)
 
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utility helpers and shared modules."""
+
+from .prices import fetch_history
+
+__all__ = ["fetch_history"]

--- a/utils/outcomes.py
+++ b/utils/outcomes.py
@@ -251,7 +251,7 @@ def evaluate_outcomes(df: pd.DataFrame, mode: str = "pending") -> pd.DataFrame:
         # Cache history DataFrames per ticker.
         histories: dict[str, pd.DataFrame | None] = {}
         for tkr, start_dt in ticker_starts.items():
-            histories[tkr] = fetch_history(tkr, start=start_dt, auto_adjust=False)
+            histories[tkr] = fetch_history(tkr, start=start_dt)
 
         for i, r in df.iterrows():
             tkr = str(r.get("Ticker", "")).upper()
@@ -381,8 +381,7 @@ def evaluate_outcomes(df: pd.DataFrame, mode: str = "pending") -> pd.DataFrame:
             tkr,
             start=start,
             end=stop + pd.Timedelta(days=1),
-            auto_adjust=False,
-        )
+            )
 
     updated: list[dict[str, Any]] = []
     for row in rows:


### PR DESCRIPTION
## Summary
- add package initializer exporting `fetch_history`
- wrap data lake provider in `utils.prices.fetch_history`
- update screeners and cached loaders to use new helper and safe date coercion

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c05bd9d170833296a1c2cffb8fe2e4