### PR TITLE
Handle unhashable Storage in cache and normalize universe dates

### DIFF
--- a/engine/universe.py
+++ b/engine/universe.py
@@ -3,13 +3,22 @@ from __future__ import annotations
 import pandas as pd
 
 
-def members_on_date(m: pd.DataFrame, date: pd.Timestamp) -> pd.DataFrame:
+def members_on_date(m: pd.DataFrame, date) -> pd.DataFrame:
     """Return members active on ``date`` with safe date handling."""
     m = m.copy()
-    m["start_date"] = pd.to_datetime(m["start_date"], errors="coerce")
-    if "end_date" in m.columns and m["end_date"].notna().any():
+
+    if not isinstance(date, pd.Timestamp):
+        date = pd.to_datetime(date)
+
+    if "start_date" in m.columns:
+        m["start_date"] = pd.to_datetime(m["start_date"], errors="coerce")
+    else:
+        m["start_date"] = pd.NaT
+
+    if "end_date" in m.columns:
         m["end_date"] = pd.to_datetime(m["end_date"], errors="coerce")
     else:
         m["end_date"] = pd.NaT
-    date = pd.to_datetime(date)
-    return m[(m["start_date"] <= date) & (m["end_date"].isna() | (date <= m["end_date"]))]
+
+    mask = (m["start_date"] <= date) & (m["end_date"].isna() | (date <= m["end_date"]))
+    return m.loc[mask]

--- a/ui/pages/45_YdayVolSignal_Open.py
+++ b/ui/pages/45_YdayVolSignal_Open.py
@@ -9,7 +9,7 @@ from engine.universe import members_on_date
 from engine.replay import time_to_hit
 
 
-@st.cache_data(show_spinner=False, hash_funcs={Storage: lambda _: 0})
+@st.cache_data(show_spinner=False, hash_funcs={Storage: lambda _: "Storage"})
 def _load_members(_storage: Storage) -> pd.DataFrame:
     """Cached membership loader that ignores the Storage instance."""
     df = load_membership(_storage)
@@ -37,7 +37,7 @@ def _prices_from_bytes(ticker: str, blob: bytes) -> pd.DataFrame:
     return df
 
 
-@st.cache_data(show_spinner=False, hash_funcs={Storage: lambda _: 0})
+@st.cache_data(show_spinner=False, hash_funcs={Storage: lambda _: "Storage"})
 def _price_bytes(_storage: Storage, ticker: str) -> bytes:
     """Cached download of the price parquet (keyed by ticker)."""
     return _storage.read_bytes(f"prices/{ticker}.parquet")


### PR DESCRIPTION
## Summary
- Fix Streamlit cache by ignoring `Storage` objects via leading underscore arg and custom hash function
- Normalize `members_on_date` dates by coercing `start_date`/`end_date` columns and user-supplied date

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0641451748332af6e0a13e2d30a2d