### PR TITLE
Fix cache hashing and datetime handling

### DIFF
--- a/engine/universe.py
+++ b/engine/universe.py
@@ -7,18 +7,13 @@ def members_on_date(m: pd.DataFrame, date) -> pd.DataFrame:
     """Return members active on ``date`` with safe date handling."""
     m = m.copy()
 
-    if not isinstance(date, pd.Timestamp):
-        date = pd.to_datetime(date)
-
-    if "start_date" in m.columns:
-        m["start_date"] = pd.to_datetime(m["start_date"], errors="coerce")
-    else:
-        m["start_date"] = pd.NaT
-
+    m["start_date"] = pd.to_datetime(m["start_date"], errors="coerce", utc=False)
     if "end_date" in m.columns:
-        m["end_date"] = pd.to_datetime(m["end_date"], errors="coerce")
+        m["end_date"] = pd.to_datetime(m["end_date"], errors="coerce", utc=False)
     else:
         m["end_date"] = pd.NaT
 
-    mask = (m["start_date"] <= date) & (m["end_date"].isna() | (date <= m["end_date"]))
+    d = pd.to_datetime(date).normalize()
+
+    mask = (m["start_date"] <= d) & (m["end_date"].isna() | (d <= m["end_date"]))
     return m.loc[mask]

--- a/ui/pages/45_YdayVolSignal_Open.py
+++ b/ui/pages/45_YdayVolSignal_Open.py
@@ -9,10 +9,11 @@ from engine.universe import members_on_date
 from engine.replay import time_to_hit
 
 
-@st.cache_data(show_spinner=False, hash_funcs={Storage: lambda _: "Storage"})
+@st.cache_data(show_spinner=False)
 def _load_members(_storage: Storage) -> pd.DataFrame:
     """Cached membership loader that ignores the Storage instance."""
-    df = load_membership(_storage)
+    storage = _storage
+    df = load_membership(storage)
     # Ensure expected dtypes (robust against CSV/Parquet differences)
     for col in ("start_date", "end_date"):
         if col not in df.columns:
@@ -37,14 +38,15 @@ def _prices_from_bytes(ticker: str, blob: bytes) -> pd.DataFrame:
     return df
 
 
-@st.cache_data(show_spinner=False, hash_funcs={Storage: lambda _: "Storage"})
+@st.cache_data(show_spinner=False)
 def _price_bytes(_storage: Storage, ticker: str) -> bytes:
     """Cached download of the price parquet (keyed by ticker)."""
-    return _storage.read_bytes(f"prices/{ticker}.parquet")
+    storage = _storage
+    return storage.read_bytes(f"prices/{ticker}.parquet")
 
 
-def _load_prices(_storage: Storage, ticker: str) -> pd.DataFrame:
-    blob = _price_bytes(_storage, ticker)
+def _load_prices(storage: Storage, ticker: str) -> pd.DataFrame:
+    blob = _price_bytes(storage, ticker)
     return _prices_from_bytes(ticker, blob)
 
 


### PR DESCRIPTION
## Summary
- avoid hashing Storage objects in Streamlit caches
- normalize dates in `members_on_date`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0691c6f3483329b266366d6acd080