### PR TITLE
Fix cache hashing and datetime handling: guard against missing start_date

### DIFF
--- a/engine/universe.py
+++ b/engine/universe.py
@@ -6,7 +6,8 @@ import pandas as pd
 def members_on_date(m: pd.DataFrame, date) -> pd.DataFrame:
     """Return members active on ``date`` with safe date handling."""
     m = m.copy()
-
+    if "start_date" not in m.columns:
+        m["start_date"] = pd.NaT
     m["start_date"] = pd.to_datetime(m["start_date"], errors="coerce", utc=False)
     if "end_date" in m.columns:
         m["end_date"] = pd.to_datetime(m["end_date"], errors="coerce", utc=False)


### PR DESCRIPTION
## Summary
- handle DataFrames lacking `start_date` in `members_on_date`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c06abfe17c83328b074707c8b4346d