### PR TITLE
Stabilize caching & Supabase bootstrap

### DIFF
--- a/engine/universe.py
+++ b/engine/universe.py
@@ -5,16 +5,15 @@ import pandas as pd
 
 def members_on_date(m: pd.DataFrame, date) -> pd.DataFrame:
     """Return members active on ``date`` with safe date handling."""
+    date = pd.Timestamp(date)
     m = m.copy()
-    if "start_date" not in m.columns:
-        m["start_date"] = pd.NaT
-    m["start_date"] = pd.to_datetime(m["start_date"], errors="coerce", utc=False)
+    m["start_date"] = pd.to_datetime(m["start_date"], errors="coerce")
     if "end_date" in m.columns:
-        m["end_date"] = pd.to_datetime(m["end_date"], errors="coerce", utc=False)
+        m["end_date"] = pd.to_datetime(m["end_date"], errors="coerce")
     else:
         m["end_date"] = pd.NaT
 
-    d = pd.to_datetime(date).normalize()
-
-    mask = (m["start_date"] <= d) & (m["end_date"].isna() | (d <= m["end_date"]))
+    mask = (m["start_date"] <= date) & (
+        m["end_date"].isna() | (date <= m["end_date"])
+    )
     return m.loc[mask]


### PR DESCRIPTION
## Summary
- cache Storage client as a Streamlit resource and normalize date inputs to pandas Timestamps
- coerce membership dates to Timestamps for reliable membership queries
- make Supabase storage bootstrap version-agnostic and safe across SDK changes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c06dee88048332942a483ca01eca5a