### PR TITLE
Fix Streamlit cache hashing and date coercion in universe

### DIFF
--- a/tests/test_universe_date_coercion.py
+++ b/tests/test_universe_date_coercion.py
@@ -1,0 +1,14 @@
+import pandas as pd
+
+from engine.universe import members_on_date
+
+
+def test_members_on_date_handles_string_dates():
+    m = pd.DataFrame({
+        "ticker": ["AAA", "BBB", "CCC"],
+        "start_date": ["2010-01-01", "2011-06-15", "2012-01-01"],
+        "end_date": ["2010-12-31", None, "2014-05-05"],
+    })
+    day = "2011-06-15"
+    active = members_on_date(m, day)
+    assert active["ticker"].tolist() == ["BBB"]

--- a/ui/pages/45_YdayVolSignal_Open.py
+++ b/ui/pages/45_YdayVolSignal_Open.py
@@ -60,7 +60,8 @@ def render_page() -> None:
 
     # ---- Inputs ----
     D_input = st.date_input("Entry day (D)", value=pd.Timestamp.today().date())
-    D = pd.Timestamp(D_input)
+    # Coerce to ``Timestamp`` to avoid ``str`` vs ``Timestamp`` comparisons downstream.
+    D = pd.to_datetime(D_input)
     min_close_up_pct = st.number_input("Min close-up on D-1 (%)", value=3.0, step=0.5, format="%.2f") / 100.0
     vol_window       = st.number_input("Volume lookback (sessions)", value=63, min_value=5, step=5)
     min_vol_mult     = st.number_input(


### PR DESCRIPTION
## Summary
- prevent Streamlit from hashing `Storage` objects by prefixing cached params with `_`
- coerce all date-like fields in `members_on_date` to `Timestamp`
- add regression test for string-based membership dates

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0817df5ec8332a0308985f947f809