### PR TITLE
Handle storage caching and add filter debug counters

### DIFF
--- a/ui/pages/45_YdayVolSignal_Open.py
+++ b/ui/pages/45_YdayVolSignal_Open.py
@@ -97,8 +97,13 @@ def _run_signal_scan(
         results.append(stage_info)
 
     counts["final"] = len(results)
-    near_df = pd.DataFrame(near).sort_values(["gap_open_pct", "d1_vol_mult"], ascending=False)
-    res_df = pd.DataFrame(results).sort_values("gap_open_pct", ascending=False)
+    cols = ["ticker", "d1_close_up_pct", "d1_vol_mult", "gap_open_pct"]
+    near_df = pd.DataFrame(near, columns=cols)
+    if not near_df.empty:
+        near_df = near_df.sort_values(["gap_open_pct", "d1_vol_mult"], ascending=False)
+    res_df = pd.DataFrame(results, columns=cols)
+    if not res_df.empty:
+        res_df = res_df.sort_values("gap_open_pct", ascending=False)
     return res_df, counts, near_df.head(10)
 
 


### PR DESCRIPTION
## Summary
- guard sorting when results or near-miss lists are empty in yesterday-volume scan

## Testing
- `python - <<'PY'
import importlib.util
import io
import pandas as pd
from data_lake.storage import Storage

# create mock membership parquet
storage = Storage()
_df = pd.DataFrame({'ticker':['AAPL'], 'start_date':['2020-01-01'], 'end_date':['2030-01-01']})
_buf = io.BytesIO()
_df.to_parquet(_buf, index=False)
storage.write_bytes('membership/sp500_members.parquet', _buf.getvalue())

spec = importlib.util.spec_from_file_location('page', 'ui/pages/45_YdayVolSignal_Open.py')
mod = importlib.util.module_from_spec(spec)
spec.loader.exec_module(mod)
print(mod._load_members.__wrapped__(storage))
PY`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0990689d0833286ac715217e5d8eb