### PR TITLE
Stop legacy scanner import; add scan predicate counters to debug panel

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,14 +10,9 @@ setup_page()
 render_header()
 
 # Create tabs once with unique variable names
-tab_scanner, tab_gap, tab_history, tab_lake, tab_debug = st.tabs(
-    ["🔍 Scanner", "⚡ Gap Scanner", "📈 History & Outcomes", "💧 Data Lake (Phase 1)", "🐞 Debugger"]
+tab_gap, tab_history, tab_lake, tab_debug = st.tabs(
+    ["⚡ Gap Scanner", "📈 History & Outcomes", "💧 Data Lake (Phase 1)", "🐞 Debugger"]
 )
-
-with tab_scanner:
-    from ui.scan import render_scanner_tab
-
-    render_scanner_tab()
 
 with tab_gap:
     spec = importlib.util.spec_from_file_location(


### PR DESCRIPTION
## Summary
- remove legacy scanner tab from main app
- track and display scan predicate counts in gap scanner debug expander

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c09c76989c83328fbfac67eee3613b