### PR TITLE
Fix date widget conversion and add legacy scanner placeholder

### DIFF
--- a/ui/pages/15_Legacy_Scanner_Disabled.py
+++ b/ui/pages/15_Legacy_Scanner_Disabled.py
@@ -1,0 +1,14 @@
+import streamlit as st
+
+def page():
+    st.header("Legacy Scanner (temporarily disabled)")
+    st.info(
+        "The old scanner is parked while we stabilize the new Gap/Volume scanner. "
+        "This avoids an import chain that pulled in a removed module (`utils.prices`). "
+        "You can use the new scanner and the History & Outcomes pages meanwhile."
+    )
+    st.caption("If you need something specific from the old scanner, say the word and we’ll stub it here safely.")
+
+# Streamlit multipage expects the module-level call:
+if __name__ == "__main__":
+    page()

--- a/ui/pages/45_YdayVolSignal_Open.py
+++ b/ui/pages/45_YdayVolSignal_Open.py
@@ -1,4 +1,6 @@
 import io
+import datetime as dt
+
 import pandas as pd
 import streamlit as st
 from data_lake.storage import Storage
@@ -129,7 +131,10 @@ def render_page():
     )
     st.session_state["show_debug"] = debug
 
-    D = st.date_input("Entry day (D)", value=pd.Timestamp.today()).to_pydatetime()
+    _d = st.date_input("Entry day (D)", value=dt.date.today())
+    if isinstance(_d, (list, tuple)):
+        _d = _d[0]
+    D = pd.Timestamp(_d)
     lookback = int(st.number_input("Lookback", value=63, min_value=1, step=1))
     min_close_up = float(
         st.number_input("Min close-up on D-1 (%)", value=3.0, step=0.5)


### PR DESCRIPTION
## Summary
- handle date widget robustly with pandas-friendly conversion
- add Legacy Scanner placeholder page to avoid crashing imports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c0ac5a27a88332a33b54b863faffdb