### PR TITLE
Fix manual start/end for get_daily_adjusted in volume signal

### DIFF
--- a/ui/pages/45_YdayVolSignal_Open.py
+++ b/ui/pages/45_YdayVolSignal_Open.py
@@ -55,7 +55,9 @@ def _run_signal_scan(
     near: list[dict] = []
 
     for t in tickers:
-        hist = get_daily_adjusted(t, end=D, lookback=max(lookback + 2, 70))
+        back_days = max(lookback + 2, 70)
+        start = (pd.Timestamp(D) - pd.Timedelta(days=back_days * 2)).date()
+        hist = get_daily_adjusted(t, start=start, end=pd.Timestamp(D).date())
         if hist.empty or D not in hist.index:
             continue
         idx = hist.index.get_loc(D)


### PR DESCRIPTION
## Summary
- Compute manual start date for historical prices in `_run_signal_scan`
- Retrieve history via `get_daily_adjusted` with explicit `start` and `end`

## Testing
- `pytest -q`
- Ran `_run_signal_scan` for 2022 date using stubbed provider

------
https://chatgpt.com/codex/tasks/task_e_68c0ae96c2d48332937bc66e771c22a7