### PR TITLE
Fix manual start/end for get_daily_adjusted in volume signal

### DIFF
--- a/ui/pages/45_YdayVolSignal_Open.py
+++ b/ui/pages/45_YdayVolSignal_Open.py
@@ -57,7 +57,11 @@ def _run_signal_scan(
     for t in tickers:
         back_days = max(lookback + 2, 70)
         start = (pd.Timestamp(D) - pd.Timedelta(days=back_days * 2)).date()
-        hist = get_daily_adjusted(t, start=start, end=pd.Timestamp(D).date())
+        hist = get_daily_adjusted(
+            t,
+            start=start,
+            end=(pd.Timestamp(D) + pd.Timedelta(days=1)).date(),
+        )
         if hist.empty or D not in hist.index:
             continue
         idx = hist.index.get_loc(D)


### PR DESCRIPTION
## Summary
- include scan date when fetching daily history to ensure evaluation occurs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0b03eec588332a42ba704ed5945b5