### PR TITLE
Disable file watcher; add progress and dry-run to gap scanner

### DIFF
--- a/tests/test_run_signal_scan.py
+++ b/tests/test_run_signal_scan.py
@@ -1,0 +1,77 @@
+import sys
+from pathlib import Path
+import importlib
+import pandas as pd
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def test_run_signal_scan_empty_active():
+    mod = importlib.import_module("ui.pages.45_YdayVolSignal_Open")
+    active = pd.DataFrame(columns=["ticker"])
+    results, stats, fails, timeout = mod._run_signal_scan(
+        active,
+        D="2024-01-02",
+        lookback=63,
+        min_close_up=3.0,
+        min_vol_mult=1.5,
+        min_gap_next_open=0.0,
+    )
+    assert results.empty
+    assert list(results.columns) == [
+        "ticker",
+        "d1_close_up_pct",
+        "d1_vol_mult",
+        "gap_open_pct",
+        "sr_ratio",
+    ]
+    assert stats.universe == 0
+    assert stats.final == 0
+    assert fails == {"close_up": [], "vol": [], "gap": [], "sr": []}
+    assert timeout is None
+
+
+def test_run_signal_scan_no_results():
+    mod = importlib.import_module("ui.pages.45_YdayVolSignal_Open")
+    active = pd.DataFrame({"ticker": ["AAPL"]})
+
+    fake_hist = pd.DataFrame(
+        {
+            "open": [100, 100],
+            "close": [100, 100],
+            "volume": [100, 100],
+            "high": [100, 100],
+            "low": [100, 100],
+        },
+        index=pd.to_datetime(["2024-01-01", "2024-01-02"]),
+    )
+
+    def fake_get_daily_adjusted(t, start, end):
+        return fake_hist
+
+    with patch("data_lake.provider.get_daily_adjusted", fake_get_daily_adjusted):
+        results, stats, fails, timeout = mod._run_signal_scan(
+            active,
+            D="2024-01-02",
+            lookback=63,
+            min_close_up=3.0,
+            min_vol_mult=1.5,
+            min_gap_next_open=0.0,
+        )
+
+    assert results.empty
+    assert list(results.columns) == [
+        "ticker",
+        "d1_close_up_pct",
+        "d1_vol_mult",
+        "gap_open_pct",
+        "sr_ratio",
+    ]
+    assert stats.universe == 1
+    assert stats.loaded == 1
+    assert stats.final == 0
+    assert fails == {"close_up": [], "vol": [], "gap": [], "sr": []}
+    assert timeout is None

--- a/ui/pages/45_YdayVolSignal_Open.py
+++ b/ui/pages/45_YdayVolSignal_Open.py
@@ -58,8 +58,11 @@ def _run_signal_scan(
     tickers = sorted(active["ticker"].dropna().unique().tolist())
     if limit:
         tickers = tickers[:limit]
+    cols = ["ticker", "d1_close_up_pct", "d1_vol_mult", "gap_open_pct"]
+    if use_sr:
+        cols.append("sr_ratio")
     if not tickers:
-        return pd.DataFrame(), stats, fails, None
+        return pd.DataFrame(columns=cols), stats, fails, None
 
     D = pd.to_datetime(D)
     results: list[dict] = []
@@ -158,11 +161,10 @@ def _run_signal_scan(
 
     stats.final = len(results)
     if results:
-        res_df = pd.DataFrame(results).sort_values("gap_open_pct", ascending=False)
+        res_df = pd.DataFrame(results)
+        if "gap_open_pct" in res_df.columns:
+            res_df = res_df.sort_values("gap_open_pct", ascending=False)
     else:
-        cols = ["ticker", "d1_close_up_pct", "d1_vol_mult", "gap_open_pct"]
-        if use_sr:
-            cols.append("sr_ratio")
         res_df = pd.DataFrame(columns=cols)
     return res_df, stats, fails, timeout_msg
 


### PR DESCRIPTION
## Summary
- Prevent `_run_signal_scan` from raising a `KeyError` on empty results by predefining columns and guarding the sort
- Expand regression tests for empty ticker sets and no-match scenarios

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c10d0ad244833285fde8bb43e6ecb3