### PR TITLE
fix: persist scan results for outcomes replay

### DIFF
--- a/ui/pages/45_YdayVolSignal_Open.py
+++ b/ui/pages/45_YdayVolSignal_Open.py
@@ -266,6 +266,15 @@ def render_page():
                 dry_run_n=(dry_n or None) if dry_n > 0 else None
             )
 
+        st.session_state["res_df"] = res_df
+        st.session_state["stats"] = stats
+        st.session_state["drops"] = drops
+
+    res_df = st.session_state.get("res_df")
+    stats = st.session_state.get("stats")
+    drops = st.session_state.get("drops")
+
+    if res_df is not None:
         st.dataframe(pd.DataFrame([stats]))
         if res_df.empty:
             st.warning("No matches for the selected filters.")


### PR DESCRIPTION
## Summary
- store scan results in session state
- render outcomes replay controls outside scan button so they persist across reruns

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2f84b0db48332bf742e39238b4ddb