### PR TITLE
Normalize dates without unsupported tz_localize errors

### DIFF
--- a/engine/replay.py
+++ b/engine/replay.py
@@ -25,11 +25,13 @@ def replay_trade(
         }
 
     # Dates should already be tz-naive normalized; make it idempotent
-    d = (
-        pd.to_datetime(bars["date"], errors="coerce")
-        .dt.tz_localize(None, errors="ignore")
-        .dt.normalize()
-    )
+    d = pd.to_datetime(bars["date"], errors="coerce")
+    # Strip timezone info to ensure comparisons work regardless of input
+    if d.dt.tz is not None:
+        d = d.dt.tz_convert(None)
+    else:
+        d = d.dt.tz_localize(None)
+    d = d.dt.normalize()
     bars = bars.assign(date=d).dropna(subset=["date"]).sort_values("date")
 
     # Slice D..D+H

--- a/ui/pages/45_YdayVolSignal_Open.py
+++ b/ui/pages/45_YdayVolSignal_Open.py
@@ -381,8 +381,11 @@ def render_page():
 
                         # Canonicalize to tz-naive midnight
                         d = pd.to_datetime(df["date"], errors="coerce")
-                        d = d.dt.tz_localize(None, errors="ignore").dt.normalize()
-                        df["date"] = d
+                        if d.dt.tz is not None:
+                            d = d.dt.tz_convert(None)
+                        else:
+                            d = d.dt.tz_localize(None)
+                        df["date"] = d.dt.normalize()
 
                         # Keep only needed columns
                         df = (


### PR DESCRIPTION
## Summary
- drop unsupported `errors` kwarg in tz-localize calls
- strip timezone info conditionally with `tz_convert` for aware data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c336c5a3888332a8014a495e55913d