### PR TITLE
Preserve wall-clock time when stripping timezones

### DIFF
--- a/engine/replay.py
+++ b/engine/replay.py
@@ -26,11 +26,8 @@ def replay_trade(
 
     # Dates should already be tz-naive normalized; make it idempotent
     d = pd.to_datetime(bars["date"], errors="coerce")
-    # Strip timezone info to ensure comparisons work regardless of input
-    if d.dt.tz is not None:
-        d = d.dt.tz_convert(None)
-    else:
-        d = d.dt.tz_localize(None)
+    # Drop timezone without shifting wall-clock time so comparisons remain valid
+    d = d.dt.tz_localize(None)
     d = d.dt.normalize()
     bars = bars.assign(date=d).dropna(subset=["date"]).sort_values("date")
 

--- a/ui/pages/45_YdayVolSignal_Open.py
+++ b/ui/pages/45_YdayVolSignal_Open.py
@@ -381,10 +381,8 @@ def render_page():
 
                         # Canonicalize to tz-naive midnight
                         d = pd.to_datetime(df["date"], errors="coerce")
-                        if d.dt.tz is not None:
-                            d = d.dt.tz_convert(None)
-                        else:
-                            d = d.dt.tz_localize(None)
+                        # Drop timezone without shifting local timestamps
+                        d = d.dt.tz_localize(None)
                         df["date"] = d.dt.normalize()
 
                         # Keep only needed columns


### PR DESCRIPTION
## Summary
- avoid timezone shifts by dropping tz with `tz_localize(None)`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c337dfea008332b949222db0ecf42e