### PR TITLE
Handle missing markdown dependency in YdayVolSignal page

### DIFF
--- a/ui/pages/45_YdayVolSignal_Open.py
+++ b/ui/pages/45_YdayVolSignal_Open.py
@@ -35,7 +35,7 @@ def _render_df_with_copy(title: str, df: pd.DataFrame, key_prefix: str):
     csv_txt = csv_buf.getvalue()
     try:
         md_txt = df.to_markdown(index=False)
-    except Exception as e:
+    except ImportError as e:
         logging.warning("markdown export skipped: %s", e)
         md_txt = None
 


### PR DESCRIPTION
## Summary
- Avoid crashes when `tabulate` dependency missing for `df.to_markdown`
- Skip markdown export and button if markdown dependency not installed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c348e6873883328f53e67f28f62bac