### PR TITLE
Gracefully handle markdown export failures in YdayVolSignal

### DIFF
--- a/ui/pages/45_YdayVolSignal_Open.py
+++ b/ui/pages/45_YdayVolSignal_Open.py
@@ -35,8 +35,8 @@ def _render_df_with_copy(title: str, df: pd.DataFrame, key_prefix: str):
     csv_txt = csv_buf.getvalue()
     try:
         md_txt = df.to_markdown(index=False)
-    except ImportError as e:
-        logging.warning("markdown export skipped: %s", e)
+    except Exception:
+        logging.exception("markdown export skipped")
         md_txt = None
 
     # Download button (native)


### PR DESCRIPTION
## Summary
- Broaden markdown export error handling in `_render_df_with_copy` to catch any exception
- Log full markdown export exception and skip Markdown button when export fails

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5845268248332a3e519f94aa140be