### PR TITLE
Add tabulate dependency for pandas to_markdown

### DIFF
--- a/requirements-smoke.txt
+++ b/requirements-smoke.txt
@@ -7,3 +7,4 @@ streamlit>=1.33,<1.40
 beautifulsoup4>=4.12
 lxml>=4.9,<5
 requests>=2.31
+tabulate>=0.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,6 @@ pyarrow==16.1.0
 beautifulsoup4==4.12.3
 lxml>=4.9,<5
 requests==2.32.3
+tabulate>=0.8
 # Supabase client (postgrest/gotrue/storage3 come as transitive deps)
 supabase>=2.6,<3


### PR DESCRIPTION
## Summary
- add `tabulate>=0.8` to main requirements
- include `tabulate>=0.8` in smoke requirements

## Testing
- `pip install -r requirements.txt` (fails: Could not find a version that satisfies the requirement tabulate>=0.8 (ProxyError))
- `python - <<'PY'` (fails: Missing optional dependency 'tabulate'. Use pip or conda to install tabulate.)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c58be21be08332a169ca8307aa2029