### PR TITLE
Add 21-day precedent and ATR feasibility filters to scanner

### DIFF
--- a/engine/metrics.py
+++ b/engine/metrics.py
@@ -1,0 +1,34 @@
+import pandas as pd
+import numpy as np
+
+
+def has_21d_runup_precedent(
+    df: pd.DataFrame,
+    lookback_days: int,
+    horizon_days: int,
+    target_move_pct: float,
+) -> bool:
+    """Return True if any window meets the target move.
+
+    df: sorted by date asc; must include columns ['date','close','high'] and end at D-1.
+    Look back `lookback_days` from D-1. Return True if any rolling window of
+    `horizon_days` has max(high)/close0 - 1 >= target_move_pct.
+    """
+    if df is None or df.empty or pd.isna(target_move_pct):
+        return False
+
+    tail = df.tail(int(lookback_days))
+    if len(tail) < horizon_days:
+        return False
+
+    highs = tail["high"].to_numpy()
+    closes = tail["close"].to_numpy()
+    n = len(tail)
+    for i in range(n - horizon_days + 1):
+        close0 = closes[i]
+        if close0 and not np.isnan(close0):
+            window_max = np.nanmax(highs[i : i + horizon_days])
+            if close0 > 0 and (window_max / close0 - 1.0) >= target_move_pct:
+                return True
+    return False
+

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,24 @@
+import pandas as pd
+
+from engine.metrics import has_21d_runup_precedent
+
+
+def test_has_21d_runup_precedent_true():
+    dates = pd.date_range("2023-01-01", periods=40)
+    close = pd.Series([100.0] * 40)
+    high = close.copy()
+    # create a 21-day window with 10% run-up
+    high.iloc[0:21] = 110.0
+    df = pd.DataFrame({"date": dates, "close": close, "high": high})
+    assert has_21d_runup_precedent(df, lookback_days=30, horizon_days=21, target_move_pct=0.09)
+
+
+def test_has_21d_runup_precedent_false():
+    dates = pd.date_range("2023-01-01", periods=40)
+    close = pd.Series([100.0] * 40)
+    high = close.copy()
+    df = pd.DataFrame({"date": dates, "close": close, "high": high})
+    assert not has_21d_runup_precedent(
+        df, lookback_days=30, horizon_days=21, target_move_pct=0.05
+    )
+


### PR DESCRIPTION
## Summary
- add `has_21d_runup_precedent` helper for run-up checks
- expose advanced feasibility filter controls in scanner UI
- compute precedent and ATR gates with reasons, guard candidate sorting, and report enabled gates when no matches

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c595eb8ba083328cf7d4a6d3f4ab4c