### PR TITLE
feat: add range backtest page

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,13 +13,28 @@ setup_page()
 render_header()
 
 # Create tabs once with unique variable names
-tab_gap, tab_history, tab_lake, tab_debug = st.tabs(
-    ["⚡ Gap Scanner", "📈 History & Outcomes", "💧 Data Lake (Phase 1)", "🐞 Debugger"]
+tab_gap, tab_backtest, tab_history, tab_lake, tab_debug = st.tabs(
+    [
+        "⚡ Gap Scanner",
+        "📅 Backtest (range)",
+        "📈 History & Outcomes",
+        "💧 Data Lake (Phase 1)",
+        "🐞 Debugger",
+    ]
 )
 
 with tab_gap:
     spec = importlib.util.spec_from_file_location(
         "ui.pages.yday_vol_signal_open", Path("ui/pages/45_YdayVolSignal_Open.py")
+    )
+    mod = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(mod)
+    mod.page()
+
+with tab_backtest:
+    spec = importlib.util.spec_from_file_location(
+        "ui.pages.backtest_range", Path("ui/pages/55_Backtest_Range.py")
     )
     mod = importlib.util.module_from_spec(spec)
     assert spec and spec.loader

--- a/backtest/run_range.py
+++ b/backtest/run_range.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
-import uuid, json, io
-import pandas as pd
+import time
 from typing import Callable, Tuple
+
+import pandas as pd
 
 from data_lake.storage import Storage
 from engine.signal_scan import scan_day, ScanParams
-
-import pyarrow.parquet as pq
-import pyarrow as pa
 
 
 def trading_days(storage: Storage, start: str, end: str) -> pd.DatetimeIndex:
@@ -27,43 +25,55 @@ def run_range(
     start: str,
     end: str,
     params: ScanParams,
-    run_id: str | None = None,
-    progress_cb: Callable[[int, int], None] | None = None,
-) -> Tuple[str, dict]:
-    rid = run_id or pd.Timestamp.utcnow().strftime("%Y%m%d_%H%M%S_") + str(uuid.uuid4())[:8]
+    progress_cb: Callable[[int, int, pd.Timestamp, int, int], None] | None = None,
+) -> Tuple[pd.DataFrame, dict]:
     days = trading_days(storage, start, end)
-    all_cands, all_out, totals = [], [], {"days": 0, "candidates": 0, "hits": 0, "fails": 0}
+    all_trades = []
     total_days = len(days)
+    days_with_candidates = 0
     for idx, D in enumerate(days, 1):
-        cands, out, fails, _dbg = scan_day(storage, D, params)
-        if not cands.empty:
-            cands = cands.copy(); cands["D"] = D.normalize()
-            all_cands.append(cands)
+        cands, out, _fails, _dbg = scan_day(storage, D, params)
+        cand_count = int(len(cands))
+        hit_count = int(out["hit"].sum()) if not out.empty else 0
+        if cand_count:
+            days_with_candidates += 1
         if not out.empty:
-            out = out.copy(); out["D"] = D.normalize()
-            totals["hits"] += int(out["hit"].sum())
-            all_out.append(out)
-        totals["fails"] += int(fails); totals["candidates"] += int(len(cands)); totals["days"] += 1
+            tmp = out.copy()
+            tmp["date"] = D.normalize()
+            all_trades.append(tmp)
         if progress_cb:
-            progress_cb(idx, total_days)
+            progress_cb(idx, total_days, D, cand_count, hit_count)
+        time.sleep(0.25)
 
-    cand_df = pd.concat(all_cands, ignore_index=True) if all_cands else pd.DataFrame()
-    out_df = pd.concat(all_out, ignore_index=True) if all_out else pd.DataFrame()
+    trades_df = pd.concat(all_trades, ignore_index=True) if all_trades else pd.DataFrame()
+    hits = int(trades_df["hit"].sum()) if not trades_df.empty else 0
     summary = {
-        "run_id": rid,
-        "start": start,
-        "end": end,
-        **totals,
-        "hit_rate": (float(totals["hits"]) / max(1, totals["candidates"]))
+        "total_days": int(total_days),
+        "days_with_candidates": int(days_with_candidates),
+        "trades": int(len(trades_df)),
+        "hits": hits,
+        "hit_rate": float(hits) / max(1, len(trades_df)),
+        "median_days_to_exit": float(trades_df["days_to_exit"].median()) if not trades_df.empty else float("nan"),
+        "avg_MAE_pct": float(trades_df["mae_pct"].mean()) if not trades_df.empty else float("nan"),
+        "avg_MFE_pct": float(trades_df["mfe_pct"].mean()) if not trades_df.empty else float("nan"),
     }
 
-    def _to_parquet_bytes(df: pd.DataFrame) -> bytes:
-        buf = io.BytesIO()
-        if not df.empty:
-            pq.write_table(pa.Table.from_pandas(df), buf)
-        return buf.getvalue()
+    needed = [
+        "date",
+        "ticker",
+        "entry_open",
+        "tp_price",
+        "hit",
+        "exit_reason",
+        "exit_price",
+        "days_to_exit",
+        "mae_pct",
+        "mfe_pct",
+        "sr_ratio",
+        "tp_halfway_pct",
+        "precedent_ok",
+        "atr_ok",
+    ]
+    trades_df = trades_df.reindex(columns=needed)
 
-    storage.write_bytes(f"runs/{rid}/candidates.parquet", _to_parquet_bytes(cand_df))
-    storage.write_bytes(f"runs/{rid}/outcomes.parquet", _to_parquet_bytes(out_df))
-    storage.write_bytes(f"runs/{rid}/summary.json", json.dumps(summary, indent=2).encode("utf-8"))
-    return rid, summary
+    return trades_df, summary


### PR DESCRIPTION
## Summary
- add Backtest (range) tab to Streamlit navigation
- implement range backtest UI with progress, summaries, and CSV download
- expose `run_range` returning trades DataFrame and summary stats

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5a55201448332bb8ef86818cb1a4a