### PR TITLE
Cache price data for faster range backtests

### DIFF
--- a/ui/pages/55_Backtest_Range.py
+++ b/ui/pages/55_Backtest_Range.py
@@ -224,7 +224,9 @@ def render_page() -> None:
 
             start_date = pd.to_datetime(start)
             end_date = pd.to_datetime(end)
-            date_list = list(pd.date_range(start=start_date, end=end_date, freq="B"))
+            df_days = load_prices_cached(storage, "AAPL")
+            day_mask = (df_days.index >= start_date) & (df_days.index <= end_date)
+            date_list = list(pd.DatetimeIndex(df_days.index[day_mask]).sort_values())
 
             members = sigscan._load_members(storage)
 
@@ -262,54 +264,64 @@ def render_page() -> None:
             def _load_members_patched(_storage):
                 return members
 
+            orig_load_prices = sigscan._load_prices
+            orig_load_members = sigscan._load_members
             sigscan._load_prices = _load_prices_patched
             sigscan._load_members = _load_members_patched
 
-            results = []
-            days_with_candidates = 0
-            done = 0
-            total_days = len(date_list)
-            for D in date_list:
-                cands, out, _fails, _stats = sigscan.scan_day(storage, pd.Timestamp(D), params)
-                cand_count = int(len(cands))
-                if cand_count:
-                    days_with_candidates += 1
-                if not out.empty:
-                    tmp = out.copy()
-                    tmp["date"] = pd.Timestamp(D).normalize()
-                    results.append(tmp)
-                done += 1
-                pct = int(done / max(1, total_days) * 100)
-                prog.progress(pct, text=f"{pct}%  ({pd.Timestamp(D).date()})")
-                if done % 5 == 0:
-                    log(f"{pd.Timestamp(D).date()} → {cand_count} candidates")
+            try:
+                results = []
+                days_with_candidates = 0
+                done = 0
+                total_days = len(date_list)
+                for D in date_list:
+                    cands, out, _fails, _stats = sigscan.scan_day(
+                        storage, pd.Timestamp(D), params
+                    )
+                    cand_count = int(len(cands))
+                    if cand_count:
+                        days_with_candidates += 1
+                    if not out.empty:
+                        tmp = out.copy()
+                        tmp["date"] = pd.Timestamp(D).normalize()
+                        results.append(tmp)
+                    done += 1
+                    pct = int(done / max(1, total_days) * 100)
+                    prog.progress(pct, text=f"{pct}%  ({pd.Timestamp(D).date()})")
+                    if done % 5 == 0:
+                        log(f"{pd.Timestamp(D).date()} → {cand_count} candidates")
 
-            trades_df = pd.concat(results, ignore_index=True) if results else pd.DataFrame()
-            hits = int(trades_df["hit"].sum()) if not trades_df.empty else 0
-            summary = {
-                "total_days": int(total_days),
-                "days_with_candidates": int(days_with_candidates),
-                "trades": int(len(trades_df)),
-                "hits": hits,
-                "hit_rate": float(hits) / max(1, len(trades_df)),
-                "median_days_to_exit": float(trades_df["days_to_exit"].median()) if not trades_df.empty else float("nan"),
-                "avg_MAE_pct": float(trades_df["mae_pct"].mean()) if not trades_df.empty else float("nan"),
-                "avg_MFE_pct": float(trades_df["mfe_pct"].mean()) if not trades_df.empty else float("nan"),
-            }
+                trades_df = pd.concat(results, ignore_index=True) if results else pd.DataFrame()
+                hits = int(trades_df["hit"].sum()) if not trades_df.empty else 0
+                summary = {
+                    "total_days": int(total_days),
+                    "days_with_candidates": int(days_with_candidates),
+                    "trades": int(len(trades_df)),
+                    "hits": hits,
+                    "hit_rate": float(hits) / max(1, len(trades_df)),
+                    "median_days_to_exit": float(trades_df["days_to_exit"].median()) if not trades_df.empty else float("nan"),
+                    "avg_MAE_pct": float(trades_df["mae_pct"].mean()) if not trades_df.empty else float("nan"),
+                    "avg_MFE_pct": float(trades_df["mfe_pct"].mean()) if not trades_df.empty else float("nan"),
+                }
 
-            st.session_state["bt_trades"] = trades_df
-            st.session_state["bt_summary"] = summary
+                st.session_state["bt_trades"] = trades_df
+                st.session_state["bt_summary"] = summary
 
-            if save_outcomes and not trades_df.empty:
-                run_id = dt.datetime.utcnow().strftime("%Y%m%d_%H%M%S")
-                buf = io.BytesIO()
-                trades_df.to_parquet(buf, index=False)
-                path = f"backtests/{run_id}.parquet"
-                storage.write_bytes(path, buf.getvalue())
-                st.session_state["bt_save_path"] = path
+                if save_outcomes and not trades_df.empty:
+                    run_id = dt.datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+                    buf = io.BytesIO()
+                    trades_df.to_parquet(buf, index=False)
+                    path = f"backtests/{run_id}.parquet"
+                    storage.write_bytes(path, buf.getvalue())
+                    st.session_state["bt_save_path"] = path
 
-            status.update(label=f"Backtest complete ✅ ({len(trades_df)} trades)", state="complete")
-            st.toast("Backtest finished", icon="✅")
+                status.update(
+                    label=f"Backtest complete ✅ ({len(trades_df)} trades)", state="complete"
+                )
+                st.toast("Backtest finished", icon="✅")
+            finally:
+                sigscan._load_prices = orig_load_prices
+                sigscan._load_members = orig_load_members
         except Exception as e:
             log(f"ERROR: {e}")
             status.update(label="Backtest failed ❌", state="error")


### PR DESCRIPTION
## Summary
- derive backtest date range from actual price data to skip market holidays
- restore `sigscan` loaders after each run to avoid leaking cached state

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5b20134148332a0f1d6dc7d18bc83