### PR TITLE
Ensure status_block handles Streamlit progress across versions

### DIFF
--- a/ui/components/progress.py
+++ b/ui/components/progress.py
@@ -19,7 +19,8 @@ def status_block(title: str, key_prefix: str = "prog"):
     Version-proof progress block built from primitives only.
     Returns: (status_like, prog_widget, log_fn)
       - status_like.update(label=..., state=...)
-      - prog_widget.progress(value) where value can be 0..1 (float) or 0..100 (int)
+      - prog_widget.progress(value, *args, **kwargs) where value can be
+        0..1 (float) or 0..100 (int)
       - log_fn(text) appends to a code block
     """
     title_slot = st.empty()
@@ -28,14 +29,14 @@ def status_block(title: str, key_prefix: str = "prog"):
     # Progress: avoid passing key= (not supported in some versions),
     # and normalize inputs so callers can pass float 0..1 or int 0..100.
     try:
-        raw = st.progress(0)  # no key argument for max compatibility
+        raw = st.progress(value=0)  # no key argument for max compatibility
 
         class _ProgLike:
             def __init__(self, raw_prog):
                 self._raw = raw_prog
 
-            def progress(self, v):
-                # Normalize to 0..100 int
+            def progress(self, v, *args, **kwargs):
+                # Normalize to 0..100 int and forward any other args/kwargs
                 try:
                     if isinstance(v, float):
                         if 0.0 <= v <= 1.0:
@@ -47,12 +48,16 @@ def status_block(title: str, key_prefix: str = "prog"):
                 except Exception:
                     v = 0
                 v = max(0, min(100, v))
-                self._raw.progress(v)
+                try:
+                    self._raw.progress(v, *args, **kwargs)
+                except TypeError:
+                    # Some versions require keyword-only value parameter
+                    self._raw.progress(value=v, **kwargs)
 
         prog_widget = _ProgLike(raw)
     except Exception:
         class _NoopProg:
-            def progress(self, v):  # no-op fallback
+            def progress(self, v, *args, **kwargs):  # no-op fallback
                 pass
 
         prog_widget = _NoopProg()


### PR DESCRIPTION
## Summary
- pass through args/kwargs in progress widget wrapper
- handle Streamlit progress value becoming keyword-only across versions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5bb284d5c83329627dc15fd800a5c