### PR TITLE
Make progress UI version-proof

### DIFF
--- a/ui/components/progress.py
+++ b/ui/components/progress.py
@@ -1,17 +1,52 @@
 from __future__ import annotations
 
+import math
 import streamlit as st
 
 
+_BAR_WIDTH = 30  # characters
+
+
+def _to_percent(v) -> int:
+    """Normalize any numeric v to 0..100 int."""
+    try:
+        if isinstance(v, float):
+            if 0.0 <= v <= 1.0:
+                v = v * 100.0
+        v = int(round(float(v)))
+    except Exception:
+        v = 0
+    return max(0, min(100, v))
+
+
 class _StatusLike:
-    """Drop-in for st.status(): supports .update(label=..., state=...)."""
+    """Minimal shim compatible with st.status(...).update(label=..., state=...)."""
 
     def __init__(self, title_slot):
         self._title_slot = title_slot
 
     def update(self, label: str | None = None, state: str | None = None):
         if label:
-            self._title_slot.markdown(f"**{label}**")  # ignore state for compat
+            self._title_slot.markdown(f"**{label}**")
+        # state is accepted but ignored for broad compatibility
+
+
+class _ProgLike:
+    """Simple progress renderer using Markdown; avoids Streamlit version differences."""
+
+    def __init__(self, bar_slot):
+        self._bar_slot = bar_slot
+        self._last = -1
+
+    def progress(self, v):
+        pct = _to_percent(v)
+        if pct == self._last:
+            return
+        self._last = pct
+        filled = math.floor(pct / 100 * _BAR_WIDTH)
+        bar = "█" * filled + "░" * (_BAR_WIDTH - filled)
+        # Render as plain markdown to keep it universal
+        self._bar_slot.markdown(f"{pct}%\n\n`{bar}`")
 
 
 def status_block(title: str, key_prefix: str = "prog"):
@@ -19,51 +54,23 @@ def status_block(title: str, key_prefix: str = "prog"):
     Version-proof progress block built from primitives only.
     Returns: (status_like, prog_widget, log_fn)
       - status_like.update(label=..., state=...)
-      - prog_widget.progress(value, *args, **kwargs) where value can be
-        0..1 (float) or 0..100 (int)
+      - prog_widget.progress(value) where value can be 0..1 (float) or 0..100 (int)
       - log_fn(text) appends to a code block
     """
+
     title_slot = st.empty()
     title_slot.markdown(f"**{title}**")
 
-    # Progress: avoid passing key= (not supported in some versions),
-    # and normalize inputs so callers can pass float 0..1 or int 0..100.
-    try:
-        raw = st.progress(0)  # no key argument for max compatibility
-
-        class _ProgLike:
-            def __init__(self, raw_prog):
-                self._raw = raw_prog
-
-            def progress(self, v, *args, **kwargs):
-                # Normalize to 0..100 int and forward any other args/kwargs
-                try:
-                    if isinstance(v, float):
-                        if 0.0 <= v <= 1.0:
-                            v = int(round(v * 100))
-                        else:
-                            v = int(round(v))
-                    else:
-                        v = int(v)
-                except Exception:
-                    v = 0
-                v = max(0, min(100, v))
-                self._raw.progress(v, *args, **kwargs)
-
-        prog_widget = _ProgLike(raw)
-    except Exception:
-        class _NoopProg:
-            def progress(self, v, *args, **kwargs):  # no-op fallback
-                pass
-
-        prog_widget = _NoopProg()
+    bar_slot = st.empty()
+    prog_widget = _ProgLike(bar_slot)
 
     log_slot = st.empty()
     _buf: list[str] = []
 
     def log_fn(msg: str):
         _buf.append(str(msg))
-        # Keep last N lines to avoid growing forever
+        # Keep last N lines to avoid unbounded growth
         log_slot.code("\n".join(_buf[-200:]), language="text")
 
     return _StatusLike(title_slot), prog_widget, log_fn
+


### PR DESCRIPTION
## Summary
- replace Streamlit status/progress widgets with version-agnostic Markdown implementation
- normalize progress values and render ASCII bar via `st.empty()`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c5bee99c208332a73c1ada6a3e6706