### PR TITLE
fix: keep progress shim API compatible

### DIFF
--- a/ui/components/progress.py
+++ b/ui/components/progress.py
@@ -38,7 +38,9 @@ class _ProgLike:
         self._bar_slot = bar_slot
         self._last = -1
 
-    def progress(self, v):
+    def progress(self, v, *args, **kwargs):
+        """Update progress, absorbing extra args/kwargs for API compatibility."""
+        # Accept and ignore extra args/kwargs to mimic st.progress signature
         pct = _to_percent(v)
         if pct == self._last:
             return


### PR DESCRIPTION
## Summary
- absorb and ignore extra args/kwargs in `_ProgLike.progress` to preserve `st.progress` compatibility

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5bfb0c93c8332bf0c5a75ec74e1bb