### PR TITLE
Resolve deployment crashes & warnings (tabulate, status key, use_container_width, Series.view)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ lxml>=4.9,<5
 requests==2.32.3
 # Supabase client (postgrest/gotrue/storage3 come as transitive deps)
 supabase>=2.6,<3
+tabulate>=0.9.0

--- a/ui/components/progress.py
+++ b/ui/components/progress.py
@@ -65,25 +65,41 @@ def status_block(title: str, key_prefix: str = "prog"):
       - log_fn(text) appends to a code block (keeps last ~200 lines)
     """
 
-    title_slot = st.container(key=f"{key_prefix}_status").empty()
     try:
-        title_slot.markdown(f"**{title}**")
+        status = st.status(title, expanded=True)
+        bar_slot = status.empty()
+        prog_widget = bar_slot.progress(0, key=f"{key_prefix}_prog")
+        log_slot = status.empty()
+        _buf: list[str] = []
+
+        def log_fn(msg: str):
+            try:
+                _buf.append(str(msg))
+                log_slot.code("\n".join(_buf[-200:]), language="text")
+            except Exception:
+                pass
+
+        return status, prog_widget, log_fn
     except Exception:
-        pass
-
-    bar_slot = st.container(key=f"{key_prefix}_prog").empty()
-    prog_widget = _ProgLike(bar_slot)
-
-    log_slot = st.container(key=f"{key_prefix}_log").empty()
-    _buf: list[str] = []
-
-    def log_fn(msg: str):
+        title_slot = st.container(key=f"{key_prefix}_status").empty()
         try:
-            _buf.append(str(msg))
-            # Keep last N lines to avoid unbounded growth
-            log_slot.code("\n".join(_buf[-200:]), language="text")
+            title_slot.markdown(f"**{title}**")
         except Exception:
             pass
 
-    return _StatusLike(title_slot), prog_widget, log_fn
+        bar_slot = st.container(key=f"{key_prefix}_prog").empty()
+        prog_widget = _ProgLike(bar_slot)
+
+        log_slot = st.container(key=f"{key_prefix}_log").empty()
+        _buf: list[str] = []
+
+        def log_fn(msg: str):
+            try:
+                _buf.append(str(msg))
+                # Keep last N lines to avoid unbounded growth
+                log_slot.code("\n".join(_buf[-200:]), language="text")
+            except Exception:
+                pass
+
+        return _StatusLike(title_slot), prog_widget, log_fn
 

--- a/ui/history.py
+++ b/ui/history.py
@@ -245,7 +245,7 @@ def outcomes_summary(dfh: pd.DataFrame):
     mask = dfh["Expiry_parsed"].notna()
     if mask.any():
         base_ns = pd.Timestamp.utcnow().normalize().value  # int64 ns at 00:00 UTC today
-        exp_ns = dfh.loc[mask, "Expiry_parsed"].view("int64")
+        exp_ns = dfh.loc[mask, "Expiry_parsed"].astype("int64")
         NS_PER_DAY = 86_400_000_000_000
         dte_days = ((exp_ns - base_ns) // NS_PER_DAY).astype("int64")
         dfh.loc[mask, "DTE"] = pd.array(dte_days, dtype="Int64")

--- a/ui/pages/45_YdayVolSignal_Open.py
+++ b/ui/pages/45_YdayVolSignal_Open.py
@@ -17,12 +17,13 @@ def _render_df_with_copy(title: str, df: pd.DataFrame, key_prefix: str) -> None:
         return
 
     # visible table
-    st.dataframe(df, use_container_width=True)
+    st.dataframe(df, width="stretch")
 
-    # CSV text once
+    # text for controls
     csv_buf = io.StringIO()
     df.to_csv(csv_buf, index=False)
     csv_txt = csv_buf.getvalue()
+    md_txt = df.to_markdown(index=False)
 
     # download
     st.download_button(
@@ -35,8 +36,8 @@ def _render_df_with_copy(title: str, df: pd.DataFrame, key_prefix: str) -> None:
 
     # copyable textarea
     st.text_area(
-        "Copy CSV",
-        value=csv_txt,
+        "Copy Markdown",
+        value=md_txt,
         height=160,
         key=f"{key_prefix}_copy",
     )

--- a/ui/pages/55_Backtest_Range.py
+++ b/ui/pages/55_Backtest_Range.py
@@ -36,12 +36,13 @@ def _render_df_with_copy(title: str, df: pd.DataFrame, key_prefix: str) -> None:
         return
 
     # visible table
-    st.dataframe(df, use_container_width=True)
+    st.dataframe(df, width="stretch")
 
-    # CSV text once
+    # text for controls
     csv_buf = io.StringIO()
     df.to_csv(csv_buf, index=False)
     csv_txt = csv_buf.getvalue()
+    md_txt = df.to_markdown(index=False)
 
     # download
     st.download_button(
@@ -54,8 +55,8 @@ def _render_df_with_copy(title: str, df: pd.DataFrame, key_prefix: str) -> None:
 
     # copyable textarea
     st.text_area(
-        "Copy CSV",
-        value=csv_txt,
+        "Copy Markdown",
+        value=md_txt,
         height=160,
         key=f"{key_prefix}_copy",
     )
@@ -174,7 +175,7 @@ def render_page() -> None:
         save_outcomes = st.checkbox(
             "Save outcomes to lake", value=False, key="bt_save_outcomes"
         )
-        run = st.form_submit_button("Run backtest", use_container_width=True, key="bt_run")
+        run = st.form_submit_button("Run backtest", width="stretch", key="bt_run")
 
     if isinstance(start, (list, tuple)):
         start = start[0]


### PR DESCRIPTION
## Summary
- add `tabulate` dependency for markdown table rendering
- call `st.status` without unsupported `key` and keep robust fallback
- replace deprecated APIs (`use_container_width`, `Series.view`) across UI

## Testing
- `pytest -q`
- `streamlit run app.py` *(fails to install tabulate due to proxy, so runtime Markdown export not tested)*

------
https://chatgpt.com/codex/tasks/task_e_68c5cb46356c8332968fd47326e82ab2