### PR TITLE
Rewire backtest to Supabase, handle yfinance fails, fix duplicates & hashing

### DIFF
--- a/data_lake/storage.py
+++ b/data_lake/storage.py
@@ -314,12 +314,14 @@ def load_prices_cached(
     if supabase:
         for t in tickers:
             try:
+                row_limit = (end - start).days + 1
                 query = (
                     supabase.table("sp500_ohlcv")
                     .select("*")
                     .eq("ticker", t)
                     .gte("date", start.strftime("%Y-%m-%d"))
                     .lte("date", end.strftime("%Y-%m-%d"))
+                    .limit(row_limit)
                     .execute()
                 )
                 df = pd.DataFrame(query.data)


### PR DESCRIPTION
## Summary
- route OHLCV requests through Supabase with yfinance retry fallback
- guard against duplicate price columns and ignore storage hashing
- show empty-data messages via `st.info`
- ensure Supabase price fetch retrieves full date ranges

## Testing
- `pytest -q`
- `timeout 5 streamlit run app.py --server.headless true --server.port 8501`
- `python - <<'PY'
import pandas as pd
from data_lake.storage import pd as _pd
prices = pd.DataFrame(
    {
        'Date': pd.to_datetime(['2024-01-01']),
        'Close': [1],
        'Close': [2],
    }
)
prices = prices.loc[:, ~prices.columns.duplicated()]
print(prices)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68c5d36ea9c48332a83194f2027e3a68