### PR TITLE
Resolve ongoing import error & expand Supabase history queries

### DIFF
--- a/data_lake/storage.py
+++ b/data_lake/storage.py
@@ -334,17 +334,29 @@ def load_prices_cached(
                     df = pd.DataFrame(response.data)
                     if not df.empty:
                         df["Date"] = pd.to_datetime(df["date"])
-                        df = df[
-                            ["Date", "open", "high", "low", "close", "volume"]
-                        ].rename(
-                            columns={
-                                "open": "Open",
-                                "high": "High",
-                                "low": "Low",
-                                "close": "Close",
-                                "volume": "Volume",
-                            }
-                        ).set_index("Date")
+                        df = (
+                            df[
+                                [
+                                    "Date",
+                                    "ticker",
+                                    "open",
+                                    "high",
+                                    "low",
+                                    "close",
+                                    "volume",
+                                ]
+                            ]
+                            .rename(
+                                columns={
+                                    "open": "Open",
+                                    "high": "High",
+                                    "low": "Low",
+                                    "close": "Close",
+                                    "volume": "Volume",
+                                }
+                            )
+                            .set_index("Date")
+                        )
                         prices.append(df)
                         missing_tickers.discard(ticker)
             except Exception as e:
@@ -376,6 +388,7 @@ def load_prices_cached(
                 ticker, start.strftime("%Y-%m-%d"), end.strftime("%Y-%m-%d")
             )
             if not df.empty:
+                df["ticker"] = ticker
                 prices.append(df)
                 missing_tickers.discard(ticker)
 


### PR DESCRIPTION
## Summary
- expose `load_prices_cached` as module-level helper using Supabase-first lookup with large row limit and yfinance fallback
- ensure backtest page handles missing price data and drops duplicate columns
- pin `tabulate` dependency to 0.9.0
- preserve ticker column in price histories to avoid `KeyError`

## Testing
- `python -m py_compile data_lake/storage.py`
- `python -c "from data_lake.storage import load_prices_cached; print('Import OK')"`
- `timeout 5 streamlit run app.py --server.headless true`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement tabulate==0.9.0)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5d86f8e708332b7fab49f07d73201