### PR TITLE
Fix backtest submit button key error

### DIFF
--- a/tests/test_backtest_form.py
+++ b/tests/test_backtest_form.py
@@ -1,0 +1,6 @@
+import importlib
+
+
+def test_backtest_form_renders():
+    mod = importlib.import_module('ui.pages.55_Backtest_Range')
+    mod.render_page()

--- a/ui/pages/55_Backtest_Range.py
+++ b/ui/pages/55_Backtest_Range.py
@@ -157,7 +157,7 @@ def render_page() -> None:
         save_outcomes = st.checkbox(
             "Save outcomes to lake", value=False, key="bt_save_outcomes"
         )
-        run = st.form_submit_button("Run backtest", key="bt_run")
+        run = st.form_submit_button("Run backtest")
 
     if isinstance(start, (list, tuple)):
         start = start[0]


### PR DESCRIPTION
## Summary
- remove unsupported key argument from backtest page submit button
- add minimal test to ensure backtest form renders

## Testing
- ⚠️ `pip install -r requirements.txt --trusted-host pypi.org` (proxy 403)
- ✅ `python -c "from data_lake.storage import load_prices_cached; print('Import OK')"`
- ✅ `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5e4cb56b88332946410fa673b9b49