### PR TITLE
Load prices from storage for backtest

### DIFF
--- a/tests/test_load_prices_cached.py
+++ b/tests/test_load_prices_cached.py
@@ -1,0 +1,22 @@
+import pandas as pd
+from data_lake import storage as stg
+
+def test_load_prices_cached_reads_parquet(tmp_path, monkeypatch):
+    monkeypatch.setattr(stg, "LOCAL_ROOT", tmp_path)
+    s = stg.Storage()
+    df = pd.DataFrame(
+        {
+            "date": pd.date_range("2020-01-01", periods=2),
+            "open": [1.0, 2.0],
+            "high": [1.0, 2.0],
+            "low": [1.0, 2.0],
+            "close": [1.0, 2.0],
+            "volume": [10, 20],
+        }
+    )
+    p = tmp_path / "prices" / "AAA.parquet"
+    p.parent.mkdir(parents=True)
+    df.to_parquet(p)
+    out = stg.load_prices_cached(s, ["AAA"], pd.Timestamp("2020-01-01"), pd.Timestamp("2020-01-02"))
+    assert not out.empty
+    assert out["ticker"].unique().tolist() == ["AAA"]

--- a/ui/pages/55_Backtest_Range.py
+++ b/ui/pages/55_Backtest_Range.py
@@ -204,6 +204,15 @@ def render_page() -> None:
             prices: Dict[str, pd.DataFrame] = {}
             log(f"Preloading {len(active_tickers)} tickers…")
             prices_df = load_prices_cached(storage, active_tickers, start_date, end_date)
+            with st.expander("\U0001F50E Data preflight (debug)"):
+                st.write(f"Tickers chosen (first 10): {active_tickers[:10]}")
+                loaded = prices_df.get("ticker").unique().tolist() if not prices_df.empty else []
+                st.write(f"Loaded price series: {len(loaded)} / {len(active_tickers)}")
+                if loaded:
+                    df_sample = prices_df[prices_df.get("ticker") == loaded[0]]
+                    st.write(
+                        f"{loaded[0]}: {df_sample.shape}, range: {df_sample.index.min()} \u2192 {df_sample.index.max()}"
+                    )
             if prices_df.empty:
                 log("No prices loaded—check Supabase table/data.")
                 prog.progress(100, text="Prefetch complete")


### PR DESCRIPTION
## Summary
- use Supabase Storage parquet files for `load_prices_cached`
- show a small debug expander on Backtest page
- add regression test for `load_prices_cached`

## Testing
- `PYTHONPATH=. pytest tests/test_load_prices_cached.py -q`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5ea6430a083329b1120b4bfc7d914