### PR TITLE
Clarify price load errors and streamline backtest submit

### DIFF
--- a/data_lake/storage.py
+++ b/data_lake/storage.py
@@ -341,7 +341,7 @@ def load_prices_cached(
         prices.append(df)
 
     if not prices:
-        st.error("No price data loaded from storage.")
+        st.error("No price data loaded from Supabase Storage.")
         return pd.DataFrame()
 
     all_prices = pd.concat(prices, axis=0, ignore_index=True)
@@ -350,3 +350,6 @@ def load_prices_cached(
         all_prices = all_prices.loc[:, ~all_prices.columns.duplicated()]
         st.info("Dropped duplicate columns in prices.")
     return all_prices
+
+
+__all__ = ["Storage", "load_prices_cached"]

--- a/tests/test_load_prices_cached.py
+++ b/tests/test_load_prices_cached.py
@@ -20,3 +20,29 @@ def test_load_prices_cached_reads_parquet(tmp_path, monkeypatch):
     out = stg.load_prices_cached(s, ["AAA"], pd.Timestamp("2020-01-01"), pd.Timestamp("2020-01-02"))
     assert not out.empty
     assert out["ticker"].unique().tolist() == ["AAA"]
+
+
+def test_load_prices_cached_uses_cache(tmp_path, monkeypatch):
+    monkeypatch.setattr(stg, "LOCAL_ROOT", tmp_path)
+    s = stg.Storage()
+    df = pd.DataFrame({"date": pd.date_range("2020-01-01", periods=1), "open": [1], "high": [1], "low": [1], "close": [1], "volume": [1]})
+    p = tmp_path / "prices" / "AAA.parquet"
+    p.parent.mkdir(parents=True)
+    df.to_parquet(p)
+
+    calls = {"n": 0}
+
+    orig = stg.Storage.read_bytes
+
+    def fake_read_bytes(self, path):
+        calls["n"] += 1
+        return orig(self, path)
+
+    monkeypatch.setattr(stg.Storage, "read_bytes", fake_read_bytes)
+
+    start = pd.Timestamp("2020-01-01")
+    end = pd.Timestamp("2020-01-01")
+    stg.load_prices_cached(s, ["AAA"], start, end)
+    stg.load_prices_cached(s, ["AAA"], start, end)
+
+    assert calls["n"] == 1

--- a/ui/pages/55_Backtest_Range.py
+++ b/ui/pages/55_Backtest_Range.py
@@ -11,16 +11,6 @@ from engine.signal_scan import ScanParams, members_on_date
 from ui.components.progress import status_block
 
 
-def _submit_button(label: str) -> bool:
-    """Compatibility wrapper for Streamlit form submit button.
-
-    Streamlit 1.39.1 does not accept a ``key`` parameter on
-    ``st.form_submit_button``. Use this helper to avoid passing unsupported
-    arguments in older versions.
-    """
-    return st.form_submit_button(label)
-
-
 def _render_df_with_copy(title: str, df: pd.DataFrame, key_prefix: str) -> None:
     st.subheader(title)
     if df is None or df.empty:
@@ -167,7 +157,7 @@ def render_page() -> None:
         save_outcomes = st.checkbox(
             "Save outcomes to lake", value=False, key="bt_save_outcomes"
         )
-        run = _submit_button("Run backtest")
+        run = st.form_submit_button("Run backtest")
 
     if isinstance(start, (list, tuple)):
         start = start[0]


### PR DESCRIPTION
## Summary
- Surface a clearer message when Supabase Storage has no price data and export `load_prices_cached` from the storage module.
- Remove the legacy submit-button wrapper and call `st.form_submit_button` directly in the backtest page.
- Add a regression test ensuring `load_prices_cached` uses Streamlit caching.

## Testing
- `PYTHONPATH=. pytest tests/test_load_prices_cached.py tests/test_backtest_form.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c609b5ba2c833286e0f60c89f61131