### PR TITLE
Fix Supabase table lookup in loader

### DIFF
--- a/data_lake/storage.py
+++ b/data_lake/storage.py
@@ -303,49 +303,121 @@ class Storage:
 def load_prices_cached(
     _storage: Storage,
     tickers: List[str],
-    start: pd.Timestamp | None = None,
-    end: pd.Timestamp | None = None,
+    start: pd.Timestamp,
+    end: pd.Timestamp,
 ) -> pd.DataFrame:
-    """Load OHLCV data from Supabase Storage parquet files.
+    """Load OHLCV data between ``start`` and ``end``.
 
-    Returns a ``DataFrame`` indexed by ``date`` with a ``ticker`` column. Any
-    missing tickers are skipped silently.
+    If a Supabase ``Client`` is available, rows are fetched from the
+    ``sp500_ohlcv`` table using paginated queries.  Otherwise parquet files in
+    the ``prices/`` prefix are read.  A DataFrame indexed by ``Date`` with a
+    ``ticker`` column is returned; missing tickers are skipped silently.
     """
 
+    supabase: Client | None = getattr(_storage, "supabase_client", None)
     prices: list[pd.DataFrame] = []
-    for ticker in tickers:
-        path = f"prices/{ticker}.parquet"
-        try:
-            buf = _storage.read_bytes(path)
-        except Exception:
-            continue
-        try:
-            df = pd.read_parquet(io.BytesIO(buf))
-        except Exception:
-            continue
-        if df.empty:
-            continue
-        if "date" not in df.columns:
-            if "Date" in df.columns:
-                df = df.rename(columns={"Date": "date"})
-            else:
+    failed: set[str] = set()
+
+    if supabase is not None:
+        page_size = 1000
+        for ticker in tickers:
+            offset = 0
+            rows: list[dict] = []
+            while True:
+                try:
+                    resp = (
+                        supabase.table("sp500_ohlcv")
+                        .select("ticker, date, open, high, low, close, volume")
+                        .eq("ticker", ticker)
+                        .gte("date", start.strftime("%Y-%m-%d"))
+                        .lte("date", end.strftime("%Y-%m-%d"))
+                        .order("date")
+                        .range(offset, offset + page_size - 1)
+                        .execute()
+                    )
+                except Exception as e:
+                    failed.add(ticker)
+                    st.error(f"Supabase query failed for {ticker}: {e}")
+                    break
+                if not resp.data:
+                    break
+                rows.extend(resp.data)
+                if len(resp.data) < page_size:
+                    break
+                offset += page_size
+
+            if not rows:
+                try:
+                    buf = _storage.read_bytes(f"prices/{ticker}.parquet")
+                    df = pd.read_parquet(io.BytesIO(buf))
+                    if "date" not in df.columns:
+                        if "Date" in df.columns:
+                            df = df.rename(columns={"Date": "date"})
+                        else:
+                            raise ValueError("missing date column")
+                    df["date"] = pd.to_datetime(df["date"], utc=False).dt.tz_localize(None)
+                    df = df[(df["date"] >= start) & (df["date"] <= end)]
+                    if df.empty:
+                        raise ValueError("empty after filter")
+                    df["ticker"] = ticker
+                    prices.append(df.set_index("date"))
+                    continue
+                except Exception:
+                    failed.add(ticker)
+                    continue
+            df = pd.DataFrame(rows)
+            if df.empty:
+                failed.add(ticker)
                 continue
-        df["date"] = pd.to_datetime(df["date"], utc=False).dt.tz_localize(None)
-        if start is not None:
-            df = df[df["date"] >= pd.to_datetime(start)]
-        if end is not None:
-            df = df[df["date"] <= pd.to_datetime(end)]
-        if df.empty:
-            continue
-        df["ticker"] = ticker
-        prices.append(df)
+            df["Date"] = pd.to_datetime(df["date"], errors="coerce")
+            df = df[
+                [
+                    "Date",
+                    "open",
+                    "high",
+                    "low",
+                    "close",
+                    "volume",
+                    "ticker",
+                ]
+            ].rename(
+                columns={
+                    "open": "Open",
+                    "high": "High",
+                    "low": "Low",
+                    "close": "Close",
+                    "volume": "Volume",
+                }
+            )
+            df = df.set_index("Date")
+            prices.append(df)
+    else:
+        for ticker in tickers:
+            path = f"prices/{ticker}.parquet"
+            try:
+                buf = _storage.read_bytes(path)
+                df = pd.read_parquet(io.BytesIO(buf))
+            except Exception:
+                continue
+            if df.empty:
+                continue
+            if "date" not in df.columns:
+                if "Date" in df.columns:
+                    df = df.rename(columns={"Date": "date"})
+                else:
+                    continue
+            df["date"] = pd.to_datetime(df["date"], utc=False).dt.tz_localize(None)
+            df = df[(df["date"] >= start) & (df["date"] <= end)]
+            if df.empty:
+                continue
+            df["ticker"] = ticker
+            prices.append(df.set_index("date"))
 
     if not prices:
-        st.error("No price data loaded from Supabase Storage.")
+        st.error("No price data loaded from Supabase or storage.")
         return pd.DataFrame()
 
-    all_prices = pd.concat(prices, axis=0, ignore_index=True)
-    all_prices = all_prices.set_index("date")
+    all_prices = pd.concat(prices, axis=0)
     if not all_prices.columns.is_unique:
         all_prices = all_prices.loc[:, ~all_prices.columns.duplicated()]
         st.info("Dropped duplicate columns in prices.")

--- a/tests/test_load_prices_cached.py
+++ b/tests/test_load_prices_cached.py
@@ -22,6 +22,49 @@ def test_load_prices_cached_reads_parquet(tmp_path, monkeypatch):
     assert out["ticker"].unique().tolist() == ["AAA"]
 
 
+def test_load_prices_cached_falls_back_to_parquet(tmp_path, monkeypatch):
+    monkeypatch.setattr(stg, "LOCAL_ROOT", tmp_path)
+    s = stg.Storage()
+    df = pd.DataFrame(
+        {
+            "date": pd.date_range("2020-01-01", periods=2),
+            "open": [1.0, 2.0],
+            "high": [1.0, 2.0],
+            "low": [1.0, 2.0],
+            "close": [1.0, 2.0],
+            "volume": [10, 20],
+        }
+    )
+    p = tmp_path / "prices" / "AAA.parquet"
+    p.parent.mkdir(parents=True)
+    df.to_parquet(p)
+
+    class FakeSupabase:
+        def table(self, _):
+            return self
+        def select(self, *_, **__):
+            return self
+        def eq(self, *_, **__):
+            return self
+        def gte(self, *_, **__):
+            return self
+        def lte(self, *_, **__):
+            return self
+        def order(self, *_, **__):
+            return self
+        def range(self, *_, **__):
+            return self
+        def execute(self):
+            return type("Resp", (), {"data": []})()
+
+    s.supabase_client = FakeSupabase()
+    out = stg.load_prices_cached(
+        s, ["AAA"], pd.Timestamp("2020-01-01"), pd.Timestamp("2020-01-02")
+    )
+    assert not out.empty
+    assert out["ticker"].unique().tolist() == ["AAA"]
+
+
 def test_load_prices_cached_uses_cache(tmp_path, monkeypatch):
     monkeypatch.setattr(stg, "LOCAL_ROOT", tmp_path)
     s = stg.Storage()


### PR DESCRIPTION
## Summary
- ensure price loader queries Supabase table `sp500_ohlcv` with pagination and local-parquet fallback
- fall back to parquet when Supabase query returns no rows

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c60cbafd2c83328efff31c4cf343dd