### PR TITLE
Use Supabase Storage for price data

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ## Data Source
 
-All price data is fetched from Supabase (`sp500_ohlcv`) using a paginated loader.
-Legacy `yfinance` imports have been removed in favor of Supabase-only
-backtests.
+Price history is loaded from Supabase Storage parquet files under
+`lake/prices/{TICKER}.parquet`. Legacy database table reads and `yfinance`
+imports have been removed in favor of this storage-based approach.
 
 ## Outcome Evaluation
 


### PR DESCRIPTION
## Summary
- switch price loading to Supabase Storage parquet files only
- add debug preflight for backtest and scanner pages
- clarify data source and add tests for storage loader

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c617c448b48332aa24e2e5aa4660c8