### PR TITLE
Normalize price dates to timezone-naive daily index

### DIFF
--- a/data_lake/storage.py
+++ b/data_lake/storage.py
@@ -338,10 +338,18 @@ def load_prices_cached(
     out = pd.concat(frames, ignore_index=True)
     out = out.drop_duplicates()
     out = out.set_index("date").sort_index()
+
+    # ensure datetime index with no timezone; daily-normalized
+    idx = pd.to_datetime(out.index, utc=True)
+    idx = idx.tz_convert("America/New_York").tz_localize(None)
+    out.index = idx.normalize()
+
     if start is not None:
-        out = out.loc[out.index >= pd.to_datetime(start)]
+        start = pd.Timestamp(start).normalize()
+        out = out.loc[out.index >= start]
     if end is not None:
-        out = out.loc[out.index <= pd.to_datetime(end)]
+        end = pd.Timestamp(end).normalize()
+        out = out.loc[out.index <= end]
     return out
 
 

--- a/tests/test_dates_tz_naive.py
+++ b/tests/test_dates_tz_naive.py
@@ -1,0 +1,43 @@
+import io
+import os
+import sys
+import pandas as pd
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from data_lake import storage as stg
+
+
+def test_load_prices_index_tz_naive(monkeypatch):
+    s = stg.Storage()
+    df = pd.DataFrame(
+        {
+            "date": pd.date_range("2020-01-01", periods=4, tz="America/New_York"),
+            "open": [1, 2, 3, 4],
+            "high": [1, 2, 3, 4],
+            "low": [1, 2, 3, 4],
+            "close": [1, 2, 3, 4],
+            "volume": [10, 20, 30, 40],
+        }
+    )
+    buf = io.BytesIO()
+    df.to_parquet(buf, index=False)
+
+    def fake_read_bytes(self, path: str) -> bytes:
+        assert path == "prices/AAA.parquet"
+        return buf.getvalue()
+
+    monkeypatch.setattr(stg.Storage, "read_bytes", fake_read_bytes)
+
+    start = pd.Timestamp("2020-01-01")
+    end = pd.Timestamp("2020-01-04")
+    out = stg.load_prices_cached(s, ["AAA"], start, end)
+
+    assert out.index.tz is None
+    assert out.index.equals(out.index.normalize())
+
+    start2 = pd.Timestamp("2020-01-02").normalize()
+    end2 = pd.Timestamp("2020-01-03").normalize()
+    sliced = out.loc[(out.index >= start2) & (out.index <= end2)]
+    assert len(sliced) == 2
+    assert sliced.index.min() == start2
+    assert sliced.index.max() == end2

--- a/tests/test_load_prices_cached.py
+++ b/tests/test_load_prices_cached.py
@@ -9,7 +9,7 @@ def test_load_prices_cached_concat_and_filter(monkeypatch):
 
     df_a = pd.DataFrame(
         {
-            "date": pd.date_range("2020-01-01", periods=3),
+            "date": pd.date_range("2020-01-01", periods=3, tz="America/New_York"),
             "open": [1, 2, 3],
             "high": [1, 2, 3],
             "low": [1, 2, 3],
@@ -22,7 +22,7 @@ def test_load_prices_cached_concat_and_filter(monkeypatch):
 
     df_b = pd.DataFrame(
         {
-            "date": pd.date_range("2020-01-01", periods=3),
+            "date": pd.date_range("2020-01-01", periods=3, tz="America/New_York"),
             "open": [4, 5, 6],
             "high": [4, 5, 6],
             "low": [4, 5, 6],


### PR DESCRIPTION
## Summary
- strip timezone and normalize price data to daily index in loader
- normalize UI date inputs for scanner and backtest and expand debug info
- add tests ensuring tz-naive handling and adjust existing cache test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6258ec1948332b09578cfc8fa138f