### PR TITLE
Fix naive price date normalization in load_prices_cached

### DIFF
--- a/data_lake/storage.py
+++ b/data_lake/storage.py
@@ -340,9 +340,12 @@ def load_prices_cached(
     out = out.set_index("date").sort_index()
 
     # ensure datetime index with no timezone; daily-normalized
-    idx = pd.to_datetime(out.index, utc=True)
-    idx = idx.tz_convert("America/New_York").tz_localize(None)
-    out.index = idx.normalize()
+    idx = pd.to_datetime(out.index)
+    if idx.tz is None:
+        idx = idx.tz_localize("America/New_York")
+    else:
+        idx = idx.tz_convert("America/New_York")
+    out.index = idx.normalize().tz_localize(None)
 
     if start is not None:
         start = pd.Timestamp(start).normalize()

--- a/tests/test_dates_tz_naive.py
+++ b/tests/test_dates_tz_naive.py
@@ -11,7 +11,7 @@ def test_load_prices_index_tz_naive(monkeypatch):
     s = stg.Storage()
     df = pd.DataFrame(
         {
-            "date": pd.date_range("2020-01-01", periods=4, tz="America/New_York"),
+            "date": pd.date_range("2020-01-01", periods=4),
             "open": [1, 2, 3, 4],
             "high": [1, 2, 3, 4],
             "low": [1, 2, 3, 4],
@@ -34,6 +34,8 @@ def test_load_prices_index_tz_naive(monkeypatch):
 
     assert out.index.tz is None
     assert out.index.equals(out.index.normalize())
+    assert out.index.min() == start
+    assert out.index.max() == end
 
     start2 = pd.Timestamp("2020-01-02").normalize()
     end2 = pd.Timestamp("2020-01-03").normalize()


### PR DESCRIPTION
## Summary
- avoid shifting naive price dates by localizing rather than converting from UTC
- add regression test covering naive price date handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6286ca97083328fa9d5d1b4c7ddd6