### PR TITLE
Normalize backtest date handling and drop duplicate price rows

### DIFF
--- a/tests/test_dates_tz_naive.py
+++ b/tests/test_dates_tz_naive.py
@@ -22,11 +22,11 @@ def test_load_prices_index_tz_naive(monkeypatch):
     buf = io.BytesIO()
     df.to_parquet(buf, index=False)
 
-    def fake_read_bytes(self, path: str) -> bytes:
+    def fake_read_parquet(self, path: str):
         assert path == "prices/AAA.parquet"
-        return buf.getvalue()
+        return pd.read_parquet(io.BytesIO(buf.getvalue()))
 
-    monkeypatch.setattr(stg.Storage, "read_bytes", fake_read_bytes)
+    monkeypatch.setattr(stg.Storage, "read_parquet", fake_read_parquet)
 
     start = pd.Timestamp("2020-01-01")
     end = pd.Timestamp("2020-01-04")

--- a/tests/test_tidy_members.py
+++ b/tests/test_tidy_members.py
@@ -1,0 +1,41 @@
+import pandas as pd
+
+from data_lake import storage as stg
+from engine import universe
+
+
+def test_tidy_prices_drops_duplicates_and_naive():
+    df = pd.DataFrame(
+        {
+            "date": pd.to_datetime([
+                "2020-01-01",
+                "2020-01-01",
+                "2020-01-02",
+            ]).tz_localize("America/New_York"),
+            "open": [1, 2, 3],
+            "high": [1, 2, 3],
+            "low": [1, 2, 3],
+            "close": [1, 2, 3],
+            "volume": [10, 20, 30],
+            "ticker": ["AAA", "AAA", "AAA"],
+        }
+    )
+    out = stg._tidy_prices(df)
+    assert out.index.tz is None
+    assert out.index.tolist() == [pd.Timestamp("2020-01-01"), pd.Timestamp("2020-01-02")]
+
+
+def test_members_on_date_tz_handling():
+    members = pd.DataFrame(
+        {
+            "ticker": ["AAA"],
+            "start_date": [pd.Timestamp("2020-01-01", tz="America/New_York")],
+            "end_date": [pd.Timestamp("2020-12-31", tz="America/New_York")],
+        }
+    )
+    d = pd.Timestamp("2020-06-01")
+    out = universe.members_on_date(members, d)
+    assert out["ticker"].tolist() == ["AAA"]
+    d2 = pd.Timestamp("2021-01-01")
+    out2 = universe.members_on_date(members, d2)
+    assert out2.empty


### PR DESCRIPTION
## Summary
- canonicalize and de-duplicate price data before concatenation
- normalize membership dates and assemble wide matrices with debug info
- add tests covering price tidying and tz-aware membership inputs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c63305dfac8332bf3da9fd5bbe000b