### PR TITLE
Fix missing price frame guard in backtest page

### DIFF
--- a/ui/pages/55_Backtest_Range.py
+++ b/ui/pages/55_Backtest_Range.py
@@ -203,6 +203,10 @@ def render_page() -> None:
             log(f"Preloading {len(active_tickers)} tickers…")
             prices_df = load_prices_cached(storage, active_tickers, start_ts, end_ts)
 
+            if prices_df.empty:
+                st.info("No price data loaded for backtest.")
+                return
+
             prices: Dict[str, pd.DataFrame] = {}
             g = prices_df.groupby("ticker", sort=False)
             series = []


### PR DESCRIPTION
## Summary
- guard against empty price DataFrame before grouping in Backtest Range page

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c634f388fc8332ab029c7e09fc5693