### PR TITLE
Handle duplicate price data and strengthen debugger

### DIFF
--- a/tests/test_debugger_fetch_history_columns.py
+++ b/tests/test_debugger_fetch_history_columns.py
@@ -1,0 +1,24 @@
+import pandas as pd
+from utils import prices as up
+
+
+def test_fetch_history_accepts_lowercase(monkeypatch):
+    def fake_load_prices_cached(storage, tickers, start, end):
+        df = pd.DataFrame(
+            {
+                "ticker": ["AAA"],
+                "date": [pd.Timestamp("2020-01-01")],
+                "open": [1],
+                "high": [1],
+                "low": [1],
+                "close": [1],
+                "volume": [100],
+            }
+        )
+        return df.set_index("date")
+
+    monkeypatch.setattr(up, "load_prices_cached", fake_load_prices_cached)
+
+    out = up.fetch_history("AAA")
+    assert set(["Open", "High", "Low", "Close", "Adj Close", "Volume", "Ticker"]).issubset(out.columns)
+    assert out.iloc[0]["Open"] == 1

--- a/tests/test_pivot_duplicate_safe.py
+++ b/tests/test_pivot_duplicate_safe.py
@@ -1,0 +1,20 @@
+import pandas as pd
+
+
+def test_pivot_duplicate_safe():
+    tidy = pd.DataFrame(
+        {
+            "ticker": ["AAA", "AAA", "BBB"],
+            "date": [
+                pd.Timestamp("2020-01-01"),
+                pd.Timestamp("2020-01-01"),
+                pd.Timestamp("2020-01-01"),
+            ],
+            "close": [1.0, 2.0, 3.0],
+        }
+    )
+    tidy = tidy.sort_values(["ticker", "date"]).drop_duplicates(["ticker", "date"], keep="last")
+    wide = tidy.pivot_table(index="date", columns="ticker", values="close", aggfunc="last")
+    wide = wide.loc[:, ~wide.columns.duplicated()].sort_index()
+    assert wide.loc[pd.Timestamp("2020-01-01"), "AAA"] == 2.0
+    assert wide.shape == (1, 2)

--- a/tests/test_tidy_members.py
+++ b/tests/test_tidy_members.py
@@ -1,28 +1,5 @@
 import pandas as pd
-
-from data_lake import storage as stg
 from engine import universe
-
-
-def test_tidy_prices_drops_duplicates_and_naive():
-    df = pd.DataFrame(
-        {
-            "date": pd.to_datetime([
-                "2020-01-01",
-                "2020-01-01",
-                "2020-01-02",
-            ]).tz_localize("America/New_York"),
-            "open": [1, 2, 3],
-            "high": [1, 2, 3],
-            "low": [1, 2, 3],
-            "close": [1, 2, 3],
-            "volume": [10, 20, 30],
-            "ticker": ["AAA", "AAA", "AAA"],
-        }
-    )
-    out = stg._tidy_prices(df)
-    assert out.index.tz is None
-    assert out.index.tolist() == [pd.Timestamp("2020-01-01"), pd.Timestamp("2020-01-02")]
 
 
 def test_members_on_date_tz_handling():

--- a/tests/test_tidy_prices.py
+++ b/tests/test_tidy_prices.py
@@ -1,0 +1,24 @@
+import pandas as pd
+from data_lake import storage as stg
+
+
+def test_tidy_prices_drops_duplicates_and_tz_naive():
+    df = pd.DataFrame(
+        {
+            "ticker": ["aaa", "AAA"],
+            "date": [
+                pd.Timestamp("2020-01-01", tz="UTC"),
+                pd.Timestamp("2020-01-01", tz="UTC"),
+            ],
+            "open": [1, 1],
+            "high": [1, 1],
+            "low": [1, 1],
+            "close": [1, 2],
+            "volume": [10, 20],
+        }
+    )
+    out, dropped = stg._tidy_prices(df)
+    assert dropped == 1
+    assert len(out) == 1
+    assert out["ticker"].tolist() == ["AAA"]
+    assert out["date"].dt.tz is None

--- a/ui/debugger.py
+++ b/ui/debugger.py
@@ -3,7 +3,6 @@ import html as _html
 import pandas as pd
 import streamlit as st
 import swing_options_screener as sos
-from utils.prices import fetch_history
 from utils.tickers import normalize_symbol
 from utils.formatting import _usd, _pct
 
@@ -116,12 +115,11 @@ def diagnose_ticker(
     symbol = normalize_symbol(original)
 
     df = sos._get_history(symbol) if symbol else None
-
-    if df is None and symbol:
-        df = fetch_history(
-            symbol,
-            start=pd.Timestamp.today() - pd.DateOffset(months=6),
+    if df is not None and df.empty:
+        st.warning(
+            "No OHLCV found for this ticker in storage; skipping legacy fetch."
         )
+        df = None
 
     entry = prev_close = today_vol = None
     src = {}


### PR DESCRIPTION
## Summary
- Deduplicate storage price data and surface stats
- Use duplicate-tolerant pivoting and diagnostics in backtest
- Accept lowercase OHLCV in debugger fetches and warn when data missing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c63a201e7083328520a5fed0bab87e