### PR TITLE
Add diagnostic hooks to Storage

### DIFF
--- a/data_lake/storage.py
+++ b/data_lake/storage.py
@@ -113,10 +113,20 @@ class Storage:
         self.mode = "local"
         self.bucket = None
         self._prices_cache: dict[str, pd.DataFrame] = {}
+        # mimic interface of production storage for UI diagnostics
+        self.key_info: dict[str, str] = {"kind": "service_role"}
 
     # The tests monkeypatch this method, so the implementation can be minimal.
     def read_parquet(self, path: str) -> pd.DataFrame:
         return pd.read_parquet(LOCAL_ROOT / path)
+
+    def info(self) -> str:
+        """Return a short description of the storage configuration."""
+        return f"mode={self.mode} root={LOCAL_ROOT}"
+
+    def selftest(self) -> dict[str, str | bool]:
+        """Basic self-test used by the Streamlit diagnostics pane."""
+        return {"ok": True, "mode": self.mode}
 
     def list_all(self, prefix: str) -> list[str]:
         if self.mode == "local":


### PR DESCRIPTION
## Summary
- add `info` and `selftest` helpers to `Storage`
- expose `key_info` metadata to mimic production interface

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c71a46fdc48332971a1dfb754d15f7