### PR TITLE
Add storage existence check and byte helpers

### DIFF
--- a/tests/test_storage_exists.py
+++ b/tests/test_storage_exists.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+from data_lake import storage
+
+
+def test_exists_local(tmp_path, monkeypatch):
+    monkeypatch.setattr(storage, "LOCAL_ROOT", tmp_path)
+    st = storage.Storage()
+    base = tmp_path / "prices"
+    base.mkdir(parents=True, exist_ok=True)
+    (base / "AAPL.parquet").write_text("x")
+    assert st.exists("prices/AAPL.parquet")
+    assert not st.exists("prices/MSFT.parquet")
+
+
+def test_exists_handles_apiresponse():
+    st = storage.Storage()
+    st.mode = "supabase"
+
+    class APIResp:
+        def __init__(self, data):
+            self.data = data
+
+    class Bucket:
+        def list(self, folder, *args, **kwargs):
+            if folder == "prices":
+                return APIResp([{"name": "AAPL.parquet"}])
+            return APIResp([])
+
+    st.bucket = Bucket()
+    assert st.exists("prices/AAPL.parquet") is True
+    assert st.exists("prices/MSFT.parquet") is False


### PR DESCRIPTION
## Summary
- add `read_bytes`, `write_bytes`, and `exists` methods to storage layer
- support local filesystem and stub remote listing
- add tests for `Storage.exists`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c71b9ba8a48332bc5937dee623f55f