### PR TITLE
Handle Supabase FileObject items in Storage.exists

### DIFF
--- a/data_lake/storage.py
+++ b/data_lake/storage.py
@@ -155,7 +155,13 @@ class Storage:
                 name = Path(path).name
                 resp = self.bucket.list(folder, search=name)
                 data = getattr(resp, "data", resp)
-                return any(item.get("name") == name for item in data)
+                for item in data:
+                    item_name = getattr(item, "name", None)
+                    if item_name is None and isinstance(item, dict):
+                        item_name = item.get("name")
+                    if item_name == name:
+                        return True
+                return False
             except Exception:
                 return False
 

--- a/tests/test_storage_exists.py
+++ b/tests/test_storage_exists.py
@@ -30,3 +30,26 @@ def test_exists_handles_apiresponse():
     st.bucket = Bucket()
     assert st.exists("prices/AAPL.parquet") is True
     assert st.exists("prices/MSFT.parquet") is False
+
+
+def test_exists_handles_fileobject():
+    st = storage.Storage()
+    st.mode = "supabase"
+
+    class FileObject:
+        def __init__(self, name: str):
+            self.name = name
+
+    class APIResp:
+        def __init__(self, data):
+            self.data = data
+
+    class Bucket:
+        def list(self, folder, *args, **kwargs):
+            if folder == "prices":
+                return APIResp([FileObject("AAPL.parquet")])
+            return APIResp([])
+
+    st.bucket = Bucket()
+    assert st.exists("prices/AAPL.parquet") is True
+    assert st.exists("prices/MSFT.parquet") is False


### PR DESCRIPTION
## Summary
- support Supabase FileObject items in `Storage.exists`
- add regression test covering attribute-based storage objects

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7214294a48332a9eb8a0036011400