### PR TITLE
Improve storage exists handling

### DIFF
--- a/data_lake/storage.py
+++ b/data_lake/storage.py
@@ -153,12 +153,15 @@ class Storage:
             try:
                 folder = str(Path(path).parent)
                 name = Path(path).name
-                resp = self.bucket.list(folder, search=name)
-                data = getattr(resp, "data", resp)
+                resp = self.bucket.list(folder)
+                data = getattr(resp, "data", resp) or []
                 for item in data:
                     item_name = getattr(item, "name", None)
-                    if item_name is None and isinstance(item, dict):
-                        item_name = item.get("name")
+                    if item_name is None:
+                        if isinstance(item, dict):
+                            item_name = item.get("name")
+                        elif isinstance(item, str):
+                            item_name = item
                     if item_name == name:
                         return True
                 return False

--- a/tests/test_storage_exists.py
+++ b/tests/test_storage_exists.py
@@ -53,3 +53,18 @@ def test_exists_handles_fileobject():
     st.bucket = Bucket()
     assert st.exists("prices/AAPL.parquet") is True
     assert st.exists("prices/MSFT.parquet") is False
+
+
+def test_exists_handles_string_list():
+    st = storage.Storage()
+    st.mode = "supabase"
+
+    class Bucket:
+        def list(self, folder, *args, **kwargs):
+            if folder == "prices":
+                return ["AAPL.parquet"]
+            return []
+
+    st.bucket = Bucket()
+    assert st.exists("prices/AAPL.parquet") is True
+    assert st.exists("prices/MSFT.parquet") is False


### PR DESCRIPTION
## Summary
- Extend storage.exists to understand string entries returned by bucket.list
- Test storage.exists with string list responses

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c722acd5f083328b63e7ecf785a6ea