### PR TITLE
Handle missing storage exists method in UI

### DIFF
--- a/tests/test_storage_has_file.py
+++ b/tests/test_storage_has_file.py
@@ -1,0 +1,24 @@
+import importlib
+import sys
+from pathlib import Path
+
+
+def test_storage_has_file_without_exists(tmp_path):
+    # Ensure repository root is on path so the UI module can be imported
+    repo_root = Path(__file__).resolve().parents[1]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+    mod = importlib.import_module("ui.pages.90_Data_Lake_Phase1")
+
+    class DummyStorage:
+        def read_bytes(self, path: str) -> bytes:
+            return (tmp_path / path).read_bytes()
+
+    base = tmp_path / "prices"
+    base.mkdir(parents=True, exist_ok=True)
+    (base / "AAPL.parquet").write_text("x")
+
+    st = DummyStorage()
+    assert mod._storage_has_file(st, "prices/AAPL.parquet") is True
+    assert mod._storage_has_file(st, "prices/MSFT.parquet") is False


### PR DESCRIPTION
## Summary
- Avoid AttributeError when storage backends lack an `exists` method
- Add fallback `_storage_has_file` helper used by Data Lake UI
- Test file-check helper against backend without `exists`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c724de356483328fb18a1cf1137654