### PR TITLE
Add Storage.exists and prefix listing with preflight debug

### DIFF
--- a/tests/test_storage_exists.py
+++ b/tests/test_storage_exists.py
@@ -68,3 +68,15 @@ def test_exists_handles_string_list():
     st.bucket = Bucket()
     assert st.exists("prices/AAPL.parquet") is True
     assert st.exists("prices/MSFT.parquet") is False
+
+
+def test_exists_local_custom_root(tmp_path):
+    """exists() and list_prefix should respect ``local_root`` overrides."""
+    lake = tmp_path / ".lake" / "prices"
+    lake.mkdir(parents=True)
+    (lake / "AAPL.parquet").write_text("x")
+    st = storage.Storage()
+    st.local_root = tmp_path / ".lake"
+    assert st.exists("prices/")
+    assert st.exists("prices/AAPL.parquet")
+    assert not st.exists("prices/MSFT.parquet")


### PR DESCRIPTION
## Summary
- implement `Storage.list_prefix` and `exists` with normalized paths for local and Supabase backends
- show sample objects and AAPL preview in Data Lake sanity check
- enhance backtest range preflight with file presence diagnostics
- add regression test covering `exists` with overridden local root

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c737d906e4833299bc37bb9c8c5c91