### PR TITLE
Fix list_prefix handling for relative local root

### DIFF
--- a/data_lake/storage.py
+++ b/data_lake/storage.py
@@ -165,18 +165,17 @@ class Storage:
 
         pfx = prefix.lstrip("/")
         if self.mode == "local":
+            root = self.local_root.resolve()
             base = (
-                (self.local_root / pfx).parent
-                if pfx.endswith(".parquet")
-                else (self.local_root / pfx)
+                (root / pfx).parent if pfx.endswith(".parquet") else (root / pfx)
             ).resolve()
             results: list[str] = []
             if base.is_file():
-                results.append(str(base.relative_to(self.local_root)).replace("\\", "/"))
+                results.append(str(base.relative_to(root)).replace("\\", "/"))
             elif base.exists():
                 for path in base.rglob("*"):
                     if path.is_file():
-                        rel = str(path.relative_to(self.local_root)).replace("\\", "/")
+                        rel = str(path.relative_to(root)).replace("\\", "/")
                         results.append(rel)
             return sorted(results)
 

--- a/tests/test_storage_exists.py
+++ b/tests/test_storage_exists.py
@@ -80,3 +80,16 @@ def test_exists_local_custom_root(tmp_path):
     assert st.exists("prices/")
     assert st.exists("prices/AAPL.parquet")
     assert not st.exists("prices/MSFT.parquet")
+
+
+def test_list_prefix_relative_root(tmp_path, monkeypatch):
+    """list_prefix and exists work when ``local_root`` is relative."""
+    monkeypatch.chdir(tmp_path)
+    rel = Path("lake")
+    (rel / "history").mkdir(parents=True)
+    (rel / "history" / "AAPL.parquet").write_text("x")
+    monkeypatch.setattr(storage, "LOCAL_ROOT", rel)
+    st = storage.Storage()
+    assert st.list_prefix("history/") == ["history/AAPL.parquet"]
+    assert st.exists("history/")
+    assert st.exists("history/AAPL.parquet")


### PR DESCRIPTION
## Summary
- resolve local_root before computing relative paths in list_prefix to avoid ValueError when using relative roots
- add regression test ensuring list_prefix and exists work with a relative local_root

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c73bee97c083328ff0762dc882811a