### PR TITLE
Address review feedback: normalize Supabase loader and restore parquet backend

### DIFF
--- a/data_lake/storage.py
+++ b/data_lake/storage.py
@@ -343,30 +343,7 @@ def load_prices_cached(
                 if ticker_rows:
                     df = pd.DataFrame(ticker_rows)
                     if not df.empty:
-                        df["Date"] = pd.to_datetime(df["date"])
-                        df = (
-                            df[
-                                [
-                                    "Date",
-                                    "open",
-                                    "high",
-                                    "low",
-                                    "close",
-                                    "volume",
-                                    "ticker",
-                                ]
-                            ]
-                            .rename(
-                                columns={
-                                    "open": "Open",
-                                    "high": "High",
-                                    "low": "Low",
-                                    "close": "Close",
-                                    "volume": "Volume",
-                                }
-                            )
-                            .set_index("Date")
-                        )
+                        df = _tidy_prices(df, ticker)
                         prices.append(df)
                     else:
                         failed_tickers.add(ticker)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ streamlit==1.39.1
 pandas==2.2.3
 supabase==2.18.1
 tabulate==0.9.0
+pyarrow==15.0.2


### PR DESCRIPTION
## Summary
- harmonize Supabase-backed `load_prices_cached` with local cache by normalizing ticker and adjusted close columns
- reintroduce `pyarrow` in requirements to support `pd.read_parquet`

## Testing
- `pip install -r requirements.txt --trusted-host pypi.org --no-cache-dir` *(fails: Could not find a version that satisfies the requirement pyarrow==15.0.2)*
- `python -c "from data_lake.storage import load_prices_cached; print('Import OK')"`
- `streamlit run app.py --server.headless true --server.port 8501`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c75ab09f188332a324dadfc9987060