### PR TITLE
feat: add universal debug panel

### DIFF
--- a/ui/components/debug.py
+++ b/ui/components/debug.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+import time, json, traceback, sys, platform, datetime as dt
+from contextlib import contextmanager
+from typing import Any, Dict, Optional
+import streamlit as st
+
+REDACT_KEYS = ("key", "secret", "token", "password")
+
+
+def _redact_secrets(d: Dict[str, Any]) -> Dict[str, Any]:
+    out = {}
+    for k, v in d.items():
+        if any(s in k.lower() for s in REDACT_KEYS):
+            out[k] = "***REDACTED***"
+        else:
+            out[k] = v
+    return out
+
+
+class DebugLog:
+    """Session-scoped debug collector."""
+
+    def __init__(self, name: str = "dbg"):
+        self.name = name
+        self._data = {
+            "meta": {
+                "session_started": dt.datetime.utcnow().isoformat() + "Z",
+                "python": sys.version.split()[0],
+                "platform": platform.platform(),
+                "streamlit": getattr(st, "__version__", "unknown"),
+            },
+            "params": {},
+            "env": {},
+            "events": [],  # list of {"t": "...", "name": "...", "data": {...}, "ms": N}
+            "errors": [],  # list of {"t": "...", "where": "...", "exc": "..."}
+        }
+
+    def set_params(self, **kwargs):
+        self._data["params"].update(kwargs)
+
+    def set_env(self, **kwargs):
+        self._data["env"].update(kwargs)
+
+    def event(self, name: str, **data):
+        self._data["events"].append({
+            "t": dt.datetime.utcnow().isoformat() + "Z",
+            "name": name,
+            "data": data,
+        })
+
+    def error(self, where: str, exc: BaseException):
+        self._data["errors"].append({
+            "t": dt.datetime.utcnow().isoformat() + "Z",
+            "where": where,
+            "exc": "".join(traceback.format_exception(type(exc), exc, exc.__traceback__)),
+        })
+
+    @contextmanager
+    def step(self, name: str, **data):
+        t0 = time.perf_counter()
+        self.event(f"{name}:start", **data)
+        try:
+            yield
+            ms = int((time.perf_counter() - t0) * 1000)
+            self.event(f"{name}:done", ms=ms)
+        except BaseException as e:
+            ms = int((time.perf_counter() - t0) * 1000)
+            self.event(f"{name}:fail", ms=ms)
+            self.error(name, e)
+            raise
+
+    def export_text(self) -> str:
+        # redact secrets in env/params
+        data = dict(self._data)
+        data["env"] = _redact_secrets(data.get("env", {}))
+        data["params"] = _redact_secrets(data.get("params", {}))
+        return json.dumps(data, indent=2, default=str)
+
+
+def _get_dbg(name: str) -> DebugLog:
+    key = f"__debuglog_{name}"
+    if key not in st.session_state:
+        st.session_state[key] = DebugLog(name)
+    return st.session_state[key]
+
+
+def debug_panel(name: str = "page", extra_info: Optional[dict] = None):
+    """
+    Returns (dbg) and renders a collapsible debug block at the bottom.
+    Usage:
+        dbg = debug_panel("backtest")
+        dbg.set_params(**params_dict)
+        with dbg.step("load_prices"):
+            ...
+    """
+    dbg = _get_dbg(name)
+    if extra_info:
+        dbg.set_env(**extra_info)
+    try:
+        with st.expander("🐞 Debug panel", expanded=False):
+            st.caption("Everything below is for diagnostics. Safe to share (secrets redacted).")
+            txt = dbg.export_text()
+            st.text_area("Report (JSON)", value=txt, height=300, key=f"{name}_json", label_visibility="collapsed")
+            st.download_button("Download JSON", data=txt.encode("utf-8"), file_name=f"{name}_debug.json", mime="application/json", key=f"{name}_dl")
+    except Exception:
+        pass
+    return dbg

--- a/ui/pages/45_YdayVolSignal_Open.py
+++ b/ui/pages/45_YdayVolSignal_Open.py
@@ -9,6 +9,7 @@ import engine.signal_scan as sigscan
 from engine.signal_scan import scan_day, ScanParams, members_on_date
 from data_lake.storage import Storage, load_prices_cached
 from ui.components.progress import status_block
+from ui.components.debug import debug_panel, _get_dbg
 
 
 def _render_df_with_copy(title: str, df: pd.DataFrame, key_prefix: str) -> None:
@@ -47,6 +48,10 @@ def _render_df_with_copy(title: str, df: pd.DataFrame, key_prefix: str) -> None:
 def render_page() -> None:
     st.header("⚡ Yesterday Close+Volume → Buy Next Open")
 
+    storage = Storage()
+    dbg = _get_dbg("scan")
+    dbg.set_env(storage_mode=getattr(storage, "mode", "unknown"), bucket=getattr(storage, "bucket", None))
+
     _d = st.date_input("Entry day (D)", value=dt.date.today())
     if isinstance(_d, (list, tuple)):
         _d = _d[0]
@@ -66,7 +71,6 @@ def render_page() -> None:
         status, prog, log = status_block("Running filters…", key_prefix="scan")
 
         try:
-            storage = Storage()
             params: ScanParams = {
                 "min_close_up_pct": min_close_up_pct,
                 "min_vol_multiple": min_vol_multiple,
@@ -76,14 +80,35 @@ def render_page() -> None:
                 "horizon_days": horizon,
                 "sr_min_ratio": sr_min_ratio,
             }
+            dbg.set_params(
+                entry_day=str(D.date()),
+                vol_lookback=vol_lookback,
+                min_close_up_pct=min_close_up_pct,
+                min_gap_open_pct=min_gap_open_pct,
+                min_volume_multiple=min_vol_multiple,
+                atr_window=atr_window,
+                horizon=horizon,
+                sr_min_ratio=sr_min_ratio,
+            )
 
             members = sigscan._load_members(storage)
             active_tickers = members_on_date(members, D)["ticker"].dropna().unique().tolist()
             start_date = D - pd.Timedelta(days=365)
             end_date = D + pd.Timedelta(days=horizon)
             log(f"Preloading {len(active_tickers)} tickers…")
-            prices_df = load_prices_cached(storage, active_tickers, start_date, end_date)
+            with dbg.step("preload_prices"):
+                prices_df = load_prices_cached(storage, active_tickers, start_date, end_date)
             prices_df = prices_df.loc[(prices_df.index >= start_date) & (prices_df.index <= end_date)]
+            loaded = prices_df.get("Ticker").nunique() if not prices_df.empty else 0
+            dbg.event(
+                "prices_loaded",
+                requested=len(active_tickers),
+                loaded=loaded,
+                index_dtype=str(getattr(prices_df.index, "dtype", "")),
+                tz=str(getattr(getattr(prices_df.index, "tz", None), "zone", None)),
+                min=str(prices_df.index.min() if not prices_df.empty else None),
+                max=str(prices_df.index.max() if not prices_df.empty else None),
+            )
             with st.expander("\U0001F50E Data preflight (debug)"):
                 st.write(f"Tickers requested: {len(active_tickers)}")
                 if prices_df.empty:
@@ -110,6 +135,7 @@ def render_page() -> None:
                 st.error(
                     "No price data loaded from Supabase Storage. Expected 'lake/prices/{TICKER}.parquet'."
                 )
+                debug_panel("scan")
                 return
 
             prices: Dict[str, pd.DataFrame] = {}
@@ -140,8 +166,14 @@ def render_page() -> None:
                 log(f"{i}/{total} {ticker} ✓")
 
             try:
-                cand_df, out_df, fails, _dbg = scan_day(
-                    storage, D, params, on_step=on_step
+                with dbg.step("run_signal_scan"):
+                    cand_df, out_df, fails, _dbg = scan_day(
+                        storage, D, params, on_step=on_step
+                    )
+                dbg.event(
+                    "scan_outcome",
+                    rows=len(cand_df) if cand_df is not None else 0,
+                    fails=len(fails) if fails is not None else 0,
                 )
             finally:
                 sigscan._load_prices = orig_load_prices
@@ -161,6 +193,7 @@ def render_page() -> None:
             status.update(label="Scan complete ✅", state="complete")
             st.toast(f"Scan done: {len(cand_df)} matches", icon="✅")
         except Exception as e:
+            dbg.error("scan", e)
             log(f"ERROR: {e}")
             status.update(label="Scan failed ❌", state="error")
         finally:
@@ -179,6 +212,8 @@ def render_page() -> None:
         st.dataframe(pd.DataFrame([summary]))
         _render_df_with_copy("✅ Candidates (matches)", cand_df, "matches")
         _render_df_with_copy("🎯 Outcomes", out_df, "outcomes")
+
+    debug_panel("scan")
 
 
 def page() -> None:


### PR DESCRIPTION
## Summary
- add reusable debug panel with secret redaction and timing breadcrumbs
- log storage diagnostics on Data Lake page
- instrument scanner and backtest pages with parameter capture and runtime events

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c75f5322148332b047c6e05ee5fd86