### PR TITLE
Enforce Supabase storage and add cache-busting diagnostics

### DIFF
--- a/data_lake/membership.py
+++ b/data_lake/membership.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pandas as pd
 
 from .storage import Storage
+import streamlit as st
 
 URL = "https://raw.githubusercontent.com/fja05680/sp500/master/sp500_ticker_start_end.csv"
 
@@ -55,7 +56,10 @@ def _load_github() -> pd.DataFrame:
     return df
 
 
-def load_membership(storage: Storage | None = None) -> pd.DataFrame:
+@st.cache_data(show_spinner=False, hash_funcs={Storage: lambda _: 0})
+def load_membership(
+    storage: Storage | None = None, cache_salt: str = ""
+) -> pd.DataFrame:
     if storage is None:
         storage = Storage()
     try:
@@ -77,7 +81,9 @@ def historical_tickers(
     Used by the UI to decide which symbols to ingest.
     """
 
-    df = load_membership(storage)
+    if storage is None:
+        storage = Storage()
+    df = load_membership(storage, cache_salt=storage.cache_salt())
     if df is None or df.empty:
         return []
     tickers = (

--- a/tests/test_cache_busts_on_mode.py
+++ b/tests/test_cache_busts_on_mode.py
@@ -1,0 +1,44 @@
+import io
+import os
+import sys
+import pandas as pd
+import streamlit as st
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from data_lake import storage as stg
+
+
+def test_cache_busts_on_mode(monkeypatch):
+    st.cache_data.clear()
+    s1 = stg.Storage()
+
+    df = pd.DataFrame(
+        {
+            "date": pd.date_range("2020-01-01", periods=2),
+            "open": [1, 2],
+            "high": [1, 2],
+            "low": [1, 2],
+            "close": [1, 2],
+            "volume": [10, 20],
+        }
+    )
+    buf = io.BytesIO()
+    df.to_parquet(buf, index=False)
+
+    calls = {"n": 0}
+
+    def fake_read_parquet(self, path: str):
+        calls["n"] += 1
+        return pd.read_parquet(io.BytesIO(buf.getvalue()))
+
+    monkeypatch.setattr(stg.Storage, "read_parquet", fake_read_parquet)
+
+    start = pd.Timestamp("2020-01-01")
+    end = pd.Timestamp("2020-01-02")
+
+    stg.load_prices_cached(s1, ["AAA"], start, end, cache_salt="mode=local")
+    stg.load_prices_cached(s1, ["AAA"], start, end, cache_salt="mode=local")
+    s2 = stg.Storage()
+    stg.load_prices_cached(s2, ["AAA"], start, end, cache_salt="mode=supabase")
+
+    assert calls["n"] == 2

--- a/tests/test_dates_tz_naive.py
+++ b/tests/test_dates_tz_naive.py
@@ -30,7 +30,7 @@ def test_load_prices_index_tz_naive(monkeypatch):
 
     start = pd.Timestamp("2020-01-01")
     end = pd.Timestamp("2020-01-04")
-    out = stg.load_prices_cached(s, ["AAA"], start, end)
+    out = stg.load_prices_cached(s, ["AAA"], start, end, cache_salt=s.cache_salt())
 
     assert out.index.tz is None
     assert out.index.equals(out.index.normalize())

--- a/tests/test_list_prefix_normalization.py
+++ b/tests/test_list_prefix_normalization.py
@@ -1,0 +1,23 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from data_lake.storage import Storage
+
+
+def test_list_prefix_normalizes_supabase_items():
+    st = Storage()
+    st.mode = "supabase"
+
+    class APIResp:
+        def __init__(self, data):
+            self.data = data
+
+    class Bucket:
+        def list(self, prefix):
+            assert prefix == "membership"
+            return APIResp([{"name": "sp500_members.parquet"}])
+
+    st.bucket = Bucket()
+    items = st.list_prefix("membership/")
+    assert items == ["membership/sp500_members.parquet"]

--- a/tests/test_load_prices_cached.py
+++ b/tests/test_load_prices_cached.py
@@ -48,6 +48,7 @@ def test_load_prices_cached_concat_and_filter(monkeypatch):
         ["AAA", "BBB", "CCC"],
         pd.Timestamp("2020-01-02"),
         pd.Timestamp("2020-01-03"),
+        cache_salt=s.cache_salt(),
     )
 
     assert sorted(out["Ticker"].unique()) == ["AAA", "BBB"]
@@ -81,7 +82,7 @@ def test_load_prices_cached_uses_cache(monkeypatch):
 
     start = pd.Timestamp("2020-01-01")
     end = pd.Timestamp("2020-01-02")
-    stg.load_prices_cached(s, ["AAA"], start, end)
-    stg.load_prices_cached(s, ["AAA"], start, end)
+    stg.load_prices_cached(s, ["AAA"], start, end, cache_salt=s.cache_salt())
+    stg.load_prices_cached(s, ["AAA"], start, end, cache_salt=s.cache_salt())
 
     assert calls["n"] == 1

--- a/tests/test_membership_historical_tickers.py
+++ b/tests/test_membership_historical_tickers.py
@@ -12,7 +12,11 @@ def test_historical_tickers_union(monkeypatch):
         ]
     )
 
-    monkeypatch.setattr(membership, "load_membership", lambda storage=None: df)
+    monkeypatch.setattr(
+        membership,
+        "load_membership",
+        lambda storage=None, cache_salt="": df,
+    )
 
     assert membership.historical_tickers() == ["AAA", "BBB"]
 

--- a/tests/test_storage_mode_switch.py
+++ b/tests/test_storage_mode_switch.py
@@ -1,0 +1,51 @@
+import types
+import os
+import sys
+import streamlit as st
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from data_lake import storage as stg
+
+
+def test_force_supabase_requires_package(monkeypatch):
+    monkeypatch.setenv("FORCE_SUPABASE", "1")
+    monkeypatch.setattr(st, "secrets", {"supabase": {"url": "u", "key": "k", "force": True}})
+    monkeypatch.setattr(stg, "supabase_available", lambda: (False, "missing"))
+    with pytest.raises(RuntimeError):
+        stg.Storage()
+
+
+def test_cache_salt_changes_with_url(monkeypatch):
+    monkeypatch.setenv("FORCE_SUPABASE", "1")
+    monkeypatch.setattr(stg, "supabase_available", lambda: (True, ""))
+
+    class DummyBucket:
+        def list(self, prefix):
+            return []
+
+    class DummyClient:
+        def __init__(self):
+            self.storage = types.SimpleNamespace(
+                from_=lambda name: DummyBucket(),
+                create_bucket=lambda name: None,
+            )
+
+    monkeypatch.setattr(stg, "create_client", lambda url, key: DummyClient())
+
+    monkeypatch.setattr(
+        st,
+        "secrets",
+        {"supabase": {"url": "https://a.supabase.co", "key": "k", "force": True}},
+    )
+    s1 = stg.Storage()
+
+    monkeypatch.setattr(
+        st,
+        "secrets",
+        {"supabase": {"url": "https://b.supabase.co", "key": "k", "force": True}},
+    )
+    s2 = stg.Storage()
+
+    assert s1.mode == s2.mode == "supabase"
+    assert s1.cache_salt() != s2.cache_salt()

--- a/utils/prices.py
+++ b/utils/prices.py
@@ -20,7 +20,7 @@ def fetch_history(
     if not ticker:
         return pd.DataFrame(columns=cols)
     s = Storage.from_env()
-    df = load_prices_cached(s, [ticker], start, end)
+    df = load_prices_cached(s, [ticker], start, end, cache_salt=s.cache_salt())
     if "Ticker" in df.columns:
         df = df[df["Ticker"] == ticker]
     if df.empty:


### PR DESCRIPTION
## Summary
- Detect Supabase credentials and require remote storage when forced
- Expose cache salt and bust Streamlit caches on mode/URL changes
- Add diagnostics banner and cache-clear to Data Lake UI; block scans when Supabase unavailable

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c764950e1883329349290fd51e185a