### PR TITLE
Handle forced Supabase mode and cache busting

### DIFF
--- a/tests/test_storage_mode_switch.py
+++ b/tests/test_storage_mode_switch.py
@@ -39,6 +39,7 @@ def test_cache_salt_changes_with_url(monkeypatch):
         {"supabase": {"url": "https://a.supabase.co", "key": "k", "force": True}},
     )
     s1 = stg.Storage()
+    salt1 = s1.cache_salt()
 
     monkeypatch.setattr(
         st,
@@ -48,4 +49,4 @@ def test_cache_salt_changes_with_url(monkeypatch):
     s2 = stg.Storage()
 
     assert s1.mode == s2.mode == "supabase"
-    assert s1.cache_salt() != s2.cache_salt()
+    assert salt1 != s2.cache_salt()

--- a/ui/pages/45_YdayVolSignal_Open.py
+++ b/ui/pages/45_YdayVolSignal_Open.py
@@ -52,9 +52,9 @@ def render_page() -> None:
     dbg = _get_dbg("scan")
     dbg.set_env(storage_mode=getattr(storage, "mode", "unknown"), bucket=getattr(storage, "bucket", None))
     st.caption(f"storage: {storage.info()} mode={storage.mode}")
-    if getattr(storage, "force_supabase", False) and getattr(storage, "mode", None) == "local":
+    if getattr(storage, "force_supabase", False) and storage.mode == "local":
         st.error(
-            "Supabase required. App is configured to force Supabase; see Data Lake page for self-test."
+            "Supabase is required but not available. Check secrets: [supabase] url/key, or disable supabase.force."
         )
         return
 

--- a/ui/pages/55_Backtest_Range.py
+++ b/ui/pages/55_Backtest_Range.py
@@ -51,9 +51,9 @@ def render_page() -> None:
     dbg = _get_dbg("backtest")
     dbg.set_env(storage_mode=getattr(storage, "mode", "unknown"), bucket=getattr(storage, "bucket", None))
     st.caption(f"storage: {storage.info()} mode={storage.mode}")
-    if storage.force_supabase and storage.mode == "local":
+    if getattr(storage, "force_supabase", False) and storage.mode == "local":
         st.error(
-            "Supabase required. App is configured to force Supabase; see Data Lake page for self-test."
+            "Supabase is required but not available. Check secrets: [supabase] url/key, or disable supabase.force."
         )
         return
 


### PR DESCRIPTION
## Summary
- Derive `force_supabase` from secrets or env and raise clear error when forced Supabase is unavailable
- Add cache salt keyed on storage mode and Supabase URL and expose richer storage info
- Safely guard UI pages against missing Supabase and pass cache salts to cached loaders

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c769ff2f288332bc2a306dd02b5df5