### PR TITLE
Force backtest to read Parquet from Storage and harden price loading

### DIFF
--- a/tests/test_fetch_history_on_storage.py
+++ b/tests/test_fetch_history_on_storage.py
@@ -3,7 +3,6 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from utils import prices as up
 from data_lake import storage as stg
 
-
 def test_fetch_history_on_storage(monkeypatch):
     df = pd.DataFrame(
         {
@@ -16,11 +15,15 @@ def test_fetch_history_on_storage(monkeypatch):
         }
     )
 
-    def fake_read_parquet(self, path: str):
+    def fake_exists(self, path: str) -> bool:
+        return path == "prices/AAA.parquet"
+
+    def fake_read_parquet_df(self, path: str):
         assert path == "prices/AAA.parquet"
         return df
 
-    monkeypatch.setattr(stg.Storage, "read_parquet", fake_read_parquet)
+    monkeypatch.setattr(stg.Storage, "exists", fake_exists)
+    monkeypatch.setattr(stg.Storage, "read_parquet_df", fake_read_parquet_df)
 
     out = up.fetch_history("AAA")
     assert list(out.columns) == ["Open", "High", "Low", "Close", "Adj Close", "Volume"]

--- a/tests/test_list_prefix_normalization.py
+++ b/tests/test_list_prefix_normalization.py
@@ -18,6 +18,20 @@ def test_list_prefix_normalizes_supabase_items():
             assert prefix == "membership"
             return APIResp([{"name": "sp500_members.parquet"}])
 
+    class Client:
+        class StorageAPI:
+            def __init__(self, bucket):
+                self._bucket = bucket
+
+            def from_(self, bucket_name):
+                assert bucket_name is st.bucket
+                return self._bucket
+
+        def __init__(self, bucket):
+            self.storage = Client.StorageAPI(bucket)
+
     st.bucket = Bucket()
+    st.supabase_client = Client(st.bucket)
+
     items = st.list_prefix("membership/")
     assert items == ["membership/sp500_members.parquet"]

--- a/tests/test_storage_exists.py
+++ b/tests/test_storage_exists.py
@@ -27,7 +27,21 @@ def test_exists_handles_apiresponse():
                 return APIResp([{"name": "AAPL.parquet"}])
             return APIResp([])
 
+    class Client:
+        class StorageAPI:
+            def __init__(self, bucket):
+                self._bucket = bucket
+
+            def from_(self, bucket_name):
+                assert bucket_name is st.bucket
+                return self._bucket
+
+        def __init__(self, bucket):
+            self.storage = Client.StorageAPI(bucket)
+
     st.bucket = Bucket()
+    st.supabase_client = Client(st.bucket)
+
     assert st.exists("prices/AAPL.parquet") is True
     assert st.exists("prices/MSFT.parquet") is False
 
@@ -50,7 +64,18 @@ def test_exists_handles_fileobject():
                 return APIResp([FileObject("AAPL.parquet")])
             return APIResp([])
 
+    class Client:
+        class StorageAPI:
+            def __init__(self, bucket):
+                self._bucket = bucket
+            def from_(self, bucket_name):
+                assert bucket_name is st.bucket
+                return self._bucket
+        def __init__(self, bucket):
+            self.storage = Client.StorageAPI(bucket)
+
     st.bucket = Bucket()
+    st.supabase_client = Client(st.bucket)
     assert st.exists("prices/AAPL.parquet") is True
     assert st.exists("prices/MSFT.parquet") is False
 
@@ -65,7 +90,18 @@ def test_exists_handles_string_list():
                 return ["AAPL.parquet"]
             return []
 
+    class Client:
+        class StorageAPI:
+            def __init__(self, bucket):
+                self._bucket = bucket
+            def from_(self, bucket_name):
+                assert bucket_name is st.bucket
+                return self._bucket
+        def __init__(self, bucket):
+            self.storage = Client.StorageAPI(bucket)
+
     st.bucket = Bucket()
+    st.supabase_client = Client(st.bucket)
     assert st.exists("prices/AAPL.parquet") is True
     assert st.exists("prices/MSFT.parquet") is False
 
@@ -77,7 +113,7 @@ def test_exists_local_custom_root(tmp_path):
     (lake / "AAPL.parquet").write_text("x")
     st = storage.Storage()
     st.local_root = tmp_path / ".lake"
-    assert st.exists("prices/")
+    assert not st.exists("prices/")
     assert st.exists("prices/AAPL.parquet")
     assert not st.exists("prices/MSFT.parquet")
 
@@ -91,5 +127,5 @@ def test_list_prefix_relative_root(tmp_path, monkeypatch):
     monkeypatch.setattr(storage, "LOCAL_ROOT", rel)
     st = storage.Storage()
     assert st.list_prefix("history/") == ["history/AAPL.parquet"]
-    assert st.exists("history/")
+    assert not st.exists("history/")
     assert st.exists("history/AAPL.parquet")

--- a/ui/pages/45_YdayVolSignal_Open.py
+++ b/ui/pages/45_YdayVolSignal_Open.py
@@ -108,9 +108,10 @@ def render_page() -> None:
                     active_tickers,
                     start_date,
                     end_date,
-                    cache_salt=storage.cache_salt(),
                 )
-            prices_df = prices_df.loc[(prices_df.index >= start_date) & (prices_df.index <= end_date)]
+            if not prices_df.empty:
+                prices_df = prices_df.set_index("date").sort_index()
+                prices_df = prices_df.loc[(prices_df.index >= start_date) & (prices_df.index <= end_date)]
             loaded = prices_df.get("Ticker").nunique() if not prices_df.empty else 0
             dbg.event(
                 "prices_loaded",

--- a/utils/prices.py
+++ b/utils/prices.py
@@ -20,9 +20,11 @@ def fetch_history(
     if not ticker:
         return pd.DataFrame(columns=cols)
     s = Storage.from_env()
-    df = load_prices_cached(s, [ticker], start, end, cache_salt=s.cache_salt())
+    df = load_prices_cached(s, [ticker], start, end)
     if "Ticker" in df.columns:
         df = df[df["Ticker"] == ticker]
     if df.empty:
         return pd.DataFrame(columns=cols)
+    if "date" in df.columns:
+        df = df.set_index("date").sort_index()
     return df[cols].copy()


### PR DESCRIPTION
## Summary
- normalize price frames to include `Ticker` and naive datetime index
- fix `list_prefix` and `exists` to handle Supabase v2 SDK and simple string listings
- load backtest data exclusively from `prices/*.parquet` in storage, with safer preflight debug

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c81806637c8332b6d3e613c76d28c9