### PR TITLE
feat: allow cache bust for price loads

### DIFF
--- a/tests/test_cache_busts_on_mode.py
+++ b/tests/test_cache_busts_on_mode.py
@@ -41,7 +41,50 @@ def test_cache_reuses_loaded_prices(monkeypatch):
     start = pd.Timestamp("2020-01-01")
     end = pd.Timestamp("2020-01-02")
 
-    stg.load_prices_cached(s, ["AAA"], start, end)
-    stg.load_prices_cached(s, ["AAA"], start, end)
+    stg.load_prices_cached(s, cache_salt=s.cache_salt(), tickers=["AAA"], start=start, end=end)
+    stg.load_prices_cached(s, cache_salt=s.cache_salt(), tickers=["AAA"], start=start, end=end)
 
     assert calls["n"] == 1
+
+
+def test_cache_busts_on_cache_salt(monkeypatch):
+    st.cache_data.clear()
+    s1 = stg.Storage()
+    s2 = stg.Storage()
+
+    df = pd.DataFrame(
+        {
+            "date": pd.date_range("2020-01-01", periods=2),
+            "open": [1, 2],
+            "high": [1, 2],
+            "low": [1, 2],
+            "close": [1, 2],
+            "volume": [10, 20],
+        }
+    )
+    buf = io.BytesIO()
+    df.to_parquet(buf, index=False)
+
+    calls = {"n": 0}
+
+    def fake_exists(self, path: str) -> bool:
+        return True
+
+    def fake_read_parquet_df(self, path: str):
+        calls["n"] += 1
+        return pd.read_parquet(io.BytesIO(buf.getvalue()))
+
+    monkeypatch.setattr(stg.Storage, "exists", fake_exists)
+    monkeypatch.setattr(stg.Storage, "read_parquet_df", fake_read_parquet_df)
+
+    start = pd.Timestamp("2020-01-01")
+    end = pd.Timestamp("2020-01-02")
+
+    # Ensure storages report different salts
+    monkeypatch.setattr(s1, "cache_salt", lambda: "salt1")
+    monkeypatch.setattr(s2, "cache_salt", lambda: "salt2")
+
+    stg.load_prices_cached(s1, cache_salt=s1.cache_salt(), tickers=["AAA"], start=start, end=end)
+    stg.load_prices_cached(s2, cache_salt=s2.cache_salt(), tickers=["AAA"], start=start, end=end)
+
+    assert calls["n"] == 2

--- a/tests/test_dates_tz_naive.py
+++ b/tests/test_dates_tz_naive.py
@@ -35,7 +35,13 @@ def test_load_prices_index_tz_naive(monkeypatch):
 
     start = pd.Timestamp("2020-01-01")
     end = pd.Timestamp("2020-01-04")
-    out = stg.load_prices_cached(s, ["AAA"], start, end)
+    out = stg.load_prices_cached(
+        s,
+        cache_salt=s.cache_salt(),
+        tickers=["AAA"],
+        start=start,
+        end=end,
+    )
     out = out.set_index("date")
 
     assert out.index.tz is None

--- a/tests/test_load_prices_cached.py
+++ b/tests/test_load_prices_cached.py
@@ -51,9 +51,10 @@ def test_load_prices_cached_concat_and_filter(monkeypatch):
     st.cache_data.clear()
     out = stg.load_prices_cached(
         s,
-        ["AAA", "BBB", "CCC"],
-        pd.Timestamp("2020-01-02"),
-        pd.Timestamp("2020-01-03"),
+        cache_salt=s.cache_salt(),
+        tickers=["AAA", "BBB", "CCC"],
+        start=pd.Timestamp("2020-01-02"),
+        end=pd.Timestamp("2020-01-03"),
     )
     out = out.set_index("date")
 
@@ -93,7 +94,7 @@ def test_load_prices_cached_uses_cache(monkeypatch):
     start = pd.Timestamp("2020-01-01")
     end = pd.Timestamp("2020-01-02")
     st.cache_data.clear()
-    stg.load_prices_cached(s, ["AAA"], start, end)
-    stg.load_prices_cached(s, ["AAA"], start, end)
+    stg.load_prices_cached(s, cache_salt=s.cache_salt(), tickers=["AAA"], start=start, end=end)
+    stg.load_prices_cached(s, cache_salt=s.cache_salt(), tickers=["AAA"], start=start, end=end)
 
     assert calls["n"] == 1

--- a/ui/pages/45_YdayVolSignal_Open.py
+++ b/ui/pages/45_YdayVolSignal_Open.py
@@ -105,9 +105,10 @@ def render_page() -> None:
             with dbg.step("preload_prices"):
                 prices_df = load_prices_cached(
                     storage,
-                    active_tickers,
-                    start_date,
-                    end_date,
+                    cache_salt=storage.cache_salt(),
+                    tickers=active_tickers,
+                    start=start_date,
+                    end=end_date,
                 )
             if not prices_df.empty:
                 prices_df = prices_df.set_index("date").sort_index()

--- a/ui/pages/55_Backtest_Range.py
+++ b/ui/pages/55_Backtest_Range.py
@@ -226,9 +226,10 @@ def render_page() -> None:
             end_ts = end_date.normalize()
             df_days = load_prices_cached(
                 storage,
-                ["AAPL"],
-                start_ts,
-                end_ts,
+                cache_salt=storage.cache_salt(),
+                tickers=["AAPL"],
+                start=start_ts,
+                end=end_ts,
             )
             df_days = df_days[df_days.get("Ticker") == "AAPL"].drop(columns=["Ticker"], errors="ignore")
             if df_days.empty:
@@ -248,9 +249,10 @@ def render_page() -> None:
             with dbg.step("preload_prices"):
                 prices_df = load_prices_cached(
                     storage,
-                    active_tickers,
-                    start_ts,
-                    end_ts,
+                    cache_salt=storage.cache_salt(),
+                    tickers=active_tickers,
+                    start=start_ts,
+                    end=end_ts,
                 )
             loaded = prices_df.get("Ticker").nunique() if not prices_df.empty else 0
             dbg.event(

--- a/utils/prices.py
+++ b/utils/prices.py
@@ -20,7 +20,13 @@ def fetch_history(
     if not ticker:
         return pd.DataFrame(columns=cols)
     s = Storage.from_env()
-    df = load_prices_cached(s, [ticker], start, end)
+    df = load_prices_cached(
+        s,
+        cache_salt=s.cache_salt(),
+        tickers=[ticker],
+        start=start,
+        end=end,
+    )
     if "Ticker" in df.columns:
         df = df[df["Ticker"] == ticker]
     if df.empty:


### PR DESCRIPTION
## Summary
- add cache_salt param to load_prices_cached and log active salt
- pass storage.cache_salt() through all price loading call sites
- test cache busting with distinct salts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c8264bf5208332bfe199bb4623880e