### PR TITLE
Fix: ensure empty tidy prices use datetime index

### DIFF
--- a/data_lake/storage.py
+++ b/data_lake/storage.py
@@ -4,12 +4,15 @@ import io
 import os
 import base64
 import json
+import logging
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, List
 
 import pandas as pd
 import streamlit as st
+
+log = logging.getLogger(__name__)
 
 try:
     from supabase import Client, create_client  # type: ignore
@@ -315,7 +318,8 @@ def _tidy_prices(df: pd.DataFrame, ticker: str | None = None) -> pd.DataFrame:
     if df is None or df.empty:
         cols = ["Open", "High", "Low", "Close", "Adj Close", "Volume", "Ticker"]
         empty = pd.DataFrame(columns=cols)
-        empty.index.name = "date"
+        empty.index = pd.DatetimeIndex([], name="date")
+        log.debug("_tidy_prices: empty frame for %s", ticker)
         return empty
 
     working = df.copy()

--- a/tests/test_load_prices_cached.py
+++ b/tests/test_load_prices_cached.py
@@ -134,3 +134,23 @@ def test_load_prices_cached_old_positional_signature(monkeypatch):
     assert list(out["Ticker"].unique()) == ["AAA"]
     assert out.index.min() == start
     assert out.index.max() == end
+
+
+def test_load_prices_cached_empty_frame(monkeypatch):
+    s = stg.Storage()
+
+    def fake_read_parquet_df(self, path: str):
+        return pd.DataFrame(columns=["date", "open", "high", "low", "close", "volume"])
+
+    monkeypatch.setattr(stg.Storage, "read_parquet_df", fake_read_parquet_df)
+
+    st.cache_data.clear()
+    out = stg.load_prices_cached(
+        s,
+        cache_salt=s.cache_salt(),
+        tickers=["AAA"],
+        start=pd.Timestamp("2020-01-01"),
+        end=pd.Timestamp("2020-01-02"),
+    )
+
+    assert out.empty


### PR DESCRIPTION
## Summary
- handle empty price frames with a proper DatetimeIndex and debug log
- test that `load_prices_cached` handles empty ticker data without error

## Testing
- `pip install -r sp500scn/requirements.txt` (fails: Could not connect to proxy)
- `pytest sp500scn/tests/test_load_prices_cached.py::test_load_prices_cached_empty_frame -q` (fails: ModuleNotFoundError: No module named 'pandas')
- `pytest -q` (fails: ModuleNotFoundError: No module named 'pandas')


------
https://chatgpt.com/codex/tasks/task_e_68c849e352848332a1e5e821ace4af88