### PR TITLE
Fix: handle non-datetime price indices in loader

### DIFF
--- a/data_lake/storage.py
+++ b/data_lake/storage.py
@@ -469,6 +469,12 @@ def load_prices_cached(
             except FileNotFoundError:
                 continue
         tidy = _tidy_prices(df_raw, ticker=ticker)
+        # Ensure index is datetime to avoid comparison failures
+        tidy.index = pd.to_datetime(tidy.index, errors="coerce").tz_localize(None)
+        if tidy.index.isna().any():
+            bad = int(tidy.index.isna().sum())
+            log.debug("load_prices_cached: dropping %s rows with bad dates for %s", bad, ticker)
+            tidy = tidy[tidy.index.notna()]
         if start_ts is not None:
             tidy = tidy[tidy.index >= start_ts]
         if end_ts is not None:


### PR DESCRIPTION
## Summary
- ensure `load_prices_cached` coerces price indices to datetimes before comparisons
- add regression test for non-datetime index handling

## Testing
- `pytest tests/test_load_prices_cached.py::test_load_prices_cached_handles_non_datetime_index -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c84cada69483328cea02bd054aef14