### PR TITLE
Backtest: skip non-trading days in scan loop

### DIFF
--- a/ui/pages/55_Backtest_Range.py
+++ b/ui/pages/55_Backtest_Range.py
@@ -388,6 +388,20 @@ def render_page() -> None:
             )
             rows_after = len(prices_df)
 
+            trading_index = pd.DatetimeIndex(prices_df.index.unique()).dropna()
+            try:
+                trading_index = trading_index.tz_localize(None)
+            except TypeError:
+                pass
+            trading_index = trading_index.sort_values()
+            date_list = [
+                d for d in trading_index if start_date <= d <= end_date
+            ]
+            if not date_list:
+                st.info("No trading days with price data in selected range.")
+                debug_panel("backtest")
+                return
+
             try:
                 close_wide = prices_df.pivot_table(
                     index=prices_df.index, columns="Ticker", values="Close", aggfunc="last"


### PR DESCRIPTION
## Summary
- adjust warmup coverage calculation to require only the maximum lookback (with a small cushion) and build the business-day loop directly from the UI range
- enhance coverage diagnostics to report actual loaded date bounds and add a schema-agnostic helper for computing the first available date per ticker
- gate each trading day by the earliest trade map so history_guard emits accurate eligibility counts before running the scan
- limit scan dates to trading days with price data so market holidays are not processed twice

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c89cbf823c8332a4575576afa83edd