### PR TITLE
Implement percent-based precedent filter with hit counts

### DIFF
--- a/backtest/run_range.py
+++ b/backtest/run_range.py
@@ -74,6 +74,7 @@ def run_range(
         "mfe_pct",
         "sr_ratio",
         "tp_halfway_pct",
+        "precedent_hits",
         "precedent_ok",
         "atr_ok",
         "reasons",

--- a/ui/pages/55_Backtest_Range.py
+++ b/ui/pages/55_Backtest_Range.py
@@ -150,6 +150,15 @@ def render_page() -> None:
                     key="bt_prec_window",
                 )
             )
+            min_precedent_hits = int(
+                st.number_input(
+                    "Min precedent hits",
+                    min_value=0,
+                    value=1,
+                    step=1,
+                    key="bt_prec_min_hits",
+                )
+            )
             exit_model = st.selectbox(
                 "Exit model",
                 options=("pct_tp_only", "sr_tp_vs_stop"),
@@ -180,6 +189,7 @@ def render_page() -> None:
                 "use_atr_feasible": use_atr_feasible,
                 "precedent_lookback": precedent_lookback,
                 "precedent_window": precedent_window,
+                "min_precedent_hits": min_precedent_hits,
                 "exit_model": exit_model,
             }
             dbg.set_params(
@@ -197,6 +207,7 @@ def render_page() -> None:
                 use_atr_feasible=use_atr_feasible,
                 precedent_lookback=precedent_lookback,
                 precedent_window=precedent_window,
+                min_precedent_hits=min_precedent_hits,
                 exit_model=exit_model,
             )
 


### PR DESCRIPTION
## Summary
- replace the precedent screen with a percent-target hit counter that works on business-day ranges and reports hit totals
- feed the new hit counts through the signal scan, rejection reasons, debug stats, and persisted CSV outputs
- expose a "min precedent hits" control in the backtest UI so the filter strength can be tuned from the form

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c8c505cd44833283bd1425de14edec