### PR TITLE
Add auditable precedent event logging and debug summaries

### DIFF
--- a/backtest/run_range.py
+++ b/backtest/run_range.py
@@ -76,6 +76,7 @@ def run_range(
         "tp_halfway_pct",
         "precedent_hits",
         "precedent_ok",
+        "precedent_details",
         "atr_ok",
         "reasons",
     ]

--- a/ui/components/debug.py
+++ b/ui/components/debug.py
@@ -99,6 +99,27 @@ def debug_panel(name: str = "page", extra_info: Optional[dict] = None):
     try:
         with st.expander("🐞 Debug panel", expanded=False):
             st.caption("Everything below is for diagnostics. Safe to share (secrets redacted).")
+            extra = st.session_state.get(f"__debug_extra_{name}")
+            if isinstance(extra, dict) and extra:
+                pass_count = extra.get("precedent_pass_count")
+                fail_count = extra.get("precedent_fail_count")
+                median_hits_pass = extra.get("precedent_hits_median_pass")
+                samples = extra.get("precedent_details_preview") or []
+                st.markdown("**Precedent checks**")
+                st.write(
+                    {
+                        "passes": int(pass_count) if pass_count is not None else None,
+                        "fails": int(fail_count) if fail_count is not None else None,
+                        "median_hits_pass": median_hits_pass,
+                    }
+                )
+                if samples:
+                    for idx, sample in enumerate(samples[:2], 1):
+                        st.caption(
+                            f"Sample {idx}: {sample.get('ticker')} on {sample.get('trade_date')} "
+                            f"(hits={sample.get('precedent_hits')} ok={sample.get('precedent_ok')})"
+                        )
+                        st.write(sample.get("events", []))
             txt = dbg.export_text()
             st.text_area("Report (JSON)", value=txt, height=300, key=f"{name}_json", label_visibility="collapsed")
             st.download_button("Download JSON", data=txt.encode("utf-8"), file_name=f"{name}_debug.json", mime="application/json", key=f"{name}_dl")

--- a/ui/pages/45_YdayVolSignal_Open.py
+++ b/ui/pages/45_YdayVolSignal_Open.py
@@ -45,12 +45,39 @@ def render_page() -> None:
         format_func=lambda opt: "Percent target only" if opt == "pct_tp_only" else "Legacy S/R TP+stop",
     )
     save_outcomes = st.checkbox("Save outcomes to lake", value=False)
+    with st.expander("Precedent logging", expanded=False):
+        log_precedent_details = st.checkbox(
+            "Log precedent details",
+            value=True,
+            key="scan_log_precedent_details",
+        )
+        log_precedent_include_misses = st.checkbox(
+            "Include misses in precedent log",
+            value=True,
+            key="scan_log_precedent_include_misses",
+        )
+        precedent_details_limit = int(
+            st.number_input(
+                "Precedent details limit",
+                min_value=1,
+                value=300,
+                step=10,
+                key="scan_precedent_details_limit",
+            )
+        )
+        write_precedent_events_table = st.checkbox(
+            "Write precedent events table",
+            value=False,
+            key="scan_write_precedent_events",
+        )
 
     if st.button("Run scan", type="primary", key="scan_run"):
         st.session_state["scan_running"] = True
         status, prog, log = status_block("Running filters…", key_prefix="scan")
 
         try:
+            stats = {}
+            st.session_state["__debug_extra_scan"] = {}
             params: ScanParams = {
                 "min_close_up_pct": min_close_up_pct,
                 "min_vol_multiple": min_vol_multiple,
@@ -59,6 +86,10 @@ def render_page() -> None:
                 "lookback_days": vol_lookback,
                 "horizon_days": horizon,
                 "sr_min_ratio": sr_min_ratio,
+                "log_precedent_details": log_precedent_details,
+                "log_precedent_include_misses": log_precedent_include_misses,
+                "precedent_details_limit": precedent_details_limit,
+                "write_precedent_events_table": write_precedent_events_table,
                 "exit_model": exit_model,
             }
             dbg.set_params(
@@ -70,6 +101,10 @@ def render_page() -> None:
                 atr_window=atr_window,
                 horizon=horizon,
                 sr_min_ratio=sr_min_ratio,
+                log_precedent_details=log_precedent_details,
+                log_precedent_include_misses=log_precedent_include_misses,
+                precedent_details_limit=precedent_details_limit,
+                write_precedent_events_table=write_precedent_events_table,
                 exit_model=exit_model,
             )
 
@@ -157,14 +192,21 @@ def render_page() -> None:
 
             try:
                 with dbg.step("run_signal_scan"):
-                    cand_df, out_df, fails, _dbg = scan_day(
+                    cand_df, out_df, fails, stats = scan_day(
                         storage, D, params, on_step=on_step
                     )
                 dbg.event(
                     "scan_outcome",
                     rows=len(cand_df) if cand_df is not None else 0,
-                    fails=len(fails) if fails is not None else 0,
+                    fails=int(fails) if fails is not None else 0,
                 )
+                if stats:
+                    dbg.event(
+                        "precedent_summary",
+                        pass_count=int(stats.get("precedent_pass_count", 0) or 0),
+                        fail_count=int(stats.get("precedent_fail_count", 0) or 0),
+                        median_hits_pass=stats.get("precedent_hits_median_pass"),
+                    )
             finally:
                 sigscan._load_prices = orig_load_prices
                 sigscan._load_members = orig_load_members
@@ -176,6 +218,8 @@ def render_page() -> None:
             st.session_state["cand_df"] = cand_df
             st.session_state["out_df"] = out_df
             st.session_state["fails"] = fails
+            st.session_state["scan_stats"] = stats
+            st.session_state["__debug_extra_scan"] = stats or {}
 
             if save_outcomes and not out_df.empty:
                 buf = io.BytesIO()

--- a/ui/pages/55_Backtest_Range.py
+++ b/ui/pages/55_Backtest_Range.py
@@ -159,6 +159,31 @@ def render_page() -> None:
                     key="bt_prec_min_hits",
                 )
             )
+            with st.expander("Precedent logging", expanded=False):
+                log_precedent_details = st.checkbox(
+                    "Log precedent details",
+                    value=True,
+                    key="bt_log_precedent_details",
+                )
+                log_precedent_include_misses = st.checkbox(
+                    "Include misses in precedent log",
+                    value=True,
+                    key="bt_log_precedent_include_misses",
+                )
+                precedent_details_limit = int(
+                    st.number_input(
+                        "Precedent details limit",
+                        min_value=1,
+                        value=300,
+                        step=10,
+                        key="bt_prec_details_limit",
+                    )
+                )
+                write_precedent_events_table = st.checkbox(
+                    "Write precedent events table",
+                    value=False,
+                    key="bt_write_precedent_events",
+                )
             exit_model = st.selectbox(
                 "Exit model",
                 options=("pct_tp_only", "sr_tp_vs_stop"),
@@ -176,6 +201,7 @@ def render_page() -> None:
         status, prog, log = status_block("Backtest running…", key_prefix="bt")
 
         try:
+            st.session_state["__debug_extra_backtest"] = {}
             params: ScanParams = {
                 "min_close_up_pct": min_close_up_pct,
                 "min_vol_multiple": min_vol_multiple,
@@ -190,6 +216,10 @@ def render_page() -> None:
                 "precedent_lookback": precedent_lookback,
                 "precedent_window": precedent_window,
                 "min_precedent_hits": min_precedent_hits,
+                "log_precedent_details": log_precedent_details,
+                "log_precedent_include_misses": log_precedent_include_misses,
+                "precedent_details_limit": precedent_details_limit,
+                "write_precedent_events_table": write_precedent_events_table,
                 "exit_model": exit_model,
             }
             dbg.set_params(
@@ -208,6 +238,10 @@ def render_page() -> None:
                 precedent_lookback=precedent_lookback,
                 precedent_window=precedent_window,
                 min_precedent_hits=min_precedent_hits,
+                log_precedent_details=log_precedent_details,
+                log_precedent_include_misses=log_precedent_include_misses,
+                precedent_details_limit=precedent_details_limit,
+                write_precedent_events_table=write_precedent_events_table,
                 exit_model=exit_model,
             )
 
@@ -473,6 +507,7 @@ def render_page() -> None:
             try:
                 trades_df = pd.DataFrame()
                 summary: Dict[str, float] = {}
+                last_stats: Dict[str, Any] = {}
                 with dbg.step("run_backtest"):
                     results = []
                     days_with_candidates = 0
@@ -502,9 +537,10 @@ def render_page() -> None:
                         if not eligible_count:
                             continue
 
-                        cands, out, _fails, _stats = sigscan.scan_day(
+                        cands, out, _fails, stats_day = sigscan.scan_day(
                             storage, current_day, params
                         )
+                        last_stats = stats_day or {}
                         cand_count = int(len(cands))
                         if cand_count:
                             days_with_candidates += 1
@@ -539,6 +575,7 @@ def render_page() -> None:
 
                 st.session_state["bt_trades"] = trades_df
                 st.session_state["bt_summary"] = summary
+                st.session_state["__debug_extra_backtest"] = last_stats
 
                 if save_outcomes and not trades_df.empty:
                     run_id = dt.datetime.utcnow().strftime("%Y%m%d_%H%M%S")


### PR DESCRIPTION
## Summary
- add per-event precedent computation helper that normalizes TP inputs and returns JSON-ready audit data
- enrich the daily scan pipeline with configurable precedent detail logging, optional normalized export, and updated candidate stats
- surface the new data in exports and UI with configuration controls plus debug panel previews for quick inspection

## Testing
- PYTHONPATH=. pytest tests/test_metrics.py

------
https://chatgpt.com/codex/tasks/task_e_68c8d3f391c88332b59d52fa0d5e8953