### PR TITLE
Address review feedback: preserve precedent hit counts with log limit

### DIFF
--- a/engine/filters.py
+++ b/engine/filters.py
@@ -61,6 +61,7 @@ def compute_precedent_events(
 
     hits = 0
     events = []
+    limit_int = int(limit) if limit is not None else None
 
     for S in starts:
         entry_vals = hist.loc[S, oc]
@@ -89,19 +90,17 @@ def compute_precedent_events(
         max_gain_pct = (max_high / entry_open - 1.0) * 100.0
 
         if include_misses or hit:
-            events.append(
-                {
-                    "date": str(S.date()),
-                    "entry_price": round(entry_open, 6),
-                    "target_pct": round(tp_frac * 100.0, 6),
-                    "max_gain_pct": round(max_gain_pct, 6),
-                    "days_to_hit": int(days_to_hit) if days_to_hit is not None else None,
-                    "hit": bool(hit),
-                }
-            )
-
-        if len(events) >= int(limit):
-            break
+            if limit_int is None or len(events) < limit_int:
+                events.append(
+                    {
+                        "date": str(S.date()),
+                        "entry_price": round(entry_open, 6),
+                        "target_pct": round(tp_frac * 100.0, 6),
+                        "max_gain_pct": round(max_gain_pct, 6),
+                        "days_to_hit": int(days_to_hit) if days_to_hit is not None else None,
+                        "hit": bool(hit),
+                    }
+                )
 
     return hits, events
 


### PR DESCRIPTION
## Summary
- add per-event precedent computation helper that normalizes TP inputs and returns JSON-ready audit data
- enrich the daily scan pipeline with configurable precedent detail logging, optional normalized export, and updated candidate stats
- surface the new data in exports and UI with configuration controls plus debug panel previews for quick inspection
- ensure precedent hit counts continue accumulating even when event logging is limited

## Testing
- PYTHONPATH=. pytest tests/test_metrics.py

------
https://chatgpt.com/codex/tasks/task_e_68c8e1d5599c833286d548b936ca928b