### PR TITLE
Add precedent hit detail tracking and export

### DIFF
--- a/backtest/run_range.py
+++ b/backtest/run_range.py
@@ -76,9 +76,24 @@ def run_range(
         "tp_halfway_pct",
         "precedent_hits",
         "precedent_ok",
+        "precedent_details_hits",
+        "precedent_hit_start_dates",
         "atr_ok",
         "reasons",
     ]
     trades_df = trades_df.reindex(columns=needed)
+
+    missing = [
+        c
+        for c in (
+            "precedent_details_hits",
+            "precedent_hit_start_dates",
+            "precedent_hits",
+            "precedent_ok",
+        )
+        if c not in trades_df.columns
+    ]
+    if missing:
+        raise RuntimeError(f"precedent columns missing at export: {missing}")
 
     return trades_df, summary

--- a/engine/utils_precedent.py
+++ b/engine/utils_precedent.py
@@ -1,0 +1,90 @@
+from typing import Tuple, List, Dict
+
+import pandas as pd
+from pandas.tseries.offsets import BDay
+
+PRICE_COLS = {
+    "open": ["Open", "open", "OPEN", "o"],
+    "high": ["High", "high", "HIGH", "h"],
+}
+
+
+def _col(df: pd.DataFrame, kind: str) -> str:
+    for candidate in PRICE_COLS[kind]:
+        if candidate in df.columns:
+            return candidate
+    raise KeyError(f"Missing price column for {kind}")
+
+
+def _tp_to_frac(tp_value: float) -> float:
+    """Normalize target percent to a fraction."""
+
+    if tp_value is None or pd.isna(tp_value):
+        return float("nan")
+    return float(tp_value / 100.0) if tp_value > 1.5 else float(tp_value)
+
+
+def compute_precedent_hit_details(
+    prices_one_ticker: pd.DataFrame,
+    asof_date: pd.Timestamp,
+    tp_value,
+    lookback_bdays: int = 252,
+    window_bdays: int = 21,
+    limit: int = 500,
+) -> Tuple[int, List[Dict[str, object]]]:
+    """Return count and details of precedent hits for a given target move."""
+
+    oc = _col(prices_one_ticker, "open")
+    hc = _col(prices_one_ticker, "high")
+
+    tp_frac = _tp_to_frac(tp_value)
+    if pd.isna(tp_frac) or tp_frac <= 0:
+        return 0, []
+
+    prices = prices_one_ticker.copy()
+    prices.index = pd.to_datetime(prices.index).tz_localize(None)
+    prices = prices.sort_index()
+
+    D = pd.Timestamp(asof_date).tz_localize(None)
+
+    hist = prices.loc[prices.index < D]
+    if hist.empty:
+        return 0, []
+
+    start_min = D - BDay(lookback_bdays)
+    starts = pd.bdate_range(max(start_min, hist.index.min()), D - BDay(1))
+    starts = [s for s in starts if s in hist.index]
+
+    hits: List[Dict[str, object]] = []
+    for S in starts:
+        entry_vals = hist.loc[S, oc]
+        oS = (
+            float(entry_vals.iloc[-1])
+            if isinstance(entry_vals, pd.Series)
+            else float(entry_vals)
+        )
+        target_abs = oS * (1.0 + tp_frac)
+        endS = min(S + BDay(window_bdays), D - BDay(1))
+        fwd = hist.loc[(hist.index > S) & (hist.index <= endS)]
+        if fwd.empty:
+            continue
+
+        hit_mask = fwd[hc] >= target_abs
+        if hit_mask.any():
+            first_hit = hit_mask.idxmax()
+            days_to_hit = pd.bdate_range(S, first_hit).size - 1
+            max_high = float(fwd[hc].max())
+            max_gain_pct = (max_high / oS - 1.0) * 100.0
+            hits.append(
+                {
+                    "date": str(S.date()),
+                    "entry_price": round(oS, 6),
+                    "target_pct": round(tp_frac * 100.0, 6),
+                    "days_to_hit": int(days_to_hit),
+                    "max_gain_pct": round(max_gain_pct, 6),
+                }
+            )
+            if len(hits) >= limit:
+                break
+
+    return len(hits), hits

--- a/tests/test_utils_precedent.py
+++ b/tests/test_utils_precedent.py
@@ -1,0 +1,65 @@
+import pandas as pd
+import pytest
+
+from engine.utils_precedent import compute_precedent_hit_details
+
+
+def test_compute_precedent_hits_details_fraction_and_percent():
+    idx = pd.bdate_range("2023-01-02", periods=6)
+    prices = pd.DataFrame(
+        {
+            "open": [100.0, 100.0, 100.0, 100.0, 100.0, 100.0],
+            "high": [101.0, 102.0, 107.0, 101.0, 103.0, 106.0],
+        },
+        index=idx,
+    )
+
+    asof = pd.Timestamp("2023-01-10")
+    hits, details = compute_precedent_hit_details(
+        prices,
+        asof_date=asof,
+        tp_value=0.05,
+        lookback_bdays=3,
+        window_bdays=3,
+    )
+
+    assert hits == 2
+    assert [d["date"] for d in details] == ["2023-01-05", "2023-01-06"]
+    assert details[0]["days_to_hit"] == 2
+    assert details[1]["days_to_hit"] == 1
+    assert details[0]["entry_price"] == pytest.approx(100.0)
+    assert details[0]["target_pct"] == pytest.approx(5.0, abs=1e-6)
+    assert details[0]["max_gain_pct"] == pytest.approx(6.0, abs=1e-6)
+
+    hits_pct, details_pct = compute_precedent_hit_details(
+        prices,
+        asof_date=asof,
+        tp_value=5.0,
+        lookback_bdays=3,
+        window_bdays=3,
+    )
+    assert hits_pct == hits
+    assert details_pct == details
+
+
+def test_compute_precedent_hits_no_peeking():
+    idx = pd.bdate_range("2023-01-06", periods=4)
+    prices = pd.DataFrame(
+        {
+            "open": [100.0, 100.0, 100.0, 100.0],
+            "high": [100.0, 100.0, 100.0, 106.0],
+        },
+        index=idx,
+    )
+
+    asof = pd.Timestamp("2023-01-11")
+    hits, details = compute_precedent_hit_details(
+        prices,
+        asof_date=asof,
+        tp_value=0.05,
+        lookback_bdays=5,
+        window_bdays=3,
+    )
+
+    assert hits == 0
+    assert details == []


### PR DESCRIPTION
## Summary
- add a utility to compute precedent hit counts and structured details for reuse
- embed precedent detail fields in the daily scan results, debug events, and export schema
- cover the helper with unit tests and guard backtest exports for the new columns

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c95fb624948332b595dc5e49fd4be7