### PR TITLE
Lake: store RAW OHLC (+ Adj Close), add validator, smoke check, CI, and rebuild CLI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,22 @@
+name: tests
+
+on:
+  push: {}
+  pull_request: {}
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install deps
+        run: |
+          pip install -r requirements.txt
+          pip install -r requirements-smoke.txt || true
+          pip install -e .
+          pip install pytest
+      - name: Run tests
+        run: pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .lake/
 *.parquet
+!tests/fixtures/**/*.parquet
 manifests/
 __pycache__/
 .streamlit/secrets.toml

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: test smoke-adi smoke-one
+
+LAKE_ROOT ?=
+
+test:
+	pytest -q
+
+smoke-adi:
+	python scripts/smoke_raw_ohlc.py --ticker ADI --date 2020-03-20 $(if $(LAKE_ROOT),--lake-root $(LAKE_ROOT),)
+
+# usage: make smoke-one TKR=MSFT DAY=2020-12-10 [LAKE_ROOT=/path/to/lake]
+smoke-one:
+	python scripts/smoke_raw_ohlc.py --ticker $(TKR) --date $(DAY) $(if $(LAKE_ROOT),--lake-root $(LAKE_ROOT),)

--- a/data_lake/ingest.py
+++ b/data_lake/ingest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 import json
+import logging
 from datetime import datetime
 from typing import List
 
@@ -11,7 +12,10 @@ import pandas as pd
 from supabase import Client
 
 from .schemas import IngestJob, IngestResult
-from .storage import Storage
+from .storage import Storage, _tidy_prices, validate_prices_schema
+
+
+log = logging.getLogger(__name__)
 
 
 def _fetch(storage: Storage, job: IngestJob) -> pd.DataFrame:
@@ -21,26 +25,52 @@ def _fetch(storage: Storage, job: IngestJob) -> pd.DataFrame:
     if not supabase:
         return pd.DataFrame()
 
-    page_size = 1000
-    offset = 0
+    page_size, offset = 1000, 0
     rows: list[dict] = []
+    select_cols = (
+        "ticker, date, open, high, low, close, adj_close, volume, dividends, stock_splits"
+    )
+    use_wildcard = False
+
     while True:
-        resp = (
+        query = (
             supabase.table("sp500_ohlcv")
-            .select(
-                "ticker, date, open, high, low, close, volume, dividends, stock_splits"
-            )
+            .select(select_cols if not use_wildcard else "*")
             .eq("ticker", ticker)
             .gte("date", start)
             .lte("date", end)
             .order("date")
             .range(offset, offset + page_size - 1)
-            .execute()
         )
-        if not resp.data:
+        try:
+            resp = query.execute()
+        except Exception as exc:
+            if not use_wildcard:
+                # Fall back to wildcard selection when explicit columns fail (older schemas).
+                log.warning(
+                    "ingest: explicit select failed for %s; retrying with '*': %s",
+                    ticker,
+                    exc,
+                )
+                use_wildcard, offset, rows = True, 0, []
+                continue
+            raise
+
+        data = resp.data or []
+        if (
+            not use_wildcard
+            and data
+            and all("adj_close" not in row for row in data if isinstance(row, dict))
+        ):
+            log.warning("ingest: rows lack 'adj_close' for %s; retrying with wildcard", ticker)
+            use_wildcard, offset, rows = True, 0, []
+            continue
+
+        if not data:
             break
-        rows.extend(resp.data)
-        if len(resp.data) < page_size:
+
+        rows.extend(data)
+        if len(data) < page_size:
             break
         offset += page_size
 
@@ -48,21 +78,28 @@ def _fetch(storage: Storage, job: IngestJob) -> pd.DataFrame:
         return pd.DataFrame()
 
     df = pd.DataFrame(rows)
-    df["date"] = pd.to_datetime(df["date"], errors="coerce")
+    if "adj_close" not in df.columns:
+        df["adj_close"] = pd.NA
+        log.warning(
+            "ingest: 'adj_close' missing; writing RAW OHLC with null Adj Close for %s",
+            ticker,
+        )
+
+    df["date"] = pd.to_datetime(df.get("date"), errors="coerce")
     df["ticker"] = ticker
-    return df[
-        [
-            "date",
-            "open",
-            "high",
-            "low",
-            "close",
-            "volume",
-            "dividends",
-            "stock_splits",
-            "ticker",
-        ]
+    cols = [
+        "date",
+        "open",
+        "high",
+        "low",
+        "close",
+        "adj_close",
+        "volume",
+        "dividends",
+        "stock_splits",
+        "ticker",
     ]
+    return df[[c for c in cols if c in df.columns]]
 
 
 def ingest_batch(storage: Storage, jobs: List[IngestJob], progress_cb=None) -> dict:
@@ -75,13 +112,18 @@ def ingest_batch(storage: Storage, jobs: List[IngestJob], progress_cb=None) -> d
         error = None
         rows = 0
         try:
-            df = _fetch(storage, job)
+            df_raw = _fetch(storage, job)
+            tidy = _tidy_prices(df_raw, ticker=job["ticker"]).reset_index()
+            # Warn-only during ingest so legacy data can be migrated without failing jobs.
+            validate_prices_schema(tidy, strict=False)
+
             buffer = io.BytesIO()
-            df.to_parquet(buffer, index=False)
+            tidy.to_parquet(buffer, index=False)
             storage.write_bytes(path, buffer.getvalue())
-            rows = len(df)
+
+            rows = len(tidy)
             if rows:
-                all_dates.append(df["date"])
+                all_dates.append(tidy["date"])
         except Exception as e:
             error = str(e)
         results.append({"ticker": job["ticker"], "rows_written": rows, "path": path, "error": error})

--- a/data_lake/storage.py
+++ b/data_lake/storage.py
@@ -11,6 +11,7 @@ from typing import Any, List
 
 import pandas as pd
 import streamlit as st
+from pandas.api.types import is_numeric_dtype
 
 log = logging.getLogger(__name__)
 
@@ -27,6 +28,20 @@ else:  # pragma: no cover - exercised when package installed
 LOCAL_ROOT = Path(".lake")
 DEFAULT_BUCKET = "lake"
 
+# Stable price schema used across ingest + read paths.
+PRICE_COLUMNS = [
+    "date",
+    "Ticker",
+    "Open",
+    "High",
+    "Low",
+    "Close",
+    "Adj Close",
+    "Volume",
+    "Dividends",
+    "Stock Splits",
+]
+
 
 def supabase_available() -> tuple[bool, str]:
     """Return ``(available, reason)`` for Supabase client support."""
@@ -39,6 +54,59 @@ def supabase_available() -> tuple[bool, str]:
         )
         return False, reason
     return True, ""
+
+
+def validate_prices_schema(df: pd.DataFrame, *, strict: bool = True) -> None:
+    """Ensure frames store raw OHLC alongside provider Adj Close."""
+
+    if df is None or df.empty:
+        return
+
+    req = set(PRICE_COLUMNS)
+    missing = sorted(req - set(df.columns))
+    if missing:
+        raise ValueError(f"Missing required price columns: {', '.join(missing)}")
+
+    dates = pd.to_datetime(df["date"], errors="coerce")
+    if dates.isna().any() and df["date"].notna().any():
+        raise ValueError("Non-datetime values in 'date' column")
+
+    tick = df["Ticker"].dropna().astype(str).str.strip()
+    if not tick.empty and not (tick == tick.str.upper()).all():
+        raise ValueError("Ticker column must be uppercase")
+
+    for col in [
+        "Open",
+        "High",
+        "Low",
+        "Close",
+        "Adj Close",
+        "Volume",
+        "Dividends",
+        "Stock Splits",
+    ]:
+        if col in df.columns:
+            series = df[col].dropna()
+            if not series.empty and not is_numeric_dtype(series):
+                pd.to_numeric(series, errors="raise")
+
+    actions_present = False
+    for col in ("Dividends", "Stock Splits"):
+        if col in df.columns:
+            values = pd.to_numeric(df[col], errors="coerce").fillna(0)
+            if values.ne(0).any():
+                actions_present = True
+                break
+
+    if actions_present:
+        close = pd.to_numeric(df["Close"], errors="coerce")
+        adj_close = pd.to_numeric(df["Adj Close"], errors="coerce")
+        mask = close.notna() & adj_close.notna()
+        if mask.any() and (close[mask] == adj_close[mask]).all():
+            msg = "Adjusted OHLC detected; store raw OHLC and keep 'Adj Close' separately."
+            if strict:
+                raise ValueError(msg)
+            log.warning(msg)
 
 
 def _is_truthy(value: Any) -> bool:
@@ -310,35 +378,36 @@ class Storage:
 
 # ====== Price helpers =======================================================
 
-def _normalize_column_name(name: str) -> str:
+
+def _normalize_key(name: str) -> str:
     return name.strip().lower().replace(" ", "_").replace("-", "_")
 
 
 def _tidy_prices(df: pd.DataFrame, ticker: str | None = None) -> pd.DataFrame:
     if df is None or df.empty:
-        cols = ["Open", "High", "Low", "Close", "Adj Close", "Volume", "Ticker"]
-        empty = pd.DataFrame(columns=cols)
+        empty = pd.DataFrame(columns=[c for c in PRICE_COLUMNS if c != "date"])
         empty.index = pd.DatetimeIndex([], name="date")
         log.debug("_tidy_prices: empty frame for %s", ticker)
         return empty
 
     working = df.copy()
     if not isinstance(working.index, pd.DatetimeIndex):
-        possible_date_col = None
-        for col in working.columns:
-            if _normalize_column_name(col) in {"date", "timestamp"}:
-                possible_date_col = col
-                break
-        if possible_date_col is not None:
-            working["date"] = working[possible_date_col]
+        date_col = next(
+            (c for c in working.columns if _normalize_key(c) in {"date", "timestamp"}),
+            None,
+        )
+        if date_col:
+            working["date"] = working[date_col]
         else:
-            working = working.reset_index().rename(columns={working.index.name or "index": "date"})
+            working = working.reset_index().rename(
+                columns={working.index.name or "index": "date"}
+            )
     else:
         working = working.reset_index().rename(columns={working.index.name or "index": "date"})
 
     rename_map: dict[str, str] = {}
     for col in list(working.columns):
-        key = _normalize_column_name(col)
+        key = _normalize_key(col)
         if key in {"date", "timestamp"}:
             rename_map[col] = "date"
         elif key == "open":
@@ -347,61 +416,56 @@ def _tidy_prices(df: pd.DataFrame, ticker: str | None = None) -> pd.DataFrame:
             rename_map[col] = "High"
         elif key == "low":
             rename_map[col] = "Low"
-        elif key in {"adj_close", "adjclose", "adjusted_close", "close_adj"}:
-            rename_map[col] = "Adj Close"
         elif key in {"close", "close_price"}:
             rename_map.setdefault(col, "Close")
+        elif key in {"adj_close", "adjusted_close", "adjclose", "close_adj"}:
+            rename_map[col] = "Adj Close"
         elif key == "volume":
             rename_map[col] = "Volume"
         elif key in {"ticker", "symbol"}:
             rename_map[col] = "Ticker"
+        elif key in {"dividends", "dividend"}:
+            rename_map[col] = "Dividends"
+        elif key in {"stock_splits", "stocksplits", "split"}:
+            rename_map[col] = "Stock Splits"
 
     working = working.rename(columns=rename_map)
-
-    working["date"] = pd.to_datetime(working["date"], errors="coerce")
+    working["date"] = pd.to_datetime(working["date"], errors="coerce").dt.tz_localize(None)
     working = working.dropna(subset=["date"])
-    try:
-        working["date"] = working["date"].dt.tz_localize(None)
-    except Exception:
-        pass
-
-    required_cols = {
-        "Open": "Open",
-        "High": "High",
-        "Low": "Low",
-        "Close": "Close",
-        "Adj Close": "Adj Close",
-        "Volume": "Volume",
-    }
-    for key, col in required_cols.items():
-        if col not in working.columns:
-            source_candidates = [c for c in working.columns if _normalize_column_name(c) == _normalize_column_name(key)]
-            if source_candidates:
-                working[col] = working[source_candidates[0]]
-
-    if "Adj Close" not in working.columns and "Close" in working.columns:
-        working["Adj Close"] = working["Close"]
 
     if "Ticker" not in working.columns:
-        if ticker is not None:
-            working["Ticker"] = ticker
-        else:
-            working["Ticker"] = pd.NA
+        working["Ticker"] = ticker or pd.NA
+    working["Ticker"] = working["Ticker"].astype("string").str.upper().str.strip()
 
-    working["Ticker"] = working["Ticker"].astype(str).str.upper()
-
-    keep_cols = ["date", "Open", "High", "Low", "Close", "Adj Close", "Volume", "Ticker"]
-    for col in keep_cols:
+    keep = PRICE_COLUMNS.copy()
+    for col in keep:
         if col not in working.columns:
-            working[col] = pd.NA
-    working = working[keep_cols]
+            if col == "Adj Close":
+                # Preserve provider adjustment data without manufacturing values.
+                working[col] = pd.NA
+            elif col in {"Dividends", "Stock Splits"}:
+                working[col] = 0.0
+            elif col == "date":
+                continue
+            else:
+                working[col] = pd.NA
 
-    working = working.sort_values("date")
-    working = working.drop_duplicates(subset=["date"], keep="last")
-    working = working.set_index("date")
-    working.index = pd.to_datetime(working.index).tz_localize(None)
-    working.index.name = "date"
-    return working
+    for col in ["Open", "High", "Low", "Close", "Adj Close", "Dividends", "Stock Splits"]:
+        if col in working.columns:
+            working[col] = pd.to_numeric(working[col], errors="coerce")
+
+    if "Volume" in working.columns:
+        vol = pd.to_numeric(working["Volume"], errors="coerce")
+        try:
+            working["Volume"] = vol.astype("Int64")
+        except Exception:
+            working["Volume"] = vol
+
+    ordered = ["date"] + [c for c in keep if c != "date"]
+    working = working[ordered]
+    working = working.sort_values("date").drop_duplicates(subset=["date"], keep="last")
+    working = working.set_index("date").rename_axis("date")
+    return working[[c for c in keep if c != "date"]]
 
 
 @st.cache_data(hash_funcs={Storage: lambda _: 0}, show_spinner=False)
@@ -438,7 +502,7 @@ def load_prices_cached(
 
     tickers = [str(t).upper() for t in raw_tickers if t]
     if not tickers:
-        return pd.DataFrame(columns=["date", "Open", "High", "Low", "Close", "Adj Close", "Volume", "Ticker"])
+        return pd.DataFrame(columns=PRICE_COLUMNS)
 
     def _naive(ts: pd.Timestamp | None) -> pd.Timestamp | None:
         if ts is None:
@@ -482,7 +546,7 @@ def load_prices_cached(
         frames.append(tidy)
 
     if not frames:
-        return pd.DataFrame(columns=["date", "Open", "High", "Low", "Close", "Adj Close", "Volume", "Ticker"])
+        return pd.DataFrame(columns=PRICE_COLUMNS)
 
     out = pd.concat(frames, axis=0, ignore_index=False)
     out.index = pd.to_datetime(out.index).tz_localize(None)
@@ -494,10 +558,26 @@ def load_prices_cached(
     out = out.sort_values(["Ticker", "date"])
     out = out.drop_duplicates(subset=["Ticker", "date"], keep="last")
 
-    columns = ["date", "Open", "High", "Low", "Close", "Adj Close", "Volume", "Ticker"]
-    for col in columns:
+    for col in PRICE_COLUMNS:
         if col not in out.columns:
-            out[col] = pd.NA
-    out = out[columns]
-    out = out.reset_index(drop=True)
-    return out
+            if col in {"Dividends", "Stock Splits"}:
+                out[col] = 0.0
+            else:
+                out[col] = pd.NA
+
+    out = out[PRICE_COLUMNS]
+
+    out["Ticker"] = out["Ticker"].astype("string").str.upper().str.strip()
+    for col in ["Open", "High", "Low", "Close", "Adj Close", "Dividends", "Stock Splits"]:
+        out[col] = pd.to_numeric(out[col], errors="coerce")
+    if "Volume" in out.columns:
+        vol = pd.to_numeric(out["Volume"], errors="coerce")
+        try:
+            out["Volume"] = vol.astype("Int64")
+        except Exception:
+            out["Volume"] = vol
+
+    # Enforce raw OHLC semantics before handing data to callers.
+    validate_prices_schema(out)
+
+    return out.reset_index(drop=True)

--- a/docs/PRICES_RAW.md
+++ b/docs/PRICES_RAW.md
@@ -1,0 +1,6 @@
+# RAW OHLC policy
+
+* Store raw provider OHLCV values as traded; keep the vendor-supplied `Adj Close` column alongside them.
+* Never rescale or back-adjust `Open`, `High`, `Low`, or `Close` after ingest.
+* Stable schema for parquet files: `date`, `Ticker`, `Open`, `High`, `Low`, `Close`, `Adj Close`, `Volume`, `Dividends`, `Stock Splits`.
+* The validator enforces that when corporate actions occur, `Close` must differ from `Adj Close`.

--- a/migrations/20240916_add_adj_close.sql
+++ b/migrations/20240916_add_adj_close.sql
@@ -1,0 +1,1 @@
+alter table public.sp500_ohlcv add column if not exists adj_close double precision;

--- a/requirements-smoke.txt
+++ b/requirements-smoke.txt
@@ -3,3 +3,4 @@ pandas==2.2.3
 streamlit==1.39.1
 tabulate==0.9.0
 supabase==2.18.1
+yfinance==0.2.43

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pandas==2.2.3
 supabase==2.18.1
 tabulate==0.9.0
 pyarrow==15.0.2
+yfinance==0.2.43

--- a/scripts/rebuild_prices_raw.py
+++ b/scripts/rebuild_prices_raw.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import io
+import sys
+import time
+from typing import Sequence
+
+import pandas as pd
+import yfinance as yf
+
+from data_lake.membership import historical_tickers
+from data_lake.storage import Storage, _tidy_prices, validate_prices_schema
+
+
+def _norm_date(value: str | None) -> str | None:
+    if not value:
+        return None
+    return pd.Timestamp(value).normalize().strftime("%Y-%m-%d")
+
+
+def _download_one(ticker: str, start: str | None, end: str | None) -> pd.DataFrame:
+    raw = yf.download(
+        ticker,
+        start=start,
+        end=end,
+        auto_adjust=False,
+        actions=True,
+        progress=False,
+        threads=False,
+    )
+    if raw.empty:
+        return pd.DataFrame()
+    if isinstance(raw.columns, pd.MultiIndex):
+        raw = raw.droplevel(1, axis=1)
+    raw = raw.reset_index()
+    raw["Ticker"] = ticker
+    tidy = _tidy_prices(raw, ticker=ticker).reset_index()
+    validate_prices_schema(tidy)
+    return tidy
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tickers", nargs="*")
+    parser.add_argument("--start")
+    parser.add_argument("--end")
+    parser.add_argument("--limit", type=int)
+    parser.add_argument("--sleep", type=float, default=0.5)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+
+    storage = Storage.from_env()
+    start = _norm_date(args.start)
+    end = _norm_date(args.end)
+    tickers = [t.upper() for t in (args.tickers or [])] or historical_tickers(
+        storage, limit=args.limit
+    )
+    if not tickers:
+        print("No tickers", file=sys.stderr)
+        return 1
+
+    for ticker in tickers:
+        df = _download_one(ticker, start, end)
+        if not args.dry_run:
+            buf = io.BytesIO()
+            df.to_parquet(buf, index=False)
+            storage.write_bytes(f"prices/{ticker}.parquet", buf.getvalue())
+        if not df.empty:
+            preview = df.iloc[[0, -1]][["date", "Open", "Close", "Adj Close"]]
+            print(
+                f"{ticker}: {len(df)} rows\n{preview.to_string(index=False)}",
+                file=sys.stderr,
+            )
+        else:
+            print(f"{ticker}: no data", file=sys.stderr)
+        time.sleep(args.sleep)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke_raw_ohlc.py
+++ b/scripts/smoke_raw_ohlc.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+
+import pandas as pd
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from data_lake.storage import Storage, load_prices_cached, validate_prices_schema
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Smoke-check RAW OHLC vs Adj Close")
+    parser.add_argument("--ticker", required=True)
+    parser.add_argument("--date", required=True)
+    parser.add_argument("--start")
+    parser.add_argument("--end")
+    parser.add_argument("--lake-root", default=None)
+    args = parser.parse_args()
+
+    storage = Storage.from_env()
+    if args.lake_root:
+        storage.local_root = args.lake_root
+
+    start = pd.Timestamp(args.start or pd.Timestamp(args.date) - pd.Timedelta(days=3))
+    end = pd.Timestamp(args.end or pd.Timestamp(args.date) + pd.Timedelta(days=3))
+
+    df = load_prices_cached(
+        storage,
+        cache_salt=storage.cache_salt(),
+        tickers=[args.ticker],
+        start=start,
+        end=end,
+    )
+    if df.empty:
+        print("NO ROWS LOADED", file=sys.stderr)
+        return 2
+
+    validate_prices_schema(df)
+
+    row = df[df["date"] == pd.Timestamp(args.date)]
+    if row.empty:
+        print(f"NO ROW FOR {args.ticker} @ {args.date}", file=sys.stderr)
+        print(df.tail(5).to_string(index=False))
+        return 3
+
+    r = row.iloc[0]
+    out = {
+        "ticker": r["Ticker"],
+        "date": str(pd.to_datetime(r["date"]).date()),
+        "open": float(r["Open"]),
+        "high": float(r["High"]),
+        "low": float(r["Low"]),
+        "close": float(r["Close"]),
+        "adj_close": float(r["Adj Close"]) if pd.notna(r["Adj Close"]) else None,
+        "dividends": float(r.get("Dividends", 0) or 0),
+        "stock_splits": float(r.get("Stock Splits", 0) or 0),
+        "volume": int(r["Volume"]) if pd.notna(r["Volume"]) else None,
+    }
+    print(out)
+
+    if out["adj_close"] is not None and out["dividends"] > 0:
+        if abs(out["adj_close"] - out["close"]) < 1e-9:
+            print(
+                "FAIL: Adj Close equals Close on a dividend day (looks adjusted).",
+                file=sys.stderr,
+            )
+            return 4
+
+    print("OK: RAW OHLC with separate Adj Close.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_prices_fixture.py
+++ b/tests/test_prices_fixture.py
@@ -1,0 +1,82 @@
+import io
+from pathlib import Path
+
+import pandas as pd
+import pytest
+import streamlit as st
+
+from data_lake import storage as stg
+
+
+def _mini_adi_frame() -> pd.DataFrame:
+    """Build a deterministic mini price frame including a dividend day."""
+    return pd.DataFrame([
+        {
+            "date": "2020-03-18",
+            "Open": 87.00,
+            "High": 91.50,
+            "Low": 85.10,
+            "Close": 90.12,
+            "Adj Close": 81.60,
+            "Volume": 12_345_678,
+            "Dividends": 0.0,
+            "Stock Splits": 0.0,
+            "Ticker": "ADI",
+        },
+        {
+            "date": "2020-03-19",
+            "Open": 88.20,
+            "High": 92.00,
+            "Low": 86.00,
+            "Close": 89.55,
+            "Adj Close": 81.06,
+            "Volume": 11_000_000,
+            "Dividends": 0.0,
+            "Stock Splits": 0.0,
+            "Ticker": "ADI",
+        },
+        {
+            "date": "2020-03-20",
+            "Open": 92.41,
+            "High": 93.37,
+            "Low": 84.88,
+            "Close": 85.08,
+            "Adj Close": 77.08,
+            "Volume": 20_000_000,
+            "Dividends": 0.62,
+            "Stock Splits": 0.0,
+            "Ticker": "ADI",
+        },
+        {
+            "date": "2020-03-23",
+            "Open": 80.00,
+            "High": 84.00,
+            "Low": 78.00,
+            "Close": 82.50,
+            "Adj Close": 74.50,
+            "Volume": 15_000_000,
+            "Dividends": 0.0,
+            "Stock Splits": 0.0,
+            "Ticker": "ADI",
+        },
+    ])
+
+
+def test_fixture_loads_raw_prices(tmp_path: Path):
+    storage = stg.Storage()
+    storage.local_root = tmp_path
+    st.cache_data.clear()
+
+    df = _mini_adi_frame()
+    buf = io.BytesIO()
+    df.to_parquet(buf, index=False)
+    storage.write_bytes("prices/ADI.parquet", buf.getvalue())
+
+    out = stg.load_prices_cached(storage, cache_salt=storage.cache_salt(), tickers=["ADI"])
+    assert not out.empty
+
+    row = out[out["date"] == pd.Timestamp("2020-03-20")].iloc[0]
+    assert row["Open"] == pytest.approx(92.41, rel=1e-6)
+    assert row["Close"] == pytest.approx(85.08, rel=1e-6)
+    assert row["Adj Close"] == pytest.approx(77.08, rel=1e-6)
+    assert row["Dividends"] == pytest.approx(0.62, rel=1e-6)

--- a/tests/test_tidy_prices.py
+++ b/tests/test_tidy_prices.py
@@ -18,11 +18,42 @@ def test_tidy_prices_normalizes_schema():
 
     tidy = _tidy_prices(df, ticker="aapl")
 
-    assert list(tidy.columns) == ["Open", "High", "Low", "Close", "Adj Close", "Volume", "Ticker"]
-    assert tidy.index.name == "date"
-    assert tidy.index.tz is None
+    assert list(tidy.columns) == [
+        "Ticker",
+        "Open",
+        "High",
+        "Low",
+        "Close",
+        "Adj Close",
+        "Volume",
+        "Dividends",
+        "Stock Splits",
+    ]
+    assert tidy.index.name == "date" and tidy.index.tz is None
     assert tidy["Ticker"].unique().tolist() == ["AAPL"]
-    assert "Adj Close" in tidy.columns
+    assert "Adj Close" in tidy and tidy["Dividends"].sum() == 0 and tidy["Stock Splits"].sum() == 0
+
+
+def test_tidy_prices_preserves_raw_ohlc():
+    df = pd.DataFrame(
+        {
+            "date": ["2024-01-02"],
+            "open": [101.0],
+            "high": [105.0],
+            "low": [99.5],
+            "close": [100.0],
+            "adj_close": [95.0],
+            "volume": [1_000_000],
+            "dividends": [1.25],
+        }
+    )
+
+    tidy = _tidy_prices(df, ticker="RAW")
+    stamp = pd.Timestamp("2024-01-02")
+
+    assert tidy.loc[stamp, "Close"] == 100.0
+    assert tidy.loc[stamp, "Adj Close"] == 95.0
+    assert tidy.loc[stamp, "Dividends"] == 1.25
 
 
 def test_tidy_prices_deduplicates_last_wins():

--- a/tests/test_validate_prices_schema.py
+++ b/tests/test_validate_prices_schema.py
@@ -1,0 +1,44 @@
+import pandas as pd
+import pytest
+
+from data_lake.storage import validate_prices_schema
+
+
+def _frame(**overrides):
+    base = {
+        "date": [pd.Timestamp("2020-03-20")],
+        "Ticker": ["RAW"],
+        "Open": [92.41],
+        "High": [93.37],
+        "Low": [84.88],
+        "Close": [85.08],
+        "Adj Close": [77.08],
+        "Volume": [100],
+        "Dividends": [0.52],
+        "Stock Splits": [0.0],
+    }
+    base.update(overrides)
+    return pd.DataFrame(base)
+
+
+def test_accepts_raw():
+    validate_prices_schema(_frame())
+
+
+def test_flags_back_adjusted():
+    with pytest.raises(ValueError, match="Adjusted OHLC detected"):
+        validate_prices_schema(_frame(**{"Adj Close": [85.08]}))
+
+
+def test_allows_equal_when_no_actions():
+    df = _frame(Dividends=[0.0])
+    df["Adj Close"] = df["Close"]
+    validate_prices_schema(df)
+
+
+def test_warns_non_strict(caplog):
+    df = _frame(**{"Adj Close": [85.08]})
+    df["Adj Close"] = df["Close"]
+    with caplog.at_level("WARNING"):
+        validate_prices_schema(df, strict=False)
+    assert any("Adjusted OHLC detected" in rec.getMessage() for rec in caplog.records)

--- a/ui/pages/55_Backtest_Range.py
+++ b/ui/pages/55_Backtest_Range.py
@@ -336,16 +336,29 @@ def render_page() -> None:
                             prices_df.loc[prices_df["Ticker"] == sample_ticker]
                             .drop(columns=["Ticker"], errors="ignore")
                         )
-                        st.write(
-                            {
-                                "sample": sample_ticker,
-                                "rows": int(df0.shape[0]),
-                                "range": [
-                                    str(df0["date"].min()),
-                                    str(df0["date"].max()),
-                                ],
-                            }
-                        )
+                        last_row = df0.sort_values("date").iloc[-1]
+                        sample_out = {
+                            "sample": sample_ticker,
+                            "rows": int(df0.shape[0]),
+                            "range": [
+                                str(df0["date"].min()),
+                                str(df0["date"].max()),
+                            ],
+                            "last_bar_date": str(pd.to_datetime(last_row["date"]).date()),
+                            "last_bar_close": float(last_row.get("Close", float("nan")))
+                            if "Close" in df0.columns
+                            else None,
+                            "last_bar_adj_close": float(last_row.get("Adj Close", float("nan")))
+                            if "Adj Close" in df0.columns
+                            else None,
+                            "last_bar_dividends": float(last_row.get("Dividends", 0) or 0)
+                            if "Dividends" in df0.columns
+                            else 0.0,
+                            "last_bar_stock_splits": float(last_row.get("Stock Splits", 0) or 0)
+                            if "Stock Splits" in df0.columns
+                            else 0.0,
+                        }
+                        st.write(sample_out)
 
             if prices_df.empty:
                 log("No prices loaded—check Storage bucket and paths (prices/*.parquet).")


### PR DESCRIPTION
## What & why
* ensure the lake keeps provider raw OHLC while surfacing adjusted close separately
* add tooling to validate price frames plus scripts to backfill and smoke-check data

## Key changes
* add `validate_prices_schema`, enforce schema in `_tidy_prices`, and make `load_prices_cached` strict
* harden Supabase ingest to request `adj_close`, warn-only validate on write, and ship rebuild/smoke scripts
* document RAW OHLC policy, add ADI fixture + tests that generate parquet at runtime, wire CI workflow, and expose debug UI details

## Invariants & safety rails
* schema validator guards against back-adjusted close values and missing columns
* new pytest coverage + smoke script verify ADI dividend day keeps raw vs adjusted prices

## Evidence
```
root@65c90384f4a0:/workspace/sp500scn# make test
pytest -q
.................................................................                                                        [100%]
======================================================= warnings summary =======================================================
ui/__init__.py:51
  /workspace/sp500scn/ui/__init__.py:51: FutureWarning: Passing literal html to 'read_html' is deprecated and will be removed in
 a future version. To read from a literal string, wrap it in a 'StringIO' object.
    pd.read_html("<table><tr><td>1</td></tr></table>")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
65 passed, 1 skipped, 1 warning in 4.25s
root@65c90384f4a0:/workspace/sp500scn#
```


------
https://chatgpt.com/codex/tasks/task_e_68ca11f01da08332b822c25b37212f9d