### PR TITLE
Fix workflow verify command to drop unsupported threshold flag

### DIFF
--- a/.github/workflows/migrate-and-verify-sample.yml
+++ b/.github/workflows/migrate-and-verify-sample.yml
@@ -72,5 +72,5 @@ jobs:
           for T in "${TKS[@]}"; do
             T=$(echo "$T" | xargs)
             echo "=== VERIFY $T ==="
-            python scripts/verify_raw_vs_yahoo.py --ticker "$T" --threshold 0.001
+            python scripts/verify_raw_vs_yahoo.py --ticker "$T"
           done


### PR DESCRIPTION
## Summary
- remove the `--threshold` argument from the verify step in the migrate-and-verify workflow since the script does not accept it

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cb3464159083329b56f6281326173b