### PR TITLE
Add Tiingo ingest workflow and scripts

### DIFF
--- a/.github/workflows/ingest-and-verify-tiingo.yml
+++ b/.github/workflows/ingest-and-verify-tiingo.yml
@@ -1,0 +1,86 @@
+name: ingest-and-verify-tiingo
+
+on:
+  workflow_dispatch:
+    inputs:
+      tickers:
+        description: "Comma-separated tickers"
+        default: "AAPL,NVDA,WMT,ALB"
+        required: true
+      start:
+        description: "Start date (YYYY-MM-DD)"
+        default: "1996-01-01"
+        required: true
+      end:
+        description: "End date (YYYY-MM-DD, optional)"
+        default: ""
+        required: false
+
+env:
+  PYTHONUNBUFFERED: "1"
+  PYTHONPATH: ${{ github.workspace }}
+  SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+  SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
+  TIINGO_API_KEY: ${{ secrets.TIINGO_API_KEY }}
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+
+      - name: Install deps
+        run: |
+          if [ -f requirements.txt ]; then
+            pip install -r requirements.txt
+          else
+            echo "pandas==2.2.3" >> requirements.txt
+            echo "pyarrow==15.0.2" >> requirements.txt
+            echo "pandas-datareader==0.10.0" >> requirements.txt
+            pip install -r requirements.txt
+          fi
+
+      - name: Show inputs
+        run: |
+          echo "Tickers: ${{ github.event.inputs.tickers }}"
+          echo "Start:   ${{ github.event.inputs.start }}"
+          echo "End:     ${{ github.event.inputs.end }}"
+
+      - name: Ingest from Tiingo → Supabase
+        run: |
+          set -e
+          IFS=',' read -ra TKS <<< "${{ github.event.inputs.tickers }}"
+          for T in "${TKS[@]}"; do
+            T=$(echo "$T" | xargs)
+            echo "=== MIGRATE $T ==="
+            python scripts/migrate_lake_from_tiingo.py \
+              --ticker "$T" \
+              --start "${{ github.event.inputs.start }}" \
+              $( [ -n "${{ github.event.inputs.end }}" ] && echo --end "${{ github.event.inputs.end }}" )
+          done
+
+      - name: Verify vs Tiingo (0.1% MAD)
+        run: |
+          set -e
+          IFS=',' read -ra TKS <<< "${{ github.event.inputs.tickers }}"
+          for T in "${TKS[@]}"; do
+            T=$(echo "$T" | xargs)
+            echo "=== VERIFY $T ==="
+            python scripts/verify_raw_vs_tiingo.py --ticker "$T" --start "${{ github.event.inputs.start }}" --end "${{ github.event.inputs.end }}"
+          done

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pyarrow==15.0.2
 requests==2.32.3
 urllib3==2.2.2
 yfinance==0.2.43
+pandas-datareader==0.10.0

--- a/scripts/migrate_lake_from_tiingo.py
+++ b/scripts/migrate_lake_from_tiingo.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import io
+import os
+import sys
+import time
+import typing as t
+
+import pandas as pd
+import pandas_datareader as pdr
+
+from data_lake.storage import Storage
+
+
+SCHEMA = [
+    "date",
+    "Ticker",
+    "Open",
+    "High",
+    "Low",
+    "Close",
+    "Adj Close",
+    "Volume",
+    "Dividends",
+    "Stock Splits",
+]
+
+
+def _validate(df: pd.DataFrame, ticker: str) -> None:
+    if df is None or df.empty:
+        raise ValueError(f"{ticker}: empty frame")
+
+    missing = [c for c in SCHEMA if c not in df.columns]
+    if missing:
+        raise ValueError(f"{ticker}: missing columns: {missing}")
+
+    df["date"] = pd.to_datetime(df["date"], errors="coerce").dt.tz_localize(None)
+    if df["date"].isna().any():
+        raise ValueError(f"{ticker}: bad dates present")
+
+
+def _to_schema(df: pd.DataFrame, tkr: str) -> pd.DataFrame:
+    df = df.reset_index()  # has columns: ['symbol','date', ...]
+    df = df.rename(
+        columns={
+            "open": "Open",
+            "high": "High",
+            "low": "Low",
+            "close": "Close",
+            "adjClose": "Adj Close",
+            "volume": "Volume",
+            "divCash": "Dividends",
+            "splitFactor": "_split",
+        }
+    )
+
+    out = pd.DataFrame(index=range(len(df)))
+    out["date"] = pd.to_datetime(df["date"]).dt.tz_localize(None)
+    out["Ticker"] = tkr.upper()
+    out["Open"] = df.get("Open", pd.NA)
+    out["High"] = df.get("High", pd.NA)
+    out["Low"] = df.get("Low", pd.NA)
+    out["Close"] = df.get("Close", pd.NA)
+    out["Adj Close"] = df.get("Adj Close", pd.NA)
+    out["Volume"] = df.get("Volume", pd.NA)
+    out["Dividends"] = df.get("Dividends", 0.0)
+
+    # Map Tiingo splitFactor (1.0=no split) to our "Stock Splits" (0.0=no split)
+    sp = df.get("_split", 1.0)
+    out["Stock Splits"] = (
+        pd.to_numeric(sp, errors="coerce")
+        .fillna(1.0)
+        .apply(lambda x: 0.0 if x == 1.0 else float(x))
+    )
+    return out[SCHEMA].sort_values("date")
+
+
+def _write_with_backup(storage: Storage, tkr: str, df: pd.DataFrame) -> None:
+    dest = f"prices/{tkr.upper()}.parquet"
+    ts = pd.Timestamp.utcnow().strftime("%Y%m%d%H%M%S")
+
+    # best-effort backup
+    try:
+        if getattr(storage, "exists", None) and storage.exists(dest):
+            prev = storage.read_bytes(dest)
+            storage.write_bytes(f"backups/prices/{tkr.upper()}.{ts}.parquet", prev)
+    except Exception:
+        pass
+
+    buf = io.BytesIO()
+    df.to_parquet(buf, index=False, compression="snappy")
+    storage.write_bytes(dest, buf.getvalue())
+
+
+def fetch_tiingo(tkr: str, start: str | None, end: str | None, api_key: str) -> pd.DataFrame:
+    # Tiingo expects BRK.B style tickers as-is; keep your filename/column as original uppercase
+    df = pdr.get_data_tiingo(tkr, start=start, end=end, api_key=api_key)
+    return _to_schema(df, tkr)
+
+
+def main(argv: t.Sequence[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Migrate RAW OHLC from Tiingo into lake.")
+    ap.add_argument(
+        "--ticker",
+        required=True,
+        help="Single ticker (repeat step for many) or comma-separated list",
+    )
+    ap.add_argument("--start")
+    ap.add_argument("--end")
+    ap.add_argument("--sleep", type=float, default=0.4)
+    args = ap.parse_args(argv)
+
+    api_key = os.getenv("TIINGO_API_KEY", "")
+    if not api_key:
+        print("TIINGO_API_KEY not set", file=sys.stderr)
+        return 2
+
+    storage = Storage.from_env()
+
+    tickers = [t for t in args.ticker.replace(",", " ").upper().split() if t]
+    ok = fail = 0
+    for tkr in tickers:
+        try:
+            df = fetch_tiingo(tkr, args.start, args.end, api_key)
+            _validate(df, tkr)
+            _write_with_backup(storage, tkr, df)
+            print(
+                f"{tkr}: wrote {len(df)} rows [{df['date'].min().date()} → {df['date'].max().date()}]"
+            )
+            ok += 1
+            time.sleep(max(args.sleep, 0))
+        except Exception as e:  # noqa: PERF203 - simple CLI tool
+            print(f"{tkr}: ERROR {e}", file=sys.stderr)
+            fail += 1
+    print(f"Done. ok={ok}, failed={fail}")
+    return 0 if fail == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_raw_vs_tiingo.py
+++ b/scripts/verify_raw_vs_tiingo.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+import typing as t
+
+import numpy as np
+import pandas as pd
+import pandas_datareader as pdr
+
+from data_lake.storage import Storage
+
+
+def _mad_pct(a: pd.Series, b: pd.Series) -> float:
+    a = pd.to_numeric(a, errors="coerce")
+    b = pd.to_numeric(b, errors="coerce")
+    common = a.index.intersection(b.index)
+    if len(common) == 0:
+        return float("inf")
+    rel = (a.loc[common] - b.loc[common]).abs() / b.loc[common].replace(0, np.nan).abs()
+    return float(np.nanmedian(rel))
+
+
+def main(argv: t.Sequence[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Compare lake RAW vs Tiingo for O/H/L/C/Vol")
+    ap.add_argument("--ticker", required=True)
+    ap.add_argument("--start")
+    ap.add_argument("--end")
+    ap.add_argument("--threshold", type=float, default=0.001)  # 0.1%
+    args = ap.parse_args(argv)
+
+    api_key = os.getenv("TIINGO_API_KEY", "")
+    if not api_key:
+        print("no TIINGO_API_KEY")
+        return 2
+
+    storage = Storage.from_env()
+    path = f"prices/{args.ticker.upper()}.parquet"
+    if not storage.exists(path):
+        print("NO lake file")
+        return 2
+
+    df = storage.read_parquet_df(path).copy()
+    df["date"] = pd.to_datetime(df["date"]).dt.tz_localize(None)
+    df = df.set_index("date").sort_index()
+
+    tdf = (
+        pdr.get_data_tiingo(
+            args.ticker.upper(), start=args.start, end=args.end, api_key=api_key
+        )
+        .reset_index()
+    )
+    tdf["date"] = pd.to_datetime(tdf["date"]).dt.tz_localize(None)
+    tdf = tdf.set_index("date").sort_index()
+
+    cols_map = {
+        "Open": "open",
+        "High": "high",
+        "Low": "low",
+        "Close": "close",
+        "Volume": "volume",
+    }
+    diffs = {k: _mad_pct(df[k], tdf[v]) for k, v in cols_map.items()}
+    print(
+        {
+            "ticker": args.ticker.upper(),
+            "median_abs_pct_diff": {k: round(v, 6) for k, v in diffs.items()},
+            "n_common_days": int(len(df.index.intersection(tdf.index))),
+        }
+    )
+    return 0 if all(v <= args.threshold for v in diffs.values()) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add pandas-datareader dependency for the new Tiingo ingest tools
- implement CLI scripts to migrate Supabase lake data from Tiingo and verify MAD differences
- add a manual GitHub Action to run Tiingo ingestion and verification across supplied tickers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb523172b483329e6de935e76b280c