### PR TITLE
Handle optional end date in Tiingo verification workflow step

### DIFF
--- a/.github/workflows/ingest-and-verify-tiingo.yml
+++ b/.github/workflows/ingest-and-verify-tiingo.yml
@@ -82,5 +82,8 @@ jobs:
           for T in "${TKS[@]}"; do
             T=$(echo "$T" | xargs)
             echo "=== VERIFY $T ==="
-            python scripts/verify_raw_vs_tiingo.py --ticker "$T" --start "${{ github.event.inputs.start }}" --end "${{ github.event.inputs.end }}"
+            python scripts/verify_raw_vs_tiingo.py \
+              --ticker "$T" \
+              --start "${{ github.event.inputs.start }}" \
+              $( [ -n "${{ github.event.inputs.end }}" ] && echo --end "${{ github.event.inputs.end }}" )
           done


### PR DESCRIPTION
## Summary
- skip adding the --end flag in the Tiingo verification step when the workflow input is blank

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cb56edb5548332ace79b0380e2b964