### PR TITLE
Guard optional Yahoo ingest helper import

### DIFF
--- a/ui/pages/90_Data_Lake_Phase1.py
+++ b/ui/pages/90_Data_Lake_Phase1.py
@@ -17,8 +17,7 @@ except ModuleNotFoundError:  # pragma: no cover - handled in UI when invoked
 
 from data_lake.storage import Storage, supabase_available
 from data_lake.membership import build_membership, load_membership
-from data_lake.ingest import ingest_batch
-from data_lake.ingest import lake_file_is_raw
+from data_lake.ingest import ingest_batch, lake_file_is_raw
 
 # Try to import the optional Yahoo RAW batch helper. Older deployments may not
 # have it yet, so fall back gracefully if import fails.


### PR DESCRIPTION
## Summary
- keep the primary ingest imports separate so the optional Yahoo RAW helper remains guarded
- leave `ingest_raw_yahoo_batch` within the try/except block so deployments without it can still load the page

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb6af9a7988332971285832a2c6fa3