### PR TITLE
Improve ticker filtering against data lake

### DIFF
--- a/tests/test_filter_tickers_with_parquet.py
+++ b/tests/test_filter_tickers_with_parquet.py
@@ -62,3 +62,17 @@ def test_filter_tickers_with_parquet_supabase_pagination():
 
     assert present == ["SYM0", "SYM150"]
     assert missing == ["MISSING"]
+
+
+def test_filter_tickers_with_parquet_normalizes_ticker_variants(tmp_path, monkeypatch):
+    st = _make_storage(tmp_path, monkeypatch)
+    prices_dir = Path(storage.LOCAL_ROOT) / "prices"
+    (prices_dir / "BRK_B.parquet").write_text("b")
+    (prices_dir / "BF-B.parquet").write_text("bf")
+
+    present, missing = storage.filter_tickers_with_parquet(
+        st, ["brk.b", "BF.B", "ally"]
+    )
+
+    assert present == ["BRK.B", "BF.B"]
+    assert missing == ["ALLY"]

--- a/ui/pages/45_YdayVolSignal_Open.py
+++ b/ui/pages/45_YdayVolSignal_Open.py
@@ -94,29 +94,27 @@ def render_page() -> None:
             )
 
             if missing_tickers:
+                missing_count = len(missing_tickers)
+                available_count = len(filtered_tickers)
                 warn_text = (
-                    f"{requested_count} tickers were requested. "
-                    f"{len(filtered_tickers)} were found with available price data. "
-                    "Running scan on valid tickers only."
+                    f"Out of {requested_count} S&P tickers for {D.date()}, "
+                    f"{available_count} have price files for scanning. "
+                    f"{missing_count} are missing and were excluded automatically."
                 )
                 st.warning(warn_text)
                 log(warn_text)
-                preview = ", ".join(missing_tickers[:10])
-                if preview:
-                    more = "…" if len(missing_tickers) > 10 else ""
+
+                with st.expander("Missing ticker diagnostics", expanded=False):
                     st.caption(
-                        f"Missing tickers ({len(missing_tickers)} total, first 10 shown): {preview}{more}"
+                        "Tickers listed below were not found in Supabase Storage under "
+                        "`prices/*.parquet`."
                     )
-                toggle_fn = getattr(st, "toggle", None)
-                if callable(toggle_fn):
-                    enable_export = toggle_fn(
-                        "Enable download for missing tickers", key="scan_missing_toggle"
-                    )
-                else:  # pragma: no cover - Streamlit fallback
-                    enable_export = st.checkbox(
-                        "Enable download for missing tickers", key="scan_missing_toggle"
-                    )
-                if enable_export:
+                    preview_count = min(50, missing_count)
+                    st.code("\n".join(missing_tickers[:preview_count]))
+                    if missing_count > preview_count:
+                        st.caption(
+                            f"Showing the first {preview_count} tickers (of {missing_count} total)."
+                        )
                     st.download_button(
                         "Download missing tickers (.txt)",
                         data="\n".join(missing_tickers),

--- a/ui/pages/55_Backtest_Range.py
+++ b/ui/pages/55_Backtest_Range.py
@@ -259,29 +259,27 @@ def render_page() -> None:
             )
 
             if missing_tickers:
+                missing_count = len(missing_tickers)
+                available_count = len(filtered_tickers)
                 warn_text = (
-                    f"{requested_count} tickers were requested. "
-                    f"{len(filtered_tickers)} were found with available price data. "
-                    "Running backtest on valid tickers only."
+                    f"Out of {requested_count} S&P tickers in the selected range, "
+                    f"{available_count} are available for backtesting. "
+                    f"{missing_count} are missing price files and were excluded automatically."
                 )
                 st.warning(warn_text)
                 log(warn_text)
-                preview = ", ".join(missing_tickers[:10])
-                if preview:
-                    more = "…" if len(missing_tickers) > 10 else ""
+
+                with st.expander("Missing ticker diagnostics", expanded=False):
                     st.caption(
-                        f"Missing tickers ({len(missing_tickers)} total, first 10 shown): {preview}{more}"
+                        "Tickers listed below were not found in Supabase Storage under "
+                        "`prices/*.parquet`."
                     )
-                toggle_fn = getattr(st, "toggle", None)
-                if callable(toggle_fn):
-                    enable_export = toggle_fn(
-                        "Enable download for missing tickers", key="bt_missing_toggle"
-                    )
-                else:  # pragma: no cover - Streamlit fallback
-                    enable_export = st.checkbox(
-                        "Enable download for missing tickers", key="bt_missing_toggle"
-                    )
-                if enable_export:
+                    preview_count = min(50, missing_count)
+                    st.code("\n".join(missing_tickers[:preview_count]))
+                    if missing_count > preview_count:
+                        st.caption(
+                            f"Showing the first {preview_count} tickers (of {missing_count} total)."
+                        )
                     st.download_button(
                         "Download missing tickers (.txt)",
                         data="\n".join(missing_tickers),


### PR DESCRIPTION
## Summary
- normalize ticker symbols before intersecting S&P membership with lake price files to handle punctuation differences
- add regression coverage for ticker normalization when listing parquet files
- update the scan and backtest UIs to report S&P coverage counts and gate missing tickers behind an expander with download support

## Testing
- PYTHONPATH=. pytest tests/test_filter_tickers_with_parquet.py

------
https://chatgpt.com/codex/tasks/task_e_68cd9701f1a4833295221aa567cab18f