### PR TITLE
Fix: guard import of filter_tickers_with_parquet; add UI fallback

### DIFF
--- a/ui/pages/45_YdayVolSignal_Open.py
+++ b/ui/pages/45_YdayVolSignal_Open.py
@@ -7,7 +7,34 @@ import streamlit as st
 
 import engine.signal_scan as sigscan
 from engine.signal_scan import scan_day, ScanParams, members_on_date
-from data_lake.storage import Storage, load_prices_cached, filter_tickers_with_parquet
+from data_lake.storage import Storage, load_prices_cached
+from data_lake import storage as _dl_storage
+
+
+def _fallback_filter_tickers_with_parquet(storage: Storage, tickers):
+    seen = set()
+    requested = []
+    for ticker in tickers or []:
+        if not ticker:
+            continue
+        normalized = str(ticker).strip().upper()
+        if normalized and normalized not in seen:
+            seen.add(normalized)
+            requested.append(normalized)
+
+    present: list[str] = []
+    missing: list[str] = []
+    for normalized in requested:
+        if storage.exists(f"prices/{normalized}.parquet"):
+            present.append(normalized)
+        else:
+            missing.append(normalized)
+    return present, missing
+
+
+filter_tickers_with_parquet = getattr(
+    _dl_storage, "filter_tickers_with_parquet", _fallback_filter_tickers_with_parquet
+)
 from ui.components.progress import status_block
 from ui.components.debug import debug_panel, _get_dbg
 from ui.components.tables import show_df


### PR DESCRIPTION
## Summary
- guard Streamlit pages against ImportError when `filter_tickers_with_parquet` is absent by dynamically binding the helper with a local fallback
- provide a minimal exists()-based fallback implementation reused by both affected pages
- add regression test that exercises the UI fallback path when the storage helper is unavailable

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd9f3cfff48332a781eb5b012e0a43