### PR TITLE
Fix: Make filter_tickers_with_parquet importable and add non-crashing fallback in pages

### DIFF
--- a/data_lake/__init__.py
+++ b/data_lake/__init__.py
@@ -5,4 +5,14 @@ membership table and fetch daily adjusted prices for all
 historical members of the S&P 500 index.
 """
 
-__all__ = []
+from .storage import (
+    Storage,
+    filter_tickers_with_parquet,
+    load_prices_cached,
+)
+
+__all__ = [
+    "Storage",
+    "filter_tickers_with_parquet",
+    "load_prices_cached",
+]

--- a/tests/test_filter_tickers_with_parquet.py
+++ b/tests/test_filter_tickers_with_parquet.py
@@ -103,5 +103,6 @@ def test_ui_fallback_filter(monkeypatch, tmp_path):
     assert present == ["AAPL"]
     assert missing == ["MSFT"]
     assert page_module.filter_tickers_with_parquet is page_module._fallback_filter_tickers_with_parquet
+    assert page_module._FILTER_TICKER_SOURCE == "fallback"
 
     sys.modules.pop(module_name, None)

--- a/tests/test_package_exports.py
+++ b/tests/test_package_exports.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+
+def test_data_lake_package_exports():
+    import data_lake
+    from data_lake import Storage, filter_tickers_with_parquet, load_prices_cached
+    from data_lake import storage as dl_storage
+
+    assert Storage is dl_storage.Storage
+    assert load_prices_cached is dl_storage.load_prices_cached
+    assert filter_tickers_with_parquet is dl_storage.filter_tickers_with_parquet
+    assert callable(filter_tickers_with_parquet)
+
+    # Package-level __all__ should advertise the helpers for ``from data_lake import *``.
+    exported = set(getattr(data_lake, "__all__", ()))
+    assert {"Storage", "load_prices_cached", "filter_tickers_with_parquet"}.issubset(exported)

--- a/ui/pages/55_Backtest_Range.py
+++ b/ui/pages/55_Backtest_Range.py
@@ -7,12 +7,11 @@ from pandas.tseries.offsets import BDay
 import streamlit as st
 
 from data_lake.storage import Storage, load_prices_cached
-from data_lake import storage as _dl_storage
 
 
-def _fallback_filter_tickers_with_parquet(storage: Storage, tickers):
-    seen = set()
-    requested = []
+def _fallback_filter_tickers_with_parquet(storage: "Storage", tickers):
+    seen: set[str] = set()
+    requested: list[str] = []
     for ticker in tickers or []:
         if not ticker:
             continue
@@ -24,16 +23,25 @@ def _fallback_filter_tickers_with_parquet(storage: Storage, tickers):
     present: list[str] = []
     missing: list[str] = []
     for normalized in requested:
-        if storage.exists(f"prices/{normalized}.parquet"):
-            present.append(normalized)
-        else:
+        try:
+            if storage.exists(f"prices/{normalized}.parquet"):
+                present.append(normalized)
+            else:
+                missing.append(normalized)
+        except Exception:
             missing.append(normalized)
     return present, missing
 
 
-filter_tickers_with_parquet = getattr(
-    _dl_storage, "filter_tickers_with_parquet", _fallback_filter_tickers_with_parquet
-)
+try:
+    from data_lake.storage import filter_tickers_with_parquet as _filter_tickers_with_parquet
+except Exception:  # pragma: no cover - exercised in fallback test
+    _FILTER_TICKER_SOURCE = "fallback"
+    filter_tickers_with_parquet = _fallback_filter_tickers_with_parquet
+else:
+    _FILTER_TICKER_SOURCE = "package"
+    filter_tickers_with_parquet = _filter_tickers_with_parquet
+
 import engine.signal_scan as sigscan
 from engine.signal_scan import ScanParams, members_on_date
 from ui.components.progress import status_block
@@ -57,8 +65,17 @@ def render_page() -> None:
         }
 
     dbg = _get_dbg("backtest")
-    dbg.set_env(storage_mode=getattr(storage, "mode", "unknown"), bucket=getattr(storage, "bucket", None))
+    dbg.set_env(
+        storage_mode=getattr(storage, "mode", "unknown"),
+        bucket=getattr(storage, "bucket", None),
+        ticker_filter_source=_FILTER_TICKER_SOURCE,
+    )
     st.caption(f"storage: mode={diag['mode']} bucket={diag['bucket']}")
+    if _FILTER_TICKER_SOURCE != "package":
+        st.warning(
+            "Price availability helper import failed; falling back to direct parquet probes."
+            " Filtering may be slower until deployments finish."
+        )
 
     if getattr(storage, "force_supabase", False) and storage.mode == "local":
         st.error(


### PR DESCRIPTION
## Summary
- export Storage, load_prices_cached, and filter_tickers_with_parquet from the data_lake package root
- guard Streamlit pages against helper import failures with a defensive fallback and user warning
- add regression tests for package exports and the UI fallback path

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cda83f71108332b36be6996ac1deb0