### PR TITLE
Kill misleading price filter fallback and abort runs when unavailable

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,12 +2,15 @@ import os
 import importlib.util
 from pathlib import Path
 import streamlit as st
+
 from ui.layout import setup_page, render_header
+from ui.price_filter import initialize_price_filter
 
 os.environ.setdefault("STREAMLIT_SERVER_FILE_WATCHER_TYPE", "none")
 
 # Initialize page and global layout/CSS
 setup_page()
+initialize_price_filter()
 
 # ---- Brand header ----
 render_header()

--- a/data_lake/__init__.py
+++ b/data_lake/__init__.py
@@ -6,12 +6,14 @@ historical members of the S&P 500 index.
 """
 
 from .storage import (
+    ConfigurationError,
     Storage,
     filter_tickers_with_parquet,
     load_prices_cached,
 )
 
 __all__ = [
+    "ConfigurationError",
     "Storage",
     "filter_tickers_with_parquet",
     "load_prices_cached",

--- a/ui/pages/45_YdayVolSignal_Open.py
+++ b/ui/pages/45_YdayVolSignal_Open.py
@@ -7,61 +7,42 @@ import streamlit as st
 
 import engine.signal_scan as sigscan
 from engine.signal_scan import ScanParams, members_on_date, scan_day
-from data_lake.storage import Storage, load_prices_cached
-
-
-def _fallback_filter_tickers_with_parquet(storage: "Storage", tickers):
-    seen: set[str] = set()
-    requested: list[str] = []
-    for ticker in tickers or []:
-        if not ticker:
-            continue
-        normalized = str(ticker).strip().upper()
-        if normalized and normalized not in seen:
-            seen.add(normalized)
-            requested.append(normalized)
-
-    present: list[str] = []
-    missing: list[str] = []
-    for normalized in requested:
-        try:
-            if storage.exists(f"prices/{normalized}.parquet"):
-                present.append(normalized)
-            else:
-                missing.append(normalized)
-        except Exception:
-            missing.append(normalized)
-    return present, missing
-
-
-try:
-    from data_lake.storage import filter_tickers_with_parquet as _filter_tickers_with_parquet
-except Exception:  # pragma: no cover - exercised in fallback test
-    _FILTER_TICKER_SOURCE = "fallback"
-    filter_tickers_with_parquet = _fallback_filter_tickers_with_parquet
-else:
-    _FILTER_TICKER_SOURCE = "package"
-    filter_tickers_with_parquet = _filter_tickers_with_parquet
+from data_lake.storage import ConfigurationError, Storage, load_prices_cached
 from ui.components.progress import status_block
 from ui.components.debug import debug_panel, _get_dbg
 from ui.components.tables import show_df
+from ui.price_filter import (
+    CALLOUT_MESSAGE,
+    STRUCTURED_ERROR_MESSAGE,
+    PriceFilterUnavailableError,
+    get_price_filter,
+    handle_filter_exception,
+)
 
 
-def render_page() -> None:
+def page() -> None:
     st.header("⚡ Yesterday Close+Volume → Buy Next Open")
 
     storage = Storage()
+    try:
+        filter_tickers_with_parquet, filter_source = get_price_filter()
+    except PriceFilterUnavailableError as exc:
+        filter_tickers_with_parquet = None
+        filter_source = "unavailable"
+        filter_error = exc
+    else:
+        filter_error = None
+
     dbg = _get_dbg("scan")
     dbg.set_env(
         storage_mode=getattr(storage, "mode", "unknown"),
         bucket=getattr(storage, "bucket", None),
-        ticker_filter_source=_FILTER_TICKER_SOURCE,
+        ticker_filter_source=filter_source,
     )
     st.caption(f"storage: {storage.info()} mode={storage.mode}")
-    if _FILTER_TICKER_SOURCE != "package":
+    if filter_source == "fallback":
         st.warning(
-            "Price availability helper import failed; falling back to direct parquet probes."
-            " Filtering may be slower until deployments finish."
+            "Price availability helper unavailable; ALLOW_FALLBACK enabled — using direct parquet probes."
         )
     if getattr(storage, "force_supabase", False) and storage.mode == "local":
         st.error(
@@ -116,6 +97,18 @@ def render_page() -> None:
                 exit_model=exit_model,
             )
 
+            if filter_tickers_with_parquet is None:
+                status.update(label="Scan cancelled ❌", state="error")
+                st.error(CALLOUT_MESSAGE)
+                log(STRUCTURED_ERROR_MESSAGE)
+                dbg.event(
+                    "price_filter_unavailable",
+                    code=PriceFilterUnavailableError.code,
+                    reason=getattr(filter_error, "reason", None),
+                )
+                debug_panel("scan")
+                return
+
             members = sigscan._load_members(storage, cache_salt=storage.cache_salt())
             active_tickers = members_on_date(members, D)["ticker"].dropna().unique().tolist()
 
@@ -126,9 +119,22 @@ def render_page() -> None:
                 return
 
             requested_count = len(active_tickers)
-            filtered_tickers, missing_tickers = filter_tickers_with_parquet(
-                storage, active_tickers
-            )
+            try:
+                filtered_tickers, missing_tickers = filter_tickers_with_parquet(
+                    storage, active_tickers
+                )
+            except ConfigurationError as exc:
+                error = handle_filter_exception(exc)
+                status.update(label="Scan cancelled ❌", state="error")
+                st.error(error.user_message)
+                log(error.structured_message)
+                dbg.event(
+                    "price_filter_unavailable",
+                    code=error.code,
+                    reason=getattr(error, "reason", str(exc)),
+                )
+                debug_panel("scan")
+                return
             dbg.event(
                 "ticker_filter",
                 requested=requested_count,
@@ -312,5 +318,5 @@ def render_page() -> None:
     debug_panel("scan")
 
 
-def page() -> None:
-    render_page()
+def render_page() -> None:  # pragma: no cover - compatibility shim
+    page()

--- a/ui/price_filter.py
+++ b/ui/price_filter.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import logging
+import os
+from typing import Callable, Iterable, Tuple
+
+from data_lake.storage import ConfigurationError, Storage
+
+PriceFilterFunc = Callable[[Storage, Iterable[str]], Tuple[list[str], list[str]]]
+
+log = logging.getLogger(__name__)
+
+STRUCTURED_ERROR_MESSAGE = (
+    "Price availability check is unavailable. Run canceled. Likely import or storage config issue."
+)
+CALLOUT_MESSAGE = (
+    "Filtering unavailable—import/storage misconfigured. Backtest canceled. "
+    "Check LAKE_LAYOUT/LAKE_PRICES_PREFIX and helper import."
+)
+
+_ALLOW_FALLBACK = os.getenv("ALLOW_FALLBACK", "false").strip().lower() == "true"
+
+_PRICE_FILTER_INITIALIZED = False
+_PRICE_FILTER_FUNC: PriceFilterFunc | None = None
+
+PRICE_FILTER_READY = False
+PRICE_FILTER_ERROR: str | None = None
+PRICE_FILTER_SOURCE = "uninitialized"
+
+
+class PriceFilterUnavailableError(RuntimeError):
+    """Raised when price availability filtering cannot run safely."""
+
+    code = "PRICE_FILTER_UNAVAILABLE"
+    structured_message = STRUCTURED_ERROR_MESSAGE
+    user_message = CALLOUT_MESSAGE
+
+    def __init__(self, reason: str | None = None) -> None:
+        super().__init__(self.structured_message)
+        self.reason = reason
+
+
+def _resolve_prefix_for_fallback(storage: Storage) -> str:
+    raw_prefix = os.getenv("LAKE_PRICES_PREFIX", "lake/prices")
+    prefix = str(raw_prefix or "").strip().strip("/")
+    bucket = str(getattr(storage, "bucket", "") or "").strip().strip("/")
+    if bucket and prefix == bucket:
+        return ""
+    if bucket and prefix.startswith(f"{bucket}/"):
+        prefix = prefix[len(bucket) + 1 :]
+    return prefix.strip("/")
+
+
+def _fallback_filter_tickers_with_parquet(
+    storage: Storage, tickers: Iterable[str]
+) -> tuple[list[str], list[str]]:
+    seen: set[str] = set()
+    present: list[str] = []
+    missing: list[str] = []
+
+    prefix = _resolve_prefix_for_fallback(storage)
+    layout = os.getenv("LAKE_LAYOUT", "flat").strip().lower() or "flat"
+
+    for raw in tickers or []:
+        if not raw:
+            continue
+        ticker = str(raw).strip().upper()
+        if not ticker or ticker in seen:
+            continue
+        seen.add(ticker)
+
+        if layout == "partitioned":
+            key = f"{prefix}/{ticker}" if prefix else ticker
+            try:
+                exists = bool(storage.list_prefix(key))
+            except Exception:
+                exists = False
+        else:
+            key = f"{prefix}/{ticker}.parquet" if prefix else f"{ticker}.parquet"
+            try:
+                exists = storage.exists(key)
+            except Exception:
+                exists = False
+
+        if exists:
+            present.append(ticker)
+        else:
+            missing.append(ticker)
+
+    return present, missing
+
+
+def initialize_price_filter() -> None:
+    """Perform a one-time import smoke of the price filter helper."""
+
+    global _PRICE_FILTER_INITIALIZED, _PRICE_FILTER_FUNC
+    global PRICE_FILTER_READY, PRICE_FILTER_ERROR, PRICE_FILTER_SOURCE
+
+    if _PRICE_FILTER_INITIALIZED:
+        return
+
+    _PRICE_FILTER_INITIALIZED = True
+
+    try:
+        from data_lake.storage import filter_tickers_with_parquet as helper
+    except Exception as exc:  # pragma: no cover - defensive
+        PRICE_FILTER_READY = False
+        PRICE_FILTER_ERROR = str(exc)
+        if _ALLOW_FALLBACK:
+            log.warning(
+                "Price availability helper import failed; ALLOW_FALLBACK=true so using direct probes: %s",
+                exc,
+            )
+            _PRICE_FILTER_FUNC = _fallback_filter_tickers_with_parquet
+            PRICE_FILTER_SOURCE = "fallback"
+        else:
+            log.error("Price availability helper import failed: %s", exc)
+            _PRICE_FILTER_FUNC = None
+            PRICE_FILTER_SOURCE = "unavailable"
+    else:
+        _PRICE_FILTER_FUNC = helper
+        PRICE_FILTER_READY = True
+        PRICE_FILTER_ERROR = None
+        PRICE_FILTER_SOURCE = "package"
+        log.info("Price availability helper import succeeded.")
+
+
+def get_price_filter() -> tuple[PriceFilterFunc, str]:
+    """Return the active price filter callable and its source."""
+
+    initialize_price_filter()
+    if _PRICE_FILTER_FUNC is None:
+        raise PriceFilterUnavailableError(PRICE_FILTER_ERROR)
+    return _PRICE_FILTER_FUNC, PRICE_FILTER_SOURCE
+
+
+def raise_unavailable(reason: str | Exception | None = None) -> PriceFilterUnavailableError:
+    """Convert a configuration failure into a user-facing error."""
+
+    text: str | None
+    if isinstance(reason, Exception):
+        text = str(reason)
+    else:
+        text = reason
+
+    if text:
+        log.error("Price availability helper unavailable: %s", text)
+    else:
+        log.error("Price availability helper unavailable for unknown reason.")
+
+    return PriceFilterUnavailableError(text)
+
+
+def handle_filter_exception(exc: Exception) -> PriceFilterUnavailableError:
+    """Normalize storage helper errors into unavailable errors."""
+
+    if isinstance(exc, PriceFilterUnavailableError):
+        return exc
+    if isinstance(exc, ConfigurationError):
+        return raise_unavailable(exc)
+    return raise_unavailable(str(exc))


### PR DESCRIPTION
## Summary
- add ConfigurationError, configurable lake prefix/layout handling, and low-coverage diagnostics to the parquet price filter
- initialize the price filter at app startup, remove silent fallbacks, and surface a blocking callout when the helper is unavailable
- update backtest/scan pages and tests to respect the new configuration and support partitioned layouts
- align Streamlit page entrypoints with the app loader while keeping a render_page compatibility shim

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cdaeee788c8332a3c9102e4f78eea8