### PR TITLE
Add configurable take-profit modes and index safety

### DIFF
--- a/backtest/run_range.py
+++ b/backtest/run_range.py
@@ -110,7 +110,7 @@ def run_range(
             "atr21_pct",
             "ret21_pct",
         ]
-        ratio_cols = ["sr_ratio", "vol_multiple"]
+        ratio_cols = ["sr_ratio", "vol_multiple", "tp_sr_fraction", "tp_atr_multiple"]
 
         for c in price_cols:
             if c in trades_df.columns:
@@ -174,6 +174,9 @@ def run_range(
         "tp_frac_used",
         "tp_pct_used",
         "tp_pct_used_2dp",
+        "tp_mode",
+        "tp_sr_fraction",
+        "tp_atr_multiple",
         "tp_halfway_pct",
         "precedent_hits",
         "precedent_ok",

--- a/engine/filters.py
+++ b/engine/filters.py
@@ -120,6 +120,7 @@ def atr_feasible(
     """
     if df is None or df.empty or pd.isna(required_pct):
         return False
+    df = df.reset_index(drop=True)
     if asof_idx + 1 >= len(df):
         return False
     entry_price = float(df["open"].iloc[asof_idx + 1])

--- a/tests/test_signal_scan_tp_modes.py
+++ b/tests/test_signal_scan_tp_modes.py
@@ -1,0 +1,202 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+import numpy as np
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from engine import signal_scan as sigscan
+from engine.filters import atr_feasible
+
+
+class DummyStorage:
+    def cache_salt(self) -> str:
+        return "dummy"
+
+
+def _patch_io(monkeypatch, price_df: pd.DataFrame, ticker: str) -> None:
+    membership = pd.DataFrame(
+        {
+            "ticker": [ticker],
+            "start_date": [pd.Timestamp(price_df["date"].min())],
+            "end_date": [pd.NaT],
+        }
+    )
+
+    monkeypatch.setattr(
+        sigscan,
+        "_load_members",
+        lambda storage, cache_salt=None: membership.copy(),
+    )
+
+    def _fake_load_prices(_storage, t: str) -> pd.DataFrame:
+        if t != ticker:
+            raise KeyError(t)
+        return price_df.copy()
+
+    monkeypatch.setattr(sigscan, "_load_prices", _fake_load_prices)
+
+
+def test_compute_metrics_handles_non_range_index():
+    dates = pd.bdate_range("2022-01-03", periods=6)
+    df = pd.DataFrame(
+        {
+            "date": dates,
+            "open": [100, 101, 102, 103, 104, 105],
+            "high": [101, 103, 104, 105, 106, 107],
+            "low": [99, 100, 101, 102, 103, 104],
+            "close": [100, 102, 103, 104, 105, 106],
+            "volume": [1_000_000, 1_050_000, 1_075_000, 1_100_000, 1_125_000, 1_150_000],
+        }
+    ).set_index("date", drop=False)
+
+    metrics = sigscan._compute_metrics(
+        df,
+        dates[-1],
+        vol_lookback=3,
+        atr_window=3,
+        atr_method="wilder",
+        sr_lookback=3,
+    )
+    assert metrics is not None
+    assert metrics["entry_open"] == pytest.approx(105.0)
+    assert not pd.isna(metrics["sr_ratio"])
+    assert "tp_halfway_pct" not in metrics
+
+
+def test_scan_day_sr_fraction_modes(monkeypatch):
+    dates = pd.bdate_range("2021-01-04", periods=5)
+    df_prices = pd.DataFrame(
+        {
+            "date": dates,
+            "open": [90, 95, 110, 115, 120],
+            "high": [92, 110, 120, 140, 130],
+            "low": [88, 95, 108, 110, 118],
+            "close": [91, 105, 112, 130, 125],
+            "volume": [1_000_000, 1_200_000, 1_400_000, 1_600_000, 1_800_000],
+        }
+    )
+
+    _patch_io(monkeypatch, df_prices, ticker="SR")
+    storage = DummyStorage()
+    scan_params = {
+        "min_close_up_pct": 0.0,
+        "min_vol_multiple": 0.0,
+        "min_gap_open_pct": -10.0,
+        "atr_window": 3,
+        "atr_method": "wilder",
+        "lookback_days": 3,
+        "horizon_days": 5,
+        "sr_min_ratio": 1.5,
+        "sr_lookback": 2,
+        "use_precedent": False,
+        "use_atr_feasible": False,
+        "exit_model": "pct_tp_only",
+    }
+
+    D = dates[-1]
+    cand_default, out_default, fail_default, _ = sigscan.scan_day(storage, D, scan_params)
+    assert fail_default == 0
+    assert len(cand_default) == 1
+    row_default = cand_default.iloc[0]
+    resistance = row_default["resistance"]
+    entry = row_default["entry_open"]
+    expected_half = 0.5 * (resistance - entry) / entry
+
+    assert row_default["tp_mode"] == "sr_fraction"
+    assert row_default["tp_sr_fraction"] == pytest.approx(0.5)
+    assert row_default["tp_frac_used"] == pytest.approx(expected_half)
+    assert row_default["tp_halfway_pct"] == pytest.approx(expected_half)
+    assert row_default["tp_price_pct_target"] == pytest.approx(expected_half * 100.0)
+    assert row_default["tp_price_abs_target"] == pytest.approx(entry * (1.0 + expected_half))
+
+    out_row_default = out_default.iloc[0]
+    assert out_row_default["tp_price_pct_target"] == pytest.approx(expected_half * 100.0)
+    assert out_row_default["tp_price_abs_target"] == pytest.approx(entry * (1.0 + expected_half))
+
+    params_quarter = {
+        **scan_params,
+        "tp_mode": "sr_fraction",
+        "tp_sr_fraction": 0.25,
+    }
+    cand_quarter, out_quarter, fail_quarter, _ = sigscan.scan_day(storage, D, params_quarter)
+    assert fail_quarter == 0
+    assert len(cand_quarter) == 1
+    row_quarter = cand_quarter.iloc[0]
+    expected_quarter = 0.25 * (resistance - entry) / entry
+    assert row_quarter["tp_sr_fraction"] == pytest.approx(0.25)
+    assert row_quarter["tp_frac_used"] == pytest.approx(expected_quarter)
+    assert row_quarter["tp_price_pct_target"] == pytest.approx(expected_quarter * 100.0)
+    assert np.isnan(row_quarter["tp_atr_multiple"])
+    out_row_quarter = out_quarter.iloc[0]
+    assert out_row_quarter["tp_price_abs_target"] == pytest.approx(entry * (1.0 + expected_quarter))
+
+
+def test_scan_day_atr_multiple_mode(monkeypatch):
+    dates = pd.bdate_range("2021-06-01", periods=6)
+    df_prices = pd.DataFrame(
+        {
+            "date": dates,
+            "open": [100.0] * 6,
+            "high": [101.0] * 6,
+            "low": [99.0] * 6,
+            "close": [100.0] * 6,
+            "volume": [1_000_000, 1_050_000, 1_100_000, 1_150_000, 1_200_000, 1_250_000],
+        }
+    )
+
+    _patch_io(monkeypatch, df_prices, ticker="ATR")
+    storage = DummyStorage()
+    params = {
+        "min_close_up_pct": 0.0,
+        "min_vol_multiple": 0.0,
+        "min_gap_open_pct": 0.0,
+        "atr_window": 3,
+        "atr_method": "wilder",
+        "lookback_days": 3,
+        "horizon_days": 5,
+        "sr_min_ratio": 0.5,
+        "sr_lookback": 3,
+        "use_precedent": False,
+        "use_atr_feasible": False,
+        "exit_model": "pct_tp_only",
+        "tp_mode": "atr_multiple",
+        "tp_atr_multiple": 0.5,
+    }
+
+    D = dates[-1]
+    cand_df, out_df, fail_count, _ = sigscan.scan_day(storage, D, params)
+    assert fail_count == 0
+    assert len(cand_df) == 1
+    row = cand_df.iloc[0]
+    expected_frac = 0.5 * row["atr21"] / row["entry_open"]
+
+    assert row["tp_mode"] == "atr_multiple"
+    assert np.isnan(row["tp_halfway_pct"])
+    assert row["tp_atr_multiple"] == pytest.approx(0.5)
+    assert row["tp_price_pct_target"] == pytest.approx(expected_frac * 100.0)
+    assert row["tp_frac_used"] == pytest.approx(expected_frac)
+
+    out_row = out_df.iloc[0]
+    assert out_row["tp_price_pct_target"] == pytest.approx(expected_frac * 100.0)
+    assert out_row["tp_price_abs_target"] == pytest.approx(
+        row["entry_open"] * (1.0 + expected_frac)
+    )
+
+
+def test_atr_feasible_handles_non_range_index():
+    dates = pd.bdate_range("2020-02-03", periods=5)
+    df = pd.DataFrame(
+        {
+            "open": [100.0] * 5,
+            "high": [101.0] * 5,
+            "low": [99.0] * 5,
+            "close": [100.0] * 5,
+        },
+        index=dates,
+    )
+    assert atr_feasible(df, asof_idx=3, required_pct=0.01, atr_window=2)


### PR DESCRIPTION
## Summary
- add configurable take-profit logic that supports S/R fraction and ATR multiple targets while keeping defaults backward compatible
- expose new take-profit controls and metadata in the backtest range UI and exports
- harden positional indexing, ATR feasibility, and add unit tests covering the new TP modes and index safety

## Testing
- pytest tests/test_signal_scan_tp_modes.py

------
https://chatgpt.com/codex/tasks/task_e_68cff59bd3b483329d8d5800ff3fcbf8