### PR TITLE
Normalize Supabase storage keys to fix price preload 404s

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ Price history is loaded from Supabase Storage parquet files under
 `lake/prices/{TICKER}.parquet`. Legacy database table reads and `yfinance`
 imports have been removed in favor of this storage-based approach.
 
+Storage paths are normalised automatically: the configured bucket name or
+leading slashes are stripped from the object key before Supabase requests are
+issued. Environment variables such as `LAKE_PRICES_PREFIX` may therefore be
+specified as `prices`, `/prices`, or even `lake/prices` without breaking remote
+fetches. The loader logs the resolved bucket, prefix, and key whenever a request
+fails to assist with troubleshooting.
+
 ## Outcome Evaluation
 
 Use the `scripts/evaluate_outcomes.py` utility to update `data/history/outcomes.csv` with trade results.

--- a/tests/test_storage_path_normalization.py
+++ b/tests/test_storage_path_normalization.py
@@ -1,0 +1,77 @@
+import os
+import sys
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from data_lake.storage import (
+    Storage,
+    _normalize_storage_key,
+    _resolve_prices_prefix,
+)
+
+
+@pytest.mark.parametrize(
+    "bucket, raw, expected",
+    [
+        ("lake", "prices/AAPL.parquet", "prices/AAPL.parquet"),
+        ("lake", "/prices/AAPL.parquet", "prices/AAPL.parquet"),
+        ("lake", "lake/prices/AAPL.parquet", "prices/AAPL.parquet"),
+        ("lake", "/lake/prices/AAPL.parquet", "prices/AAPL.parquet"),
+        ("lake", "//lake///prices//AAPL.parquet", "prices/AAPL.parquet"),
+        ("lake", "lake", ""),
+        ("", "prices/AAPL.parquet", "prices/AAPL.parquet"),
+    ],
+)
+def test_normalize_storage_key(bucket, raw, expected):
+    assert _normalize_storage_key(raw, bucket=bucket) == expected
+
+
+@pytest.mark.parametrize(
+    "env_value, expected",
+    [
+        ("prices", "prices"),
+        ("/prices", "prices"),
+        ("lake/prices", "prices"),
+        ("lake/prices/", "prices"),
+        ("//lake///prices", "prices"),
+        ("lake", ""),
+    ],
+)
+def test_resolve_prices_prefix_handles_bucket(monkeypatch, env_value, expected):
+    monkeypatch.setenv("LAKE_PRICES_PREFIX", env_value)
+    storage = Storage()
+    storage.bucket = "lake"
+    assert _resolve_prices_prefix(storage) == expected
+
+
+def test_read_bytes_normalizes_supabase_key():
+    storage = Storage()
+    storage.mode = "supabase"
+    storage.bucket = "lake"
+
+    called: dict[str, str] = {}
+
+    class Bucket:
+        def download(self, key: str) -> bytes:
+            called["key"] = key
+            return b"payload"
+
+    class Client:
+        class StorageAPI:
+            def __init__(self, bucket_obj: Bucket) -> None:
+                self._bucket = bucket_obj
+
+            def from_(self, bucket: str) -> Bucket:
+                assert bucket == "lake"
+                return self._bucket
+
+        def __init__(self) -> None:
+            self.storage = Client.StorageAPI(Bucket())
+
+    storage.supabase_client = Client()
+    data = storage.read_bytes("lake/prices/AAA.parquet")
+
+    assert data == b"payload"
+    assert called["key"] == "prices/AAA.parquet"


### PR DESCRIPTION
## Summary
- normalize Supabase storage keys so bucket-prefixed paths resolve consistently in both local and remote modes
- update price loading to reuse normalized keys across availability checks, add partition-aware fallbacks, and include bucket/prefix information in failure logs
- add regression tests for key normalization and document the normalization behavior for LAKE_PRICES_PREFIX values

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0134b34848332afffbb200cadfbbf