### PR TITLE
Anchor vertical spreads to TP and enforce real-world sizing

### DIFF
--- a/backtest/run_range.py
+++ b/backtest/run_range.py
@@ -309,6 +309,7 @@ def run_range(
         "revenue",
         "fees_exit",
         "pnl_dollars",
+        "opt_reason",
         "win",
     ]
 

--- a/engine/signal_scan.py
+++ b/engine/signal_scan.py
@@ -535,6 +535,7 @@ def scan_day(
                         config=options_cfg,
                         atr_value=atr_for_vol,
                         exit_reason=res.get("exit_reason"),
+                        tp_abs_target=tp_abs_target,
                     )
 
                     out_row.update(options_row)
@@ -594,6 +595,7 @@ def scan_day(
                         config=options_cfg,
                         atr_value=atr_for_vol,
                         exit_reason=out.get("exit_reason"),
+                        tp_abs_target=tp_price,
                     )
 
                     out_row.update(options_row)


### PR DESCRIPTION
## Summary
- anchor debit call spreads to the TP target using tick-aware leg selection and skip invalid or overpriced structures
- enforce integer contract sizing that respects budget and fees while returning loud opt_reason diagnostics
- expose new TP anchor controls in the UI, add fractional-contract health checks, and include opt_reason in exports
- expand option spread unit tests to cover new helpers, budget guards, and debit-vs-width validation

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d091ba46648332a7b4af45bf04223b