### PR TITLE
Fix tests for adjacent spread gating

### DIFF
--- a/backtest/run_range.py
+++ b/backtest/run_range.py
@@ -291,6 +291,8 @@ def run_range(
         "tp_required_dollars",
         "tp_required_dollars_2dp",
         "reasons",
+        "passes_all_rules",
+        "rule_fail_reasons",
         "opt_structure",
         "K1",
         "K2",

--- a/engine/options_spread.py
+++ b/engine/options_spread.py
@@ -1,15 +1,20 @@
 from __future__ import annotations
 
 import math
+import bisect
+import logging
 from dataclasses import dataclass, fields, replace
-from typing import Dict, Iterable, Optional
+from typing import Dict, Iterable, Optional, Sequence
 
 import numpy as np
 import pandas as pd
 
 
+log = logging.getLogger(__name__)
+
 _ANNUALIZATION_FACTOR = math.sqrt(252.0)
 _EPSILON_TIME = 1.0 / 3650.0
+_MAX_STRIKE_STEPS = 512
 
 
 def floor_to_tick(value: float, tick: float) -> float:
@@ -21,11 +26,513 @@ def floor_to_tick(value: float, tick: float) -> float:
     return round(floored, 6)
 
 
+def ceil_to_tick(value: float, tick: float) -> float:
+    """Ceil a value to the nearest higher multiple of ``tick``."""
+
+    if tick <= 0 or not math.isfinite(value):
+        return float("nan")
+    ceiled = math.ceil(value / tick) * tick
+    return round(ceiled, 6)
+
+
+def _sanitize_chain(option_chain: Sequence[float] | None) -> list[float]:
+    if option_chain is None:
+        return []
+    clean: list[float] = []
+    for val in option_chain:
+        try:
+            flt = float(val)
+        except (TypeError, ValueError):
+            continue
+        if not math.isfinite(flt):
+            continue
+        clean.append(round(flt, 6))
+    if not clean:
+        return []
+    clean = sorted(set(clean))
+    return clean
+
+
+def _detect_chain_tick(strikes: Sequence[float], anchor: float | None = None) -> float | None:
+    """Derive an effective strike increment from a chain.
+
+    When ``anchor`` is supplied, the increment surrounding the anchor is
+    prioritised; otherwise the smallest positive difference is returned.
+    """
+
+    if not strikes:
+        return None
+    diffs = []
+    for i in range(1, len(strikes)):
+        diff = round(strikes[i] - strikes[i - 1], 6)
+        if diff > 0:
+            diffs.append(diff)
+    if not diffs:
+        return None
+    if anchor is None or not math.isfinite(anchor):
+        return float(min(diffs))
+
+    idx = bisect.bisect_left(strikes, float(anchor))
+    nearby: list[float] = []
+    if 0 < idx < len(strikes):
+        nearby.append(round(strikes[idx] - strikes[idx - 1], 6))
+    if idx + 1 < len(strikes):
+        nearby.append(round(strikes[idx + 1] - strikes[idx], 6))
+    nearby = [d for d in nearby if d > 0]
+    if nearby:
+        return float(min(nearby))
+    return float(min(diffs))
+
+
+def _call_shift_ok(lower: float, spot: float, max_shift_pct: float) -> bool:
+    if max_shift_pct is None or not math.isfinite(max_shift_pct) or max_shift_pct <= 0:
+        return True
+    if not math.isfinite(spot) or spot <= 0:
+        return True
+    shift_pct = ((float(lower) / float(spot)) - 1.0) * 100.0
+    return shift_pct <= float(max_shift_pct) + 1e-9
+
+
+def _put_shift_ok(upper: float, spot: float, max_shift_pct: float) -> bool:
+    if max_shift_pct is None or not math.isfinite(max_shift_pct) or max_shift_pct <= 0:
+        return True
+    if not math.isfinite(spot) or spot <= 0:
+        return True
+    shift_pct = ((float(spot) - float(upper)) / float(spot)) * 100.0
+    return shift_pct <= float(max_shift_pct) + 1e-9
+
+
+def _iter_call_pairs(
+    *,
+    spot: float,
+    tp_abs_target: float | None,
+    chain: Sequence[float],
+    tick: float,
+    anchor_mode: bool,
+    max_shift_pct: float,
+) -> Iterable[tuple[float, float]]:
+    if tick <= 0:
+        return []
+
+    def _chain_iter() -> Iterable[tuple[float, float]]:
+        if not chain:
+            return []
+        if anchor_mode and tp_abs_target is not None and math.isfinite(tp_abs_target):
+            idx = bisect.bisect_right(chain, float(tp_abs_target)) - 1
+            idx = max(1, min(idx, len(chain) - 1))
+            rng = range(idx, 0, -1)
+        else:
+            idx = bisect.bisect_left(chain, float(spot))
+            if idx <= 0:
+                idx = 1
+            if idx >= len(chain):
+                idx = len(chain) - 1
+            rng = range(idx, len(chain))
+        for j in rng:
+            upper = float(chain[j])
+            lower = float(chain[j - 1])
+            if anchor_mode and tp_abs_target is not None and math.isfinite(tp_abs_target):
+                if upper > float(tp_abs_target) + 1e-9:
+                    continue
+            yield lower, upper
+
+    if chain:
+        seen_shift_violation = False
+        for lower, upper in _chain_iter():
+            if not _call_shift_ok(lower, spot, max_shift_pct):
+                if not anchor_mode:
+                    seen_shift_violation = True
+                continue
+            if anchor_mode:
+                yield lower, upper
+            else:
+                if seen_shift_violation:
+                    break
+                yield lower, upper
+        return
+
+    if anchor_mode and tp_abs_target is not None and math.isfinite(tp_abs_target):
+        upper = floor_to_tick(float(tp_abs_target), tick)
+        if not math.isfinite(upper) or upper <= 0:
+            return
+        steps = 0
+        while upper > tick and steps < _MAX_STRIKE_STEPS:
+            lower = round(upper - tick, 6)
+            if lower <= 0:
+                break
+            if upper <= float(tp_abs_target) + 1e-9 and _call_shift_ok(lower, spot, max_shift_pct):
+                yield float(lower), float(upper)
+            upper = round(lower, 6)
+            steps += 1
+        return
+
+    base_lower = _round_to_tick(float(spot), tick)
+    if not math.isfinite(base_lower) or base_lower <= 0:
+        base_lower = tick
+    lower = float(base_lower)
+    upper = round(lower + tick, 6)
+    steps = 0
+    while steps < _MAX_STRIKE_STEPS:
+        if lower <= 0 or upper <= lower:
+            break
+        if _call_shift_ok(lower, spot, max_shift_pct):
+            yield float(lower), float(upper)
+        else:
+            break
+        lower = round(lower + tick, 6)
+        upper = round(lower + tick, 6)
+        steps += 1
+
+
+def _iter_put_pairs(
+    *,
+    spot: float,
+    tp_abs_target: float | None,
+    chain: Sequence[float],
+    tick: float,
+    anchor_mode: bool,
+    max_shift_pct: float,
+) -> Iterable[tuple[float, float]]:
+    if tick <= 0:
+        return []
+
+    def _chain_iter() -> Iterable[tuple[float, float]]:
+        if not chain:
+            return []
+        if anchor_mode and tp_abs_target is not None and math.isfinite(tp_abs_target):
+            idx = bisect.bisect_left(chain, float(tp_abs_target))
+            idx = max(0, min(idx, len(chain) - 1))
+            rng = range(idx, len(chain) - 1)
+        else:
+            idx = bisect.bisect_left(chain, float(spot))
+            if idx <= 0:
+                idx = 0
+            if idx >= len(chain) - 1:
+                idx = len(chain) - 2
+            rng = range(idx, -1, -1)
+        for j in rng:
+            lower = float(chain[j])
+            upper = float(chain[j + 1])
+            if anchor_mode and tp_abs_target is not None and math.isfinite(tp_abs_target):
+                if lower < float(tp_abs_target) - 1e-9:
+                    continue
+            yield lower, upper
+
+    if chain:
+        seen_shift_violation = False
+        for lower, upper in _chain_iter():
+            if not _put_shift_ok(upper, spot, max_shift_pct):
+                if not anchor_mode:
+                    seen_shift_violation = True
+                continue
+            if anchor_mode:
+                yield lower, upper
+            else:
+                if seen_shift_violation:
+                    break
+                yield lower, upper
+        return
+
+    if anchor_mode and tp_abs_target is not None and math.isfinite(tp_abs_target):
+        lower = ceil_to_tick(float(tp_abs_target), tick)
+        if not math.isfinite(lower) or lower <= 0:
+            return
+        steps = 0
+        while steps < _MAX_STRIKE_STEPS:
+            upper = round(lower + tick, 6)
+            if upper <= lower:
+                break
+            if _put_shift_ok(upper, spot, max_shift_pct):
+                yield float(lower), float(upper)
+            lower = round(upper, 6)
+            steps += 1
+        return
+
+    base_upper = _round_to_tick(float(spot), tick)
+    if not math.isfinite(base_upper) or base_upper <= 0:
+        base_upper = tick
+    upper = float(base_upper)
+    lower = round(max(upper - tick, tick), 6)
+    steps = 0
+    while steps < _MAX_STRIKE_STEPS:
+        if upper <= lower:
+            break
+        if _put_shift_ok(upper, spot, max_shift_pct):
+            yield float(lower), float(upper)
+        else:
+            break
+        upper = round(upper - tick, 6)
+        lower = round(max(upper - tick, tick), 6)
+        steps += 1
+
+
+def _snap_to_chain(
+    lower: float,
+    upper: float,
+    chain: Sequence[float],
+    tick: float,
+) -> tuple[float, float, bool]:
+    """Snap strikes to the nearest valid levels, flagging non-adjacent gaps."""
+
+    has_gap = False
+    snapped_lower = float(lower)
+    snapped_upper = float(upper)
+
+    if chain:
+        strikes = list(chain)
+        if not strikes:
+            return float(lower), float(upper), has_gap
+        idx_lower = bisect.bisect_right(strikes, float(lower)) - 1
+        if idx_lower < 0:
+            idx_lower = 0
+        snapped_lower = float(strikes[idx_lower])
+
+        idx_upper = bisect.bisect_left(strikes, float(upper))
+        if idx_upper >= len(strikes):
+            idx_upper = len(strikes) - 1
+        snapped_upper = float(strikes[idx_upper])
+
+        if snapped_upper <= snapped_lower and idx_upper + 1 < len(strikes):
+            snapped_upper = float(strikes[idx_upper + 1])
+
+        gap = snapped_upper - snapped_lower
+        if tick > 0 and gap > tick + 1e-6:
+            has_gap = True
+        return snapped_lower, snapped_upper, has_gap
+
+    snapped_lower = floor_to_tick(float(lower), tick)
+    snapped_upper = ceil_to_tick(float(upper), tick)
+    if snapped_upper <= snapped_lower:
+        snapped_upper = round(snapped_lower + tick, 6)
+    if tick > 0 and snapped_upper - snapped_lower > tick + 1e-6:
+        has_gap = True
+    return float(snapped_lower), float(snapped_upper), has_gap
+
+
+def _build_adjacent_vertical_spread(
+    *,
+    structure: str,
+    spot: float,
+    sigma: float,
+    time_years: float,
+    config: OptionsSpreadConfig,
+    tp_abs_target: float | None,
+    chain: Sequence[float],
+    tick: float,
+    r: float,
+    q: float,
+    meta: dict,
+) -> tuple[VerticalSpread | None, dict]:
+    max_shift = float(config.max_otm_shift_pct)
+    anchor_mode = bool(config.tp_anchor_mode)
+    min_width_ticks = max(int(config.min_width_ticks), 1)
+    required_width = float(min_width_ticks) * float(tick)
+
+    if structure == "bull_call":
+        anchor_target = None
+        if anchor_mode and tp_abs_target is not None and math.isfinite(tp_abs_target):
+            offset = max(int(config.tp_anchor_offset_ticks), 1)
+            anchor_target = tp_abs_target - offset * tick
+            if anchor_target <= 0:
+                anchor_target = None
+        iterator = _iter_call_pairs(
+            spot=float(spot),
+            tp_abs_target=anchor_target,
+            chain=chain,
+            tick=float(tick),
+            anchor_mode=anchor_mode,
+            max_shift_pct=max_shift,
+        )
+    else:
+        anchor_target = None
+        if anchor_mode and tp_abs_target is not None and math.isfinite(tp_abs_target):
+            offset = max(int(config.tp_anchor_offset_ticks), 1)
+            anchor_target = tp_abs_target + offset * tick
+        iterator = _iter_put_pairs(
+            spot=float(spot),
+            tp_abs_target=anchor_target,
+            chain=chain,
+            tick=float(tick),
+            anchor_mode=anchor_mode,
+            max_shift_pct=max_shift,
+        )
+
+    last_meta: dict[str, object] = {}
+    for lower, upper in iterator:
+        if structure == "bull_call" and tp_abs_target is not None and math.isfinite(tp_abs_target):
+            if upper > tp_abs_target + 1e-9:
+                continue
+        if structure == "bear_put" and tp_abs_target is not None and math.isfinite(tp_abs_target):
+            if lower < tp_abs_target - 1e-9:
+                continue
+
+        spread_width = float(upper - lower)
+        if spread_width <= 0:
+            continue
+        if abs(spread_width - required_width) > 1e-6:
+            continue
+
+        width_frac = spread_width / spot if spot else float("nan")
+        debit = price_vertical_spread(structure, spot, lower, upper, time_years, sigma, r, q)
+        attempt_meta = {
+            "K1": float(lower),
+            "K2": float(upper),
+            "width_frac": float(width_frac),
+            "debit_entry": float(debit),
+        }
+
+        if not math.isfinite(debit) or debit <= 0:
+            last_meta = attempt_meta
+            continue
+
+        width_dollars = spread_width * 100.0
+        if config.enforce_debit_le_width and (debit * 100.0 > width_dollars + 1e-6):
+            attempt_meta.update({"opt_reason": "invalid_debit_gt_width", "width_dollars": width_dollars})
+            meta.update(attempt_meta)
+            return None, meta
+
+        contracts, cash_outlay = compute_contracts_and_costs(
+            debit, config.budget_per_trade, config.fees_per_contract, legs=2
+        )
+        if contracts <= 0:
+            last_meta = attempt_meta
+            continue
+
+        fees_entry = contracts * 2.0 * float(config.fees_per_contract)
+        spread = VerticalSpread(
+            structure=structure,
+            lower_strike=float(lower),
+            upper_strike=float(upper),
+            width_frac=float(width_frac),
+            expiry_days=int(config.expiry_days),
+            sigma_entry=float(sigma),
+            debit_entry=float(debit),
+            contracts=int(contracts),
+            cash_outlay=float(cash_outlay),
+            fees_entry=float(fees_entry),
+        )
+        attempt_meta["opt_reason"] = ""
+        meta.update(attempt_meta)
+        return spread, meta
+
+    failure_meta = {"opt_reason": "insufficient_budget"}
+    failure_meta.update(last_meta)
+    meta.update(failure_meta)
+    return None, meta
+
+
+def _build_percent_vertical_spread(
+    *,
+    structure: str,
+    spot: float,
+    sigma: float,
+    time_years: float,
+    config: OptionsSpreadConfig,
+    chain: Sequence[float],
+    tick: float,
+    r: float,
+    q: float,
+    meta: dict,
+) -> tuple[VerticalSpread | None, dict]:
+    atm = _round_to_tick(spot, tick)
+    if structure == "bull_call":
+        lower = atm
+        if config.width_abs is not None and config.width_abs > 0:
+            upper_target = lower + float(config.width_abs)
+        else:
+            width_frac = float(config.width_frac or 0.0)
+            if width_frac <= 0:
+                width_frac = 0.05
+            upper_target = lower * (1.0 + width_frac)
+        upper = upper_target
+    else:
+        upper = atm
+        if config.width_abs is not None and config.width_abs > 0:
+            lower_target = upper - float(config.width_abs)
+        else:
+            width_frac = float(config.width_frac or 0.0)
+            if width_frac <= 0:
+                width_frac = 0.05
+            lower_target = upper * (1.0 - width_frac)
+        lower = lower_target
+
+    snapped_lower, snapped_upper, has_gap = _snap_to_chain(lower, upper, chain, tick)
+    if has_gap:
+        log.warning("percent spread snapped to non-adjacent strikes (width=%s)", snapped_upper - snapped_lower)
+
+    if snapped_upper <= snapped_lower:
+        snapped_upper = round(snapped_lower + tick, 6)
+
+    spread_width = float(snapped_upper - snapped_lower)
+    if spread_width <= 0:
+        meta["opt_reason"] = "invalid_width"
+        meta.update({"K1": float(snapped_lower), "K2": float(snapped_upper)})
+        return None, meta
+
+    width_frac = spread_width / spot if spot else float("nan")
+    debit = price_vertical_spread(
+        structure,
+        spot,
+        snapped_lower,
+        snapped_upper,
+        time_years,
+        sigma,
+        r,
+        q,
+    )
+    attempt_meta = {
+        "K1": float(snapped_lower),
+        "K2": float(snapped_upper),
+        "width_frac": float(width_frac),
+        "debit_entry": float(debit),
+    }
+
+    if not math.isfinite(debit) or debit <= 0:
+        attempt_meta["opt_reason"] = "pricing_failed"
+        meta.update(attempt_meta)
+        return None, meta
+
+    width_dollars = spread_width * 100.0
+    if config.enforce_debit_le_width and (debit * 100.0 > width_dollars + 1e-6):
+        attempt_meta.update({"opt_reason": "invalid_debit_gt_width", "width_dollars": width_dollars})
+        meta.update(attempt_meta)
+        return None, meta
+
+    contracts, cash_outlay = compute_contracts_and_costs(
+        debit, config.budget_per_trade, config.fees_per_contract, legs=2
+    )
+    if contracts <= 0:
+        attempt_meta["opt_reason"] = "insufficient_budget"
+        meta.update(attempt_meta)
+        return None, meta
+
+    fees_entry = contracts * 2.0 * float(config.fees_per_contract)
+    spread = VerticalSpread(
+        structure=structure,
+        lower_strike=float(snapped_lower),
+        upper_strike=float(snapped_upper),
+        width_frac=float(width_frac),
+        expiry_days=int(config.expiry_days),
+        sigma_entry=float(sigma),
+        debit_entry=float(debit),
+        contracts=int(contracts),
+        cash_outlay=float(cash_outlay),
+        fees_entry=float(fees_entry),
+    )
+    attempt_meta["opt_reason"] = ""
+    meta.update(attempt_meta)
+    return spread, meta
+
+
 def choose_vertical_call_legs(
     tp_abs_target: float,
     strike_tick: float,
     tp_anchor_offset_ticks: int = 1,
     min_width_ticks: int = 1,
+    *,
+    option_chain: Sequence[float] | None = None,
+    spot: float | None = None,
+    max_otm_shift_pct: float | None = None,
 ) -> tuple[float | None, float | None, dict]:
     """Select strikes for a call debit spread anchored to the TP target."""
 
@@ -33,32 +540,36 @@ def choose_vertical_call_legs(
     if strike_tick <= 0 or not math.isfinite(strike_tick):
         return None, None, {"opt_reason": "invalid_strike_tick", **meta}
 
-    offset_ticks = max(int(tp_anchor_offset_ticks), 1)
-    width_ticks = max(int(min_width_ticks), 1)
-
     if not math.isfinite(tp_abs_target) or tp_abs_target <= 0:
         return None, None, {"opt_reason": "tp_target_invalid", **meta}
 
-    k2_target = tp_abs_target - offset_ticks * strike_tick
-    meta["k2_target"] = k2_target
-    K2 = floor_to_tick(k2_target, strike_tick)
-    if not math.isfinite(K2) or K2 <= 0:
-        return None, None, {"opt_reason": "invalid_leg_nonpositive", **meta}
+    width_ticks = max(int(min_width_ticks), 1)
+    offset_ticks = max(int(tp_anchor_offset_ticks), 1)
+    anchor_target = tp_abs_target - offset_ticks * strike_tick
+    meta["k2_target"] = anchor_target
 
-    K1 = round(K2 - width_ticks * strike_tick, 6)
-    if K1 <= 0:
-        return None, None, {"opt_reason": "invalid_leg_nonpositive", **meta}
+    chain = _sanitize_chain(option_chain)
+    max_shift = float(max_otm_shift_pct) if max_otm_shift_pct is not None else float("nan")
+    spot_val = float(spot) if spot is not None else float("nan")
 
-    if not (K2 < tp_abs_target):
-        return None, None, {"opt_reason": "k2_not_below_tp", **meta}
-    if not (K1 < K2):
-        return None, None, {"opt_reason": "k1_not_below_k2", **meta}
+    for lower, upper in _iter_call_pairs(
+        spot=spot_val,
+        tp_abs_target=anchor_target,
+        chain=chain,
+        tick=float(strike_tick),
+        anchor_mode=True,
+        max_shift_pct=max_shift,
+    ):
+        spread_ticks = (upper - lower) / float(strike_tick)
+        if abs(spread_ticks - width_ticks) > 1e-6:
+            continue
+        if upper >= tp_abs_target + 1e-9:
+            continue
+        if lower <= 0 or upper <= 0:
+            continue
+        return float(lower), float(upper), meta
 
-    width_ratio = (K2 - K1) / strike_tick
-    if not math.isfinite(width_ratio) or abs(width_ratio - round(width_ratio)) > 1e-6:
-        return None, None, {"opt_reason": "width_not_tick_multiple", **meta}
-
-    return float(K1), float(K2), meta
+    return None, None, {"opt_reason": "tp_anchor_failed", **meta}
 
 
 def compute_contracts_and_costs(
@@ -98,6 +609,7 @@ class OptionsSpreadConfig:
     expiry_days: int = 30
     width_frac: float = 0.05
     width_abs: float | None = None
+    width_pct: float | None = None
     vol_lookback_days: int = 21
     vol_method: str = "parkinson"
     vol_multiplier: float = 1.0
@@ -111,6 +623,7 @@ class OptionsSpreadConfig:
     tp_anchor_offset_ticks: int = 1
     min_width_ticks: int = 1
     enforce_debit_le_width: bool = True
+    spread_mode: str = "adjacent"
 
     @classmethod
     def from_params(
@@ -146,7 +659,7 @@ class OptionsSpreadConfig:
                 val = val.item()
             if isinstance(val, str):
                 val = val.strip()
-            if f.name in {"kind", "vol_method"} and isinstance(val, str):
+            if f.name in {"kind", "vol_method", "spread_mode"} and isinstance(val, str):
                 val = val.lower()
             if f.type is bool:
                 updates[f.name] = bool(val)
@@ -156,6 +669,12 @@ class OptionsSpreadConfig:
         if updates:
             return replace(cfg, **updates)
         return cfg
+
+    def resolved_spread_mode(self) -> str:
+        mode = (self.spread_mode or "adjacent").strip().lower()
+        if mode not in {"adjacent", "percent"}:
+            return "adjacent"
+        return mode
 
     def empty_result(self) -> dict:
         return {
@@ -170,6 +689,7 @@ class OptionsSpreadConfig:
             "contracts": 0,
             "cash_outlay": 0.0,
             "fees_entry": 0.0,
+            "chain_tick": float("nan"),
             "S_exit": float("nan"),
             "T_exit_days": float("nan"),
             "sigma_exit": float("nan"),
@@ -397,6 +917,7 @@ def build_vertical_spread(
     sigma: float,
     config: OptionsSpreadConfig,
     tp_abs_target: float | None = None,
+    option_chain: Sequence[float] | None = None,
 ) -> tuple[VerticalSpread | None, dict]:
     meta: dict[str, object] = {}
     if not config.enabled or config.kind != "vertical_debit":
@@ -406,7 +927,15 @@ def build_vertical_spread(
         meta["opt_reason"] = "invalid_underlying"
         return None, meta
 
-    tick = float(config.strike_tick or 1.0)
+    chain = _sanitize_chain(option_chain)
+    anchor_hint = None
+    if config.tp_anchor_mode and tp_abs_target is not None and math.isfinite(tp_abs_target):
+        anchor_hint = float(tp_abs_target)
+    tick = _detect_chain_tick(chain, anchor_hint)
+    if tick is None or tick <= 0:
+        tick = float(config.strike_tick or 1.0)
+    meta["chain_tick"] = float(tick)
+
     structure = "bull_call" if direction.lower() != "down" else "bear_put"
     meta["opt_structure"] = (
         "CALL_VERTICAL_DEBIT" if structure == "bull_call" else "PUT_VERTICAL_DEBIT"
@@ -415,162 +944,34 @@ def build_vertical_spread(
     time_years = max(float(config.expiry_days) / 365.0, _EPSILON_TIME)
     r = float(config.risk_free_rate)
     q = float(config.dividend_yield)
-
-    if config.tp_anchor_mode and structure == "bull_call":
-        tp_value = float(tp_abs_target) if tp_abs_target is not None else float("nan")
-        lower, upper, anchor_meta = choose_vertical_call_legs(
-            tp_value,
-            strike_tick=tick,
-            tp_anchor_offset_ticks=int(config.tp_anchor_offset_ticks),
-            min_width_ticks=int(config.min_width_ticks),
-        )
-        meta.update(anchor_meta)
-        if lower is None or upper is None:
-            meta.setdefault("opt_reason", anchor_meta.get("opt_reason", "tp_anchor_failed"))
-            return None, meta
-
-        spread_width = float(upper - lower)
-        width_frac = spread_width / spot if spot else float("nan")
-        debit = price_vertical_spread(structure, spot, lower, upper, time_years, sigma, r, q)
-        meta.update(
-            {
-                "K1": float(lower),
-                "K2": float(upper),
-                "width_frac": float(width_frac),
-                "debit_entry": float(debit),
-            }
-        )
-
-        if not math.isfinite(debit) or debit <= 0:
-            meta["opt_reason"] = "pricing_failed"
-            return None, meta
-
-        width_dollars = spread_width * 100.0
-        if config.enforce_debit_le_width and (debit * 100.0 > width_dollars + 1e-6):
-            meta.update({"opt_reason": "invalid_debit_gt_width", "width_dollars": width_dollars})
-            return None, meta
-
-        contracts, cash_outlay = compute_contracts_and_costs(
-            debit, config.budget_per_trade, config.fees_per_contract, legs=2
-        )
-        if contracts <= 0:
-            meta["opt_reason"] = "insufficient_budget"
-            return None, meta
-
-        fees_entry = contracts * 2.0 * float(config.fees_per_contract)
-        spread = VerticalSpread(
+    mode = config.resolved_spread_mode()
+    if mode == "percent":
+        return _build_percent_vertical_spread(
             structure=structure,
-            lower_strike=float(lower),
-            upper_strike=float(upper),
-            width_frac=float(width_frac),
-            expiry_days=int(config.expiry_days),
-            sigma_entry=float(sigma),
-            debit_entry=float(debit),
-            contracts=int(contracts),
-            cash_outlay=float(cash_outlay),
-            fees_entry=float(fees_entry),
+            spot=spot,
+            sigma=sigma,
+            time_years=time_years,
+            config=config,
+            chain=chain,
+            tick=float(tick),
+            r=r,
+            q=q,
+            meta=meta,
         )
-        meta["opt_reason"] = ""
-        return spread, meta
 
-    atm = _round_to_tick(spot, tick)
-    if structure == "bull_call":
-        lower = atm
-        if config.width_abs is not None and config.width_abs > 0:
-            upper_target = lower + float(config.width_abs)
-        else:
-            width_frac = float(config.width_frac or 0.0)
-            if width_frac <= 0:
-                width_frac = 0.05
-            upper_target = lower * (1.0 + width_frac)
-        upper = _round_to_tick(upper_target, tick)
-        if upper <= lower:
-            upper = lower + tick
-    else:
-        upper = atm
-        if config.width_abs is not None and config.width_abs > 0:
-            lower_target = upper - float(config.width_abs)
-        else:
-            width_frac = float(config.width_frac or 0.0)
-            if width_frac <= 0:
-                width_frac = 0.05
-            lower_target = upper * (1.0 - width_frac)
-        lower = _round_to_tick(lower_target, tick)
-        if lower >= upper:
-            lower = max(upper - tick, tick)
-
-    base_lower = float(lower)
-    base_upper = float(upper)
-    last_meta: dict[str, object] = {}
-
-    attempts = [0.0]
-    attempts.extend(np.arange(1.0, float(config.max_otm_shift_pct) + 1.0, 1.0))
-
-    for pct in attempts:
-        if pct > 0:
-            shift = pct / 100.0
-            if structure == "bull_call":
-                lower = _round_to_tick(base_lower * (1.0 + shift), tick)
-                upper = _round_to_tick(lower + (base_upper - base_lower), tick)
-                if upper <= lower:
-                    upper = lower + tick
-            else:
-                upper = _round_to_tick(base_upper * (1.0 - shift), tick)
-                lower = _round_to_tick(upper - (base_upper - base_lower), tick)
-                if lower >= upper:
-                    lower = max(upper - tick, tick)
-
-        spread_width = float(upper - lower)
-        if spread_width <= 0:
-            continue
-
-        width_frac = spread_width / spot if spot else float("nan")
-        debit = price_vertical_spread(structure, spot, lower, upper, time_years, sigma, r, q)
-        attempt_meta = {
-            "K1": float(lower),
-            "K2": float(upper),
-            "width_frac": float(width_frac),
-            "debit_entry": float(debit),
-        }
-
-        if not math.isfinite(debit) or debit <= 0:
-            last_meta = attempt_meta
-            continue
-
-        width_dollars = spread_width * 100.0
-        if config.enforce_debit_le_width and (debit * 100.0 > width_dollars + 1e-6):
-            attempt_meta.update({"opt_reason": "invalid_debit_gt_width", "width_dollars": width_dollars})
-            meta.update(attempt_meta)
-            return None, meta
-
-        contracts, cash_outlay = compute_contracts_and_costs(
-            debit, config.budget_per_trade, config.fees_per_contract, legs=2
-        )
-        if contracts <= 0:
-            last_meta = attempt_meta
-            continue
-
-        fees_entry = contracts * 2.0 * float(config.fees_per_contract)
-        spread = VerticalSpread(
-            structure=structure,
-            lower_strike=float(lower),
-            upper_strike=float(upper),
-            width_frac=float(width_frac),
-            expiry_days=int(config.expiry_days),
-            sigma_entry=float(sigma),
-            debit_entry=float(debit),
-            contracts=int(contracts),
-            cash_outlay=float(cash_outlay),
-            fees_entry=float(fees_entry),
-        )
-        attempt_meta["opt_reason"] = ""
-        meta.update(attempt_meta)
-        return spread, meta
-
-    failure_meta = {"opt_reason": "insufficient_budget"}
-    failure_meta.update(last_meta)
-    meta.update(failure_meta)
-    return None, meta
+    return _build_adjacent_vertical_spread(
+        structure=structure,
+        spot=spot,
+        sigma=sigma,
+        time_years=time_years,
+        config=config,
+        tp_abs_target=tp_abs_target,
+        chain=chain,
+        tick=float(tick),
+        r=r,
+        q=q,
+        meta=meta,
+    )
 
 
 def evaluate_vertical_spread(
@@ -627,6 +1028,7 @@ def compute_vertical_spread_trade(
     atr_value: float | Iterable[float] | None = None,
     exit_reason: str | None = None,
     tp_abs_target: float | None = None,
+    option_chain: Sequence[float] | None = None,
 ) -> dict:
     result = config.empty_result()
     if not config.enabled or config.kind != "vertical_debit":
@@ -680,6 +1082,7 @@ def compute_vertical_spread_trade(
         sigma_entry,
         config,
         tp_abs_target=tp_abs_target,
+        option_chain=option_chain,
     )
 
     opt_structure = meta.get("opt_structure")
@@ -693,6 +1096,11 @@ def compute_vertical_spread_trade(
                     result[key] = float(meta[key])
                 except (TypeError, ValueError):
                     continue
+        if "chain_tick" in meta and meta.get("chain_tick") is not None:
+            try:
+                result["chain_tick"] = float(meta["chain_tick"])
+            except (TypeError, ValueError):
+                pass
         if "width_frac" in meta and meta.get("width_frac") is not None:
             try:
                 result["width_pct"] = float(meta["width_frac"]) * 100.0

--- a/engine/rules.py
+++ b/engine/rules.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Mapping, Tuple, List, Any
+
+
+@dataclass
+class RuleConfig:
+    min_rr_required: float = 2.0
+
+    def __post_init__(self) -> None:
+        try:
+            value = float(self.min_rr_required)
+        except (TypeError, ValueError):
+            value = 2.0
+        if not math.isfinite(value) or value < 2.0:
+            value = 2.0
+        self.min_rr_required = value
+
+
+def _to_float(value: Any) -> float | None:
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return None
+    return f if math.isfinite(f) else None
+
+
+def _to_int(value: Any) -> int | None:
+    try:
+        return int(float(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _infer_rr_ratio(row: Mapping[str, Any]) -> float | None:
+    rr = _to_float(row.get("rr_ratio"))
+    if rr is not None:
+        return rr
+
+    entry = _to_float(row.get("entry_open"))
+    support = _to_float(row.get("support"))
+    tp_abs = _to_float(row.get("tp_price_abs_target"))
+
+    if entry is None or support is None or tp_abs is None:
+        return None
+
+    risk = entry - support
+    if risk <= 0:
+        return None
+
+    reward = tp_abs - entry if tp_abs >= entry else entry - tp_abs
+    if reward <= 0:
+        return None
+
+    return reward / risk
+
+
+def passes_all_rules(row: Mapping[str, Any], cfg: RuleConfig) -> Tuple[bool, List[str]]:
+    reasons: List[str] = []
+
+    if _to_int(row.get("atr_ok")) != 1:
+        reasons.append("atr_fail")
+    if _to_int(row.get("sr_ok")) != 1:
+        reasons.append("sr_fail")
+    if _to_int(row.get("precedent_ok")) != 1:
+        reasons.append("precedent_fail")
+
+    rr_value = _infer_rr_ratio(row)
+    if rr_value is None or rr_value < cfg.min_rr_required:
+        reasons.append("rr_fail")
+
+    rsi_1h = _to_float(row.get("rsi_1h"))
+    if rsi_1h is None or rsi_1h > 65.0:
+        reasons.append("rsi_1h_high")
+
+    rsi_d = _to_float(row.get("rsi_d"))
+    if rsi_d is None or rsi_d > 75.0:
+        reasons.append("rsi_d_high")
+
+    earnings_days = _to_float(row.get("earnings_days"))
+    if earnings_days is None or earnings_days < 5:
+        reasons.append("earnings_window_fail")
+
+    if _to_int(row.get("vwap_hold")) != 1:
+        reasons.append("vwap_hold_fail")
+
+    if _to_int(row.get("setup_valid")) != 1:
+        reasons.append("setup_invalid")
+
+    return (len(reasons) == 0), reasons
+
+
+__all__ = ["RuleConfig", "passes_all_rules"]

--- a/tests/test_rules_gating.py
+++ b/tests/test_rules_gating.py
@@ -1,0 +1,159 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from engine.rules import RuleConfig, passes_all_rules
+from engine import signal_scan as sigscan
+
+
+class DummyStorage:
+    def cache_salt(self) -> str:
+        return "dummy"
+
+
+def test_passes_all_rules_detects_failure():
+    cfg = RuleConfig(min_rr_required=2.5)
+    base_row = {
+        "atr_ok": 1,
+        "sr_ok": 1,
+        "precedent_ok": 1,
+        "rr_ratio": 3.0,
+        "rsi_1h": 40.0,
+        "rsi_d": 55.0,
+        "earnings_days": 12.0,
+        "vwap_hold": 1,
+        "setup_valid": 1,
+    }
+
+    ok, reasons = passes_all_rules(base_row, cfg)
+    assert ok is True
+    assert reasons == []
+
+    failing = dict(base_row)
+    failing.update({"rsi_1h": 80.0, "earnings_days": 2, "vwap_hold": 0})
+    ok_fail, reasons_fail = passes_all_rules(failing, cfg)
+    assert ok_fail is False
+    assert "rsi_1h_high" in reasons_fail
+    assert "earnings_window_fail" in reasons_fail
+    assert "vwap_hold_fail" in reasons_fail
+
+
+def test_scan_day_respects_rule_gate(monkeypatch):
+    dates = pd.bdate_range("2022-01-03", periods=6)
+    df_prices = pd.DataFrame(
+        {
+            "date": dates,
+            "open": [90, 95, 110, 115, 120, 125],
+            "high": [92, 110, 120, 140, 130, 135],
+            "low": [88, 95, 108, 110, 118, 120],
+            "close": [91, 105, 112, 130, 125, 130],
+            "volume": [1_000_000, 1_200_000, 1_400_000, 1_600_000, 1_800_000, 2_000_000],
+        }
+    )
+
+    membership = pd.DataFrame(
+        {
+            "ticker": ["PASS", "FAIL"],
+            "start_date": [dates.min(), dates.min()],
+            "end_date": [pd.NaT, pd.NaT],
+        }
+    )
+
+    monkeypatch.setattr(sigscan, "_load_members", lambda storage, cache_salt=None: membership.copy())
+
+    def _fake_load_prices(_storage, ticker):
+        return df_prices.copy()
+
+    monkeypatch.setattr(sigscan, "_load_prices", _fake_load_prices)
+
+    def _fake_compute_metrics(df, D_ts, vol_lookback, atr_window, atr_method, sr_lookback):
+        return {
+            "close_up_pct": 5.0,
+            "vol_multiple": 2.0,
+            "gap_open_pct": 0.5,
+            "atr21": 2.5,
+            "support": 90.0,
+            "resistance": 120.0,
+            "sr_ratio": 3.0,
+            "sr_support": 90.0,
+            "sr_resistance": 120.0,
+            "sr_window_len": int(sr_lookback),
+            "entry_open": 100.0,
+            "atr_method": atr_method,
+        }
+
+    monkeypatch.setattr(sigscan, "_compute_metrics", _fake_compute_metrics)
+    monkeypatch.setattr(sigscan, "atr_feasible", lambda *args, **kwargs: True)
+
+    gate_calls: list[str] = []
+
+    def _fake_passes(row, cfg):
+        gate_calls.append(row.get("ticker"))
+        if row.get("ticker") == "FAIL":
+            return False, ["forced_fail"]
+        return True, []
+
+    monkeypatch.setattr(sigscan, "passes_all_rules", _fake_passes)
+
+    option_calls: list[str] = []
+
+    def _fake_compute_vertical_spread_trade(**kwargs):
+        option_calls.append(kwargs.get("direction"))
+        return {
+            "opt_structure": "CALL_VERTICAL_DEBIT",
+            "K1": kwargs.get("entry_price", 100.0) - 1.0,
+            "K2": kwargs.get("entry_price", 100.0),
+            "width_frac": 0.01,
+            "debit_entry": 1.0,
+            "contracts": 1,
+            "cash_outlay": 100.0,
+            "fees_entry": 1.3,
+            "chain_tick": 1.0,
+            "opt_reason": "",
+        }
+
+    monkeypatch.setattr(sigscan, "compute_vertical_spread_trade", _fake_compute_vertical_spread_trade)
+
+    params = {
+        "min_close_up_pct": 0.0,
+        "min_vol_multiple": 0.0,
+        "min_gap_open_pct": -10.0,
+        "atr_window": 3,
+        "atr_method": "wilder",
+        "lookback_days": 3,
+        "horizon_days": 5,
+        "sr_min_ratio": 0.0,
+        "sr_lookback": 3,
+        "use_precedent": False,
+        "use_atr_feasible": False,
+        "exit_model": "pct_tp_only",
+        "min_rr_required": 0.5,
+        "rule_defaults": {
+            "rsi_1h": 40.0,
+            "rsi_d": 50.0,
+            "earnings_days": 10.0,
+            "vwap_hold": 1,
+            "setup_valid": 1,
+            "rr_ratio": 3.0,
+        },
+        "entry_model_default": "sr_breakout",
+    }
+
+    storage = DummyStorage()
+    D = dates[-1]
+
+    cand_df, out_df, fail_count, _ = sigscan.scan_day(storage, D, params)
+
+    assert fail_count == 0
+    assert set(gate_calls) == {"PASS", "FAIL"}
+    assert len(option_calls) == 1  # only PASS ticker processed
+    assert list(out_df["ticker"]) == ["PASS"]
+    assert out_df.iloc[0]["passes_all_rules"] == 1
+    assert out_df.iloc[0]["entry_model"]
+    assert (out_df["rule_fail_reasons"] == "").all()


### PR DESCRIPTION
## Summary
* add a dedicated rule gate module and accompanying unit test coverage to exercise the new hard filters before spreads are built【F:engine/rules.py†L1-L95】【F:tests/test_rules_gating.py†L1-L159】
* update the option spread test suite to verify adjacent-strike construction with configurable tick sizes and mixed chains【F:tests/test_options_spread.py†L153-L312】
* adjust signal-scan TP mode fixtures to satisfy the gating predicate by supplying deterministic data and overriding rr_ratio only for the synthetic cases【F:tests/test_signal_scan_tp_modes.py†L72-L320】

## Testing
* ✅ `pytest`【ec757c†L1-L16】

------
https://chatgpt.com/codex/tasks/task_e_68d0a2faf78c83329e984fb9cd9a2ffd