### PR TITLE
Add debug bypass toggle for backtest diagnostics

### DIFF
--- a/backtest/run_range.py
+++ b/backtest/run_range.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import time
 from typing import Callable, Tuple
 
@@ -128,6 +129,16 @@ def run_range(
     params: ScanParams,
     progress_cb: Callable[[int, int, pd.Timestamp, int, int], None] | None = None,
 ) -> Tuple[pd.DataFrame, dict]:
+    params = dict(params)
+    if "debug_include_all" not in params:
+        env_value = os.getenv("BACKTEST_DEBUG_INCLUDE_ALL", "0")
+        params["debug_include_all"] = str(env_value).strip().lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }
+
     days = trading_days(storage, start, end)
     all_trades = []
     total_days = len(days)


### PR DESCRIPTION
## Summary
- add a Streamlit checkbox to pass `debug_include_all` through the backtest form and debug logging
- surface per-scan diagnostic counters after a run for easier investigation of pre-filter behavior
- allow `backtest.run_range` to honor the `BACKTEST_DEBUG_INCLUDE_ALL` environment override when params omit the flag

## Testing
- PYTHONPATH=. pytest tests/test_backtest_form.py


------
https://chatgpt.com/codex/tasks/task_e_68d0c755e4c483329ba0a8413d69160a