### PR TITLE
Add stocks-only share scanner UI and engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,23 @@ specified as `prices`, `/prices`, or even `lake/prices` without breaking remote
 fetches. The loader logs the resolved bucket, prefix, and key whenever a request
 fails to assist with troubleshooting.
 
+## Stock Scanner (Shares Only)
+
+The Streamlit app now includes a **Stock Scanner (Shares Only)** tab that
+simulates whole-share entries capped at **$1,000** per trade. Candidates must
+pass configurable filters for yesterday's performance, open gap, volume
+multiple, and support/resistance ratio. Two exit models are available:
+
+- **ATR multiples** – take-profit/stop-loss are set from Wilder ATR values
+  (defaults 1×/1×).
+- **Support/Resistance** – exits at the detected support/resistance levels.
+
+Each position is evaluated forward for up to 30 trading days. If neither the
+take-profit nor stop-loss triggers, the trade exits at the day-30 close with a
+`timeout` label. The tab reports per-trade details (entry/exit, shares, TP/SL,
+cost, proceeds, P&L) and aggregates total capital deployed, total P&L, and win
+rate. Results can be downloaded as a CSV ledger for further analysis.
+
 ## Outcome Evaluation
 
 Use the `scripts/evaluate_outcomes.py` utility to update `data/history/outcomes.csv` with trade results.

--- a/app.py
+++ b/app.py
@@ -16,9 +16,10 @@ initialize_price_filter()
 render_header()
 
 # Create tabs once with unique variable names
-tab_gap, tab_backtest, tab_history, tab_lake, tab_debug = st.tabs(
+tab_gap, tab_stock, tab_backtest, tab_history, tab_lake, tab_debug = st.tabs(
     [
         "⚡ Gap Scanner",
+        "📊 Stock Scanner (Shares Only)",
         "📅 Backtest (range)",
         "📈 History & Outcomes",
         "💧 Data Lake (Phase 1)",
@@ -29,6 +30,16 @@ tab_gap, tab_backtest, tab_history, tab_lake, tab_debug = st.tabs(
 with tab_gap:
     spec = importlib.util.spec_from_file_location(
         "ui.pages.yday_vol_signal_open", Path("ui/pages/45_YdayVolSignal_Open.py")
+    )
+    mod = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(mod)
+    mod.page()
+
+with tab_stock:
+    spec = importlib.util.spec_from_file_location(
+        "ui.pages.stock_scanner_shares_only",
+        Path("ui/pages/65_Stock_Scanner_SharesOnly.py"),
     )
     mod = importlib.util.module_from_spec(spec)
     assert spec and spec.loader

--- a/engine/stocks_only_scanner.py
+++ b/engine/stocks_only_scanner.py
@@ -1,0 +1,532 @@
+from __future__ import annotations
+
+import datetime as dt
+import json
+import logging
+import math
+from dataclasses import dataclass
+from typing import Callable, Dict, Iterable, Literal, TypedDict
+
+import numpy as np
+import pandas as pd
+from pandas.tseries.offsets import BDay
+
+from data_lake.membership import load_membership
+from data_lake.storage import Storage, load_prices_cached
+from engine.features import atr as compute_atr
+from engine.replay import replay_trade
+
+log = logging.getLogger(__name__)
+
+DEFAULT_CASH_CAP = 1_000.0
+
+
+class StocksOnlyScanParams(TypedDict, total=False):
+    start: pd.Timestamp | dt.date | str
+    end: pd.Timestamp | dt.date | str
+    horizon_days: int
+    sr_lookback: int
+    sr_min_ratio: float
+    min_yup_pct: float
+    min_gap_pct: float
+    min_volume_multiple: float
+    volume_lookback: int
+    exit_model: Literal["atr", "sr"]
+    atr_window: int
+    atr_method: str
+    tp_atr_multiple: float
+    sl_atr_multiple: float
+    use_sp_filter: bool
+    cash_per_trade: float
+
+
+@dataclass
+class ScanSummary:
+    start: pd.Timestamp
+    end: pd.Timestamp
+    tickers_scanned: int
+    candidates: int
+    trades: int
+    wins: int
+    total_capital: float
+    total_pnl: float
+    win_rate: float
+
+
+def _log_event(event: str, **fields: object) -> None:
+    payload = {"event": event, **fields}
+    try:
+        log.info("stocks_only_scanner %s", json.dumps(payload, default=str))
+    except TypeError:
+        log.info("stocks_only_scanner %s", payload)
+
+
+def _normalize_timestamp(value: pd.Timestamp | dt.date | str | None) -> pd.Timestamp | None:
+    if value is None:
+        return None
+    ts = pd.Timestamp(value)
+    if getattr(ts, "tzinfo", None) is not None:
+        ts = ts.tz_localize(None)
+    return ts.normalize()
+
+
+def _compute_padding(params: StocksOnlyScanParams) -> int:
+    horizon = int(params.get("horizon_days", 30) or 30)
+    padding = max(
+        int(params.get("sr_lookback", 21) or 21),
+        int(params.get("volume_lookback", 20) or 20),
+        int(params.get("atr_window", 14) or 14),
+        3,
+    )
+    return padding + horizon + 5
+
+
+def _build_membership_index(
+    members: pd.DataFrame | None,
+) -> dict[str, list[tuple[pd.Timestamp, pd.Timestamp | None]]]:
+    if members is None or members.empty:
+        return {}
+    working = members.copy()
+    working["ticker"] = working["ticker"].astype(str).str.upper().str.strip()
+    working["start_date"] = pd.to_datetime(working["start_date"], errors="coerce").dt.tz_localize(None)
+    if "end_date" in working.columns:
+        working["end_date"] = pd.to_datetime(working["end_date"], errors="coerce").dt.tz_localize(None)
+    else:
+        working["end_date"] = pd.NaT
+
+    index: dict[str, list[tuple[pd.Timestamp, pd.Timestamp | None]]] = {}
+    for row in working.itertuples(index=False):
+        start = getattr(row, "start_date")
+        end = getattr(row, "end_date", pd.NaT)
+        end_ts: pd.Timestamp | None
+        if pd.isna(end):
+            end_ts = None
+        else:
+            end_ts = pd.Timestamp(end).tz_localize(None)
+        ticker = getattr(row, "ticker")
+        if pd.isna(start) or not ticker:
+            continue
+        start_ts = pd.Timestamp(start).tz_localize(None)
+        index.setdefault(ticker, []).append((start_ts, end_ts))
+    return index
+
+
+def _is_member(
+    index: dict[str, list[tuple[pd.Timestamp, pd.Timestamp | None]]],
+    ticker: str,
+    day: pd.Timestamp,
+) -> bool:
+    intervals = index.get(ticker)
+    if not intervals:
+        return False
+    for start, end in intervals:
+        if start is None:
+            continue
+        if start <= day and (end is None or day <= end):
+            return True
+    return False
+
+
+def _normalize_prices_df(df: pd.DataFrame, ticker: str) -> pd.DataFrame:
+    working = df.copy()
+    if "date" not in working.columns:
+        working = working.reset_index()
+        if "date" not in working.columns and "Date" in working.columns:
+            working = working.rename(columns={"Date": "date"})
+    working["date"] = pd.to_datetime(working["date"], errors="coerce").dt.tz_localize(None)
+    working = working.dropna(subset=["date"])
+    rename_map = {c: c.lower() for c in working.columns}
+    working = working.rename(columns=rename_map)
+    for col in ["open", "high", "low", "close"]:
+        if col not in working.columns:
+            raise KeyError(f"Missing required price column '{col}' for {ticker}")
+        working[col] = pd.to_numeric(working[col], errors="coerce")
+    if "volume" in working.columns:
+        working["volume"] = pd.to_numeric(working["volume"], errors="coerce")
+    else:
+        working["volume"] = float("nan")
+    working = working.sort_values("date").drop_duplicates(subset=["date"], keep="last")
+    return working
+
+
+def _prepare_panel(df: pd.DataFrame, params: StocksOnlyScanParams, *, ticker: str) -> pd.DataFrame:
+    sr_lookback = int(params.get("sr_lookback", 21) or 21)
+    volume_lookback = int(params.get("volume_lookback", 20) or 20)
+    atr_window = int(params.get("atr_window", 14) or 14)
+    atr_method = str(params.get("atr_method", "wilder") or "wilder").lower()
+
+    panel = _normalize_prices_df(df, ticker)
+    panel = panel.assign(ticker=ticker)
+
+    panel = panel.sort_values("date").reset_index(drop=True)
+
+    close = panel["close"].astype(float)
+    panel["yesterday_up_pct"] = (close.shift(1) / close.shift(2) - 1.0) * 100.0
+    panel["open_gap_pct"] = (panel["open"] / close.shift(1) - 1.0) * 100.0
+
+    vol = panel["volume"].astype(float)
+    vol_sma = vol.rolling(volume_lookback, min_periods=volume_lookback).mean().shift(1)
+    panel["volume_multiple"] = vol / vol_sma
+
+    atr_series = compute_atr(panel[["high", "low", "close"]], window=atr_window, method=atr_method)
+    panel["atr_value"] = atr_series.shift(1)
+
+    panel["support"] = (
+        panel["low"].rolling(sr_lookback, min_periods=sr_lookback).min().shift(1)
+    )
+    panel["resistance"] = (
+        panel["high"].rolling(sr_lookback, min_periods=sr_lookback).max().shift(1)
+    )
+
+    denom = panel["open"] - panel["support"]
+    with np.errstate(divide="ignore", invalid="ignore"):
+        ratio = (panel["resistance"] - panel["open"]) / denom
+    ratio = ratio.where((panel["support"] < panel["open"]) & (panel["resistance"] > panel["open"]))
+    panel["sr_ratio"] = ratio
+
+    panel = panel.set_index("date", drop=False)
+    return panel
+
+
+def _compute_shares(entry_price: float, cash_cap: float) -> int:
+    if entry_price <= 0 or cash_cap <= 0:
+        return 0
+    if entry_price > cash_cap:
+        return 0
+    shares = int(math.floor(cash_cap / entry_price))
+    return shares if shares >= 1 else 0
+
+
+def _sr_ratio_ok(entry_price: float, support: float, resistance: float, min_ratio: float) -> bool:
+    if any(math.isnan(x) for x in [entry_price, support, resistance, min_ratio]):
+        return False
+    if support >= entry_price or resistance <= entry_price:
+        return False
+    down = entry_price - support
+    up = resistance - entry_price
+    if down <= 0:
+        return False
+    ratio = up / down
+    return ratio >= min_ratio
+
+
+def _passes_filters(row: pd.Series, params: StocksOnlyScanParams) -> bool:
+    min_yup = float(params.get("min_yup_pct", 0.0) or 0.0)
+    min_gap = float(params.get("min_gap_pct", 0.0) or 0.0)
+    min_vol = float(params.get("min_volume_multiple", 1.0) or 0.0)
+
+    yup = float(row.get("yesterday_up_pct", float("nan")))
+    gap = float(row.get("open_gap_pct", float("nan")))
+    vol_mult = float(row.get("volume_multiple", float("nan")))
+
+    if not math.isfinite(yup) or yup < min_yup:
+        return False
+    if not math.isfinite(gap) or gap < min_gap:
+        return False
+    if not math.isfinite(vol_mult) or vol_mult < min_vol:
+        return False
+    return True
+
+
+def _simulate_exit(
+    bars: pd.DataFrame,
+    entry_date: pd.Timestamp,
+    entry_price: float,
+    tp_price: float,
+    sl_price: float,
+    horizon_days: int,
+) -> dict | None:
+    result = replay_trade(
+        bars[["date", "open", "high", "low", "close"]].copy(),
+        entry_date,
+        entry_price,
+        tp_price,
+        sl_price,
+        horizon_days=horizon_days,
+    )
+    reason = result.get("exit_reason")
+    if reason == "stop":
+        reason = "sl"
+    if reason not in {"tp", "sl", "timeout"}:
+        return None
+    exit_date = result.get("exit_date")
+    if pd.isna(exit_date):
+        return None
+    return {
+        "exit_reason": reason,
+        "exit_price": float(result.get("exit_price", float("nan"))),
+        "exit_date": pd.Timestamp(exit_date).tz_localize(None),
+    }
+
+
+def run_scan(
+    params: StocksOnlyScanParams,
+    *,
+    storage: Storage | None = None,
+    prices_by_ticker: dict[str, pd.DataFrame] | None = None,
+    membership: pd.DataFrame | None = None,
+    progress: Callable[[int, int, str], None] | None = None,
+) -> tuple[pd.DataFrame, ScanSummary]:
+    start_ts = _normalize_timestamp(params.get("start"))
+    end_ts = _normalize_timestamp(params.get("end"))
+    if start_ts is None or end_ts is None:
+        raise ValueError("Both start and end dates are required")
+    if end_ts < start_ts:
+        raise ValueError("End date must be on or after start date")
+
+    horizon = int(params.get("horizon_days", 30) or 30)
+    cash_cap = float(params.get("cash_per_trade", DEFAULT_CASH_CAP) or DEFAULT_CASH_CAP)
+    sr_min_ratio = float(params.get("sr_min_ratio", 2.0) or 2.0)
+    exit_model = str(params.get("exit_model", "atr") or "atr").lower()
+    tp_mult = float(params.get("tp_atr_multiple", 1.0) or 1.0)
+    sl_mult = float(params.get("sl_atr_multiple", 1.0) or 1.0)
+    use_sp_filter = bool(params.get("use_sp_filter", True))
+
+    storage = storage or Storage()
+    members = membership
+    if members is None:
+        members = load_membership(storage, cache_salt=storage.cache_salt())
+
+    membership_index = _build_membership_index(members)
+
+    padding_days = _compute_padding(params)
+    fetch_start = start_ts - BDay(padding_days)
+    fetch_end = end_ts + BDay(padding_days)
+
+    price_map: dict[str, pd.DataFrame] = {}
+    tickers_to_load: Iterable[str]
+
+    if prices_by_ticker is not None:
+        tickers_to_load = prices_by_ticker.keys()
+        for t, frame in prices_by_ticker.items():
+            price_map[str(t).upper()] = _prepare_panel(frame, params, ticker=str(t).upper())
+    else:
+        members_for_range = members.copy() if members is not None else pd.DataFrame()
+        if not members_for_range.empty:
+            members_for_range["start_date"] = pd.to_datetime(
+                members_for_range["start_date"], errors="coerce"
+            ).dt.tz_localize(None)
+            members_for_range["end_date"] = pd.to_datetime(
+                members_for_range.get("end_date"), errors="coerce"
+            ).dt.tz_localize(None)
+            mask = (members_for_range["start_date"] <= end_ts) & (
+                members_for_range["end_date"].isna() | (start_ts <= members_for_range["end_date"])
+            )
+            filtered = members_for_range.loc[mask]
+            tickers_to_load = sorted(filtered["ticker"].astype(str).str.upper().unique())
+        else:
+            tickers_to_load = []
+
+        if not tickers_to_load:
+            empty = pd.DataFrame(
+                columns=[
+                    "entry_date",
+                    "exit_date",
+                    "ticker",
+                    "entry_price",
+                    "tp_price",
+                    "sl_price",
+                    "exit_price",
+                    "exit_reason",
+                    "shares",
+                    "cost",
+                    "proceeds",
+                    "pnl",
+                ]
+            )
+            summary = ScanSummary(
+                start=start_ts,
+                end=end_ts,
+                tickers_scanned=0,
+                candidates=0,
+                trades=0,
+                wins=0,
+                total_capital=0.0,
+                total_pnl=0.0,
+                win_rate=0.0,
+            )
+            return empty, summary
+
+        cache_salt = storage.cache_salt()
+        _log_event(
+            "preload_prices:start",
+            tickers=len(list(tickers_to_load)),
+            start=str(fetch_start.date()),
+            end=str(fetch_end.date()),
+        )
+        prices_df = load_prices_cached(
+            storage,
+            cache_salt=cache_salt,
+            tickers=list(tickers_to_load),
+            start=fetch_start,
+            end=fetch_end,
+        )
+        _log_event(
+            "preload_prices:done",
+            rows=int(len(prices_df)),
+            tickers=len(list(tickers_to_load)),
+        )
+        if not prices_df.empty:
+            available_start = pd.to_datetime(prices_df["date"], errors="coerce").min()
+            available_end = pd.to_datetime(prices_df["date"], errors="coerce").max()
+            if pd.notna(available_start) and pd.notna(available_end):
+                _log_event(
+                    "coverage",
+                    available_start=str(pd.Timestamp(available_start).date()),
+                    available_end=str(pd.Timestamp(available_end).date()),
+                    requested_start=str(start_ts.date()),
+                    requested_end=str(end_ts.date()),
+                )
+        for ticker, frame in prices_df.groupby("Ticker"):
+            price_map[str(ticker).upper()] = _prepare_panel(frame, params, ticker=str(ticker).upper())
+
+    tickers_sorted = sorted(price_map.keys())
+    _log_event(
+        "scan:start",
+        start=str(start_ts.date()),
+        end=str(end_ts.date()),
+        horizon=horizon,
+        tickers=len(tickers_sorted),
+    )
+
+    ledger_rows: list[dict[str, object]] = []
+    candidate_count = 0
+
+    bdays = pd.bdate_range(start_ts, end_ts)
+    for idx, ticker in enumerate(tickers_sorted, 1):
+        panel = price_map[ticker]
+        bars = panel[["date", "open", "high", "low", "close"]].copy()
+        if progress is not None:
+            progress(idx, len(tickers_sorted), ticker)
+
+        for day in bdays:
+            if use_sp_filter and not _is_member(membership_index, ticker, day):
+                continue
+            if day not in panel.index:
+                continue
+            row = panel.loc[day]
+            if isinstance(row, pd.DataFrame):
+                row = row.iloc[-1]
+            entry_price = float(row.get("open", float("nan")))
+            if not math.isfinite(entry_price) or entry_price <= 0:
+                continue
+            support = float(row.get("support", float("nan")))
+            resistance = float(row.get("resistance", float("nan")))
+            if not _sr_ratio_ok(entry_price, support, resistance, sr_min_ratio):
+                continue
+            if not _passes_filters(row, params):
+                continue
+
+            candidate_count += 1
+
+            shares = _compute_shares(entry_price, cash_cap)
+            if shares < 1:
+                continue
+
+            if exit_model == "sr":
+                tp_price = resistance
+                sl_price = support
+            else:
+                atr_val = float(row.get("atr_value", float("nan")))
+                if not math.isfinite(atr_val) or atr_val <= 0:
+                    continue
+                tp_price = entry_price + tp_mult * atr_val
+                sl_price = entry_price - sl_mult * atr_val
+
+            if not math.isfinite(tp_price) or not math.isfinite(sl_price):
+                continue
+            if sl_price >= entry_price or tp_price <= entry_price:
+                continue
+
+            _log_event(
+                "trade_open",
+                ticker=ticker,
+                entry=str(day.date()),
+                entry_price=float(entry_price),
+                tp=float(tp_price),
+                sl=float(sl_price),
+                shares=int(shares),
+            )
+
+            exit_info = _simulate_exit(bars, day, entry_price, tp_price, sl_price, horizon)
+            if exit_info is None:
+                continue
+
+            exit_reason = str(exit_info["exit_reason"])
+            exit_price = float(exit_info["exit_price"])
+            exit_date = pd.Timestamp(exit_info["exit_date"]).tz_localize(None)
+
+            cost = shares * entry_price
+            proceeds = shares * exit_price
+            pnl = proceeds - cost
+
+            ledger_rows.append(
+                {
+                    "entry_date": day,
+                    "exit_date": exit_date,
+                    "ticker": ticker,
+                    "entry_price": float(entry_price),
+                    "tp_price": float(tp_price),
+                    "sl_price": float(sl_price),
+                    "exit_price": float(exit_price),
+                    "exit_reason": exit_reason,
+                    "shares": int(shares),
+                    "cost": float(cost),
+                    "proceeds": float(proceeds),
+                    "pnl": float(pnl),
+                }
+            )
+
+            _log_event(
+                "trade_close",
+                ticker=ticker,
+                exit=str(exit_date.date()),
+                exit_reason=exit_reason,
+                exit_price=float(exit_price),
+                pnl=float(pnl),
+            )
+
+    ledger = pd.DataFrame(ledger_rows)
+    if not ledger.empty:
+        ledger = ledger.sort_values(["entry_date", "ticker"]).reset_index(drop=True)
+
+    trades = int(len(ledger))
+    wins = int((ledger["exit_reason"].str.lower() == "tp").sum()) if trades else 0
+    total_capital = float(ledger["cost"].sum()) if trades else 0.0
+    total_pnl = float(ledger["pnl"].sum()) if trades else 0.0
+    win_rate = (wins / trades) if trades else 0.0
+
+    summary = ScanSummary(
+        start=start_ts,
+        end=end_ts,
+        tickers_scanned=len(tickers_sorted),
+        candidates=candidate_count,
+        trades=trades,
+        wins=wins,
+        total_capital=total_capital,
+        total_pnl=total_pnl,
+        win_rate=win_rate,
+    )
+
+    _log_event(
+        "bt_stats",
+        trades=trades,
+        wins=wins,
+        total_capital=total_capital,
+        total_pnl=total_pnl,
+        win_rate=win_rate,
+    )
+    _log_event("scan:done", trades=trades, candidates=candidate_count)
+
+    return ledger, summary
+
+
+__all__ = [
+    "StocksOnlyScanParams",
+    "ScanSummary",
+    "run_scan",
+    "_compute_shares",
+    "_sr_ratio_ok",
+    "_passes_filters",
+    "_simulate_exit",
+]

--- a/tests/test_stocks_only_scanner.py
+++ b/tests/test_stocks_only_scanner.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+import engine.stocks_only_scanner as sos
+
+
+def _basic_params(**overrides):
+    params: sos.StocksOnlyScanParams = {
+        "start": pd.Timestamp("2022-01-03"),
+        "end": pd.Timestamp("2022-01-10"),
+        "horizon_days": 5,
+        "sr_lookback": 3,
+        "sr_min_ratio": 2.0,
+        "min_yup_pct": 0.0,
+        "min_gap_pct": 0.0,
+        "min_volume_multiple": 0.0,
+        "volume_lookback": 3,
+        "exit_model": "atr",
+        "atr_window": 3,
+        "atr_method": "wilder",
+        "tp_atr_multiple": 1.0,
+        "sl_atr_multiple": 1.0,
+        "use_sp_filter": False,
+        "cash_per_trade": sos.DEFAULT_CASH_CAP,
+    }
+    params.update(overrides)
+    return params
+
+
+def test_wilder_atr_matches_manual():
+    dates = pd.bdate_range("2022-01-03", periods=5)
+    df = pd.DataFrame(
+        {
+            "date": dates,
+            "open": [10, 11, 12, 13, 14],
+            "high": [11, 12, 13, 14, 15],
+            "low": [9, 10, 11, 12, 13],
+            "close": [10, 11, 12, 13, 14],
+            "volume": [1_000_000] * 5,
+        }
+    )
+
+    panel = sos._prepare_panel(df, _basic_params(), ticker="AAA")
+    # Wilder ATR with window=3, seed is average of first three true ranges (all 2.0)
+    # Values are then shifted by one in the panel.
+    assert panel.loc[dates[3], "atr_value"] == pytest.approx(2.0)
+    assert panel.loc[dates[4], "atr_value"] == pytest.approx(2.0)
+
+
+@pytest.mark.parametrize(
+    "price, expected",
+    [
+        (333.0, 3),
+        (1001.0, 0),
+        (0.0, 0),
+    ],
+)
+def test_compute_shares_obeys_cap(price: float, expected: int):
+    assert sos._compute_shares(price, sos.DEFAULT_CASH_CAP) == expected
+
+
+def test_simulate_exit_prefers_tp(monkeypatch):
+    dates = pd.bdate_range("2022-01-03", periods=3)
+    bars = pd.DataFrame(
+        {
+            "date": dates,
+            "open": [10.0, 10.5, 11.0],
+            "high": [10.6, 11.5, 11.2],
+            "low": [9.8, 10.4, 10.9],
+            "close": [10.4, 11.4, 11.1],
+        }
+    )
+
+    info = sos._simulate_exit(bars, dates[0], 10.0, 11.0, 9.5, horizon_days=5)
+    assert info is not None
+    assert info["exit_reason"] == "tp"
+
+
+def test_simulate_exit_hits_sl_first():
+    dates = pd.bdate_range("2022-01-03", periods=2)
+    bars = pd.DataFrame(
+        {
+            "date": dates,
+            "open": [10.0, 9.0],
+            "high": [11.5, 9.5],
+            "low": [8.5, 8.8],
+            "close": [9.0, 9.1],
+        }
+    )
+
+    info = sos._simulate_exit(bars, dates[0], 10.0, 11.0, 9.0, horizon_days=5)
+    assert info is not None
+    assert info["exit_reason"] == "sl"
+
+
+def test_simulate_exit_timeout():
+    dates = pd.bdate_range("2022-01-03", periods=3)
+    bars = pd.DataFrame(
+        {
+            "date": dates,
+            "open": [10.0, 10.2, 10.4],
+            "high": [10.3, 10.4, 10.5],
+            "low": [9.9, 10.0, 10.1],
+            "close": [10.1, 10.2, 10.3],
+        }
+    )
+
+    info = sos._simulate_exit(bars, dates[0], 10.0, 11.0, 9.0, horizon_days=2)
+    assert info is not None
+    assert info["exit_reason"] == "timeout"
+    assert info["exit_date"].date() == dates[2].date()
+
+
+def test_sr_ratio_gate():
+    assert sos._sr_ratio_ok(10.0, 8.0, 14.0, 2.0)
+    assert not sos._sr_ratio_ok(10.0, 9.25, 11.0, 2.0)
+    assert not sos._sr_ratio_ok(10.0, 8.0, 11.0, 2.0)
+
+
+def test_filter_thresholds():
+    params = _basic_params(min_yup_pct=1.0, min_gap_pct=0.5, min_volume_multiple=1.2)
+    row = pd.Series(
+        {
+            "yesterday_up_pct": 1.5,
+            "open_gap_pct": 0.6,
+            "volume_multiple": 1.25,
+        }
+    )
+    assert sos._passes_filters(row, params)
+
+    failing_row = pd.Series(
+        {
+            "yesterday_up_pct": 0.9,
+            "open_gap_pct": 0.6,
+            "volume_multiple": 1.25,
+        }
+    )
+    assert not sos._passes_filters(failing_row, params)

--- a/ui/pages/65_Stock_Scanner_SharesOnly.py
+++ b/ui/pages/65_Stock_Scanner_SharesOnly.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import datetime as dt
+from typing import Callable
+
+import pandas as pd
+import streamlit as st
+
+from data_lake.storage import Storage
+from engine.stocks_only_scanner import (
+    DEFAULT_CASH_CAP,
+    ScanSummary,
+    StocksOnlyScanParams,
+    run_scan,
+)
+from ui.components.progress import status_block
+
+
+def _default_dates() -> tuple[dt.date, dt.date]:
+    today = pd.Timestamp.today().tz_localize(None).normalize()
+    start = (today - pd.tseries.offsets.BDay(30)).date()
+    return start, today.date()
+
+
+def _format_currency(value: float) -> str:
+    return f"${value:,.2f}"
+
+
+def _progress_callback(progress_widget, log_fn: Callable[[str], None]):
+    def _cb(current: int, total: int, ticker: str) -> None:
+        if total <= 0:
+            pct = 0.0
+        else:
+            pct = current / total
+        try:
+            progress_widget.progress(pct, text=f"{current}/{total} • {ticker}")
+        except Exception:
+            progress_widget.progress(pct)
+        log_fn(f"[{current}/{total}] {ticker}")
+
+    return _cb
+
+
+def _render_summary(summary: ScanSummary) -> None:
+    st.markdown(
+        f"**Date span:** {summary.start.date()} → {summary.end.date()}  \\\n+**Tickers scanned:** {summary.tickers_scanned}  \\\n+**Candidates:** {summary.candidates}  \\\n+**Trades taken:** {summary.trades}"
+    )
+
+    metrics = st.columns(4)
+    metrics[0].metric("Trades", summary.trades)
+    win_display = (
+        f"{summary.wins} wins" if summary.trades else "0"
+    )
+    metrics[1].metric("Win rate", f"{summary.win_rate:.1%}", win_display)
+    metrics[2].metric("Total capital deployed", _format_currency(summary.total_capital))
+    metrics[3].metric("Total P&L", _format_currency(summary.total_pnl))
+
+
+def _render_ledger(df: pd.DataFrame) -> None:
+    st.subheader("Trade ledger")
+    if df.empty:
+        st.info("No trades met the criteria.")
+        return
+
+    display_cols = [
+        "entry_date",
+        "exit_date",
+        "ticker",
+        "entry_price",
+        "tp_price",
+        "sl_price",
+        "exit_price",
+        "exit_reason",
+        "shares",
+        "cost",
+        "proceeds",
+        "pnl",
+    ]
+    working = df[display_cols].copy()
+    working["entry_date"] = pd.to_datetime(working["entry_date"]).dt.date
+    working["exit_date"] = pd.to_datetime(working["exit_date"]).dt.date
+    numeric_cols = [
+        "entry_price",
+        "tp_price",
+        "sl_price",
+        "exit_price",
+        "cost",
+        "proceeds",
+        "pnl",
+    ]
+    working[numeric_cols] = working[numeric_cols].astype(float).round(2)
+    working["shares"] = working["shares"].astype(int)
+    working["exit_reason"] = working["exit_reason"].astype(str)
+
+    st.dataframe(working, use_container_width=True)
+    csv_bytes = working.to_csv(index=False).encode("utf-8")
+    st.download_button(
+        "Download CSV of the trade ledger",
+        csv_bytes,
+        file_name="stock_scanner_trades.csv",
+        mime="text/csv",
+        key="stock_scan_download",
+    )
+
+
+def page() -> None:
+    st.header("📊 Stock Scanner (Shares Only)")
+    st.caption("Backtest whole-share stock entries with ATR or support/resistance exits.")
+    st.info(
+        "Entries are capped at $1,000 per trade (whole shares only). Positions exit on TP, SL, or at the day-30 close if neither level is hit."
+    )
+
+    storage = Storage()
+    st.caption(f"storage: {storage.info()} mode={storage.mode}")
+    if getattr(storage, "force_supabase", False) and storage.mode == "local":
+        st.error(
+            "Supabase is required but not available. Check configuration or disable supabase.force."
+        )
+        return
+
+    default_start, default_end = _default_dates()
+
+    with st.form("stock_scanner_form"):
+        col_dates = st.columns(2)
+        start_date = col_dates[0].date_input("Start date", value=default_start)
+        end_date = col_dates[1].date_input("End date", value=default_end)
+
+        horizon = int(st.number_input("Horizon (business days)", min_value=1, value=30, step=1))
+
+        sr_cols = st.columns(2)
+        sr_lookback = int(
+            sr_cols[0].number_input("SR lookback (days)", min_value=5, value=21, step=1)
+        )
+        sr_min_ratio = float(
+            sr_cols[1].number_input("SR min ratio", min_value=0.5, value=2.0, step=0.1)
+        )
+
+        filter_cols = st.columns(3)
+        min_yup_pct = float(
+            filter_cols[0].number_input("Yesterday up % minimum", value=0.0, step=0.1)
+        )
+        min_gap_pct = float(
+            filter_cols[1].number_input("Open gap % minimum", value=0.0, step=0.1)
+        )
+        min_volume_multiple = float(
+            filter_cols[2].number_input("Volume multiple minimum", value=1.0, step=0.1)
+        )
+
+        volume_lookback = int(
+            st.number_input("Volume lookback (days)", min_value=5, value=20, step=1)
+        )
+
+        exit_model = st.radio(
+            "Exit model",
+            options=("atr", "sr"),
+            index=0,
+            format_func=lambda v: "ATR multiples" if v == "atr" else "Support/Resistance",
+        )
+
+        if exit_model == "atr":
+            atr_cols = st.columns(2)
+            tp_atr_multiple = float(
+                atr_cols[0].number_input("TP ATR multiple", min_value=0.1, value=1.0, step=0.1)
+            )
+            sl_atr_multiple = float(
+                atr_cols[1].number_input("SL ATR multiple", min_value=0.1, value=1.0, step=0.1)
+            )
+        else:
+            tp_atr_multiple = 1.0
+            sl_atr_multiple = 1.0
+
+        atr_cols_bottom = st.columns(2)
+        atr_window = int(
+            atr_cols_bottom[0].number_input("ATR window", min_value=1, value=14, step=1)
+        )
+        atr_method = atr_cols_bottom[1].selectbox(
+            "ATR method",
+            options=("wilder", "sma", "ema"),
+            index=0,
+            format_func=lambda opt: "Wilder" if opt == "wilder" else opt.upper(),
+        )
+
+        use_sp_filter = bool(st.checkbox("Use S&P membership filter", value=True))
+
+        st.number_input(
+            "$ per trade cap",
+            value=int(DEFAULT_CASH_CAP),
+            step=100,
+            disabled=True,
+            help="Whole shares only; trades skip when one share exceeds the cap.",
+        )
+
+        run_scan_btn = st.form_submit_button("Run scan", type="primary")
+
+    if not run_scan_btn:
+        return
+
+    start_ts = pd.Timestamp(start_date).tz_localize(None)
+    end_ts = pd.Timestamp(end_date).tz_localize(None)
+    if end_ts < start_ts:
+        st.error("End date must be on or after the start date.")
+        return
+
+    params: StocksOnlyScanParams = {
+        "start": start_ts,
+        "end": end_ts,
+        "horizon_days": horizon,
+        "sr_lookback": sr_lookback,
+        "sr_min_ratio": sr_min_ratio,
+        "min_yup_pct": min_yup_pct,
+        "min_gap_pct": min_gap_pct,
+        "min_volume_multiple": min_volume_multiple,
+        "volume_lookback": volume_lookback,
+        "exit_model": exit_model,
+        "atr_window": atr_window,
+        "atr_method": atr_method,
+        "tp_atr_multiple": tp_atr_multiple,
+        "sl_atr_multiple": sl_atr_multiple,
+        "use_sp_filter": use_sp_filter,
+        "cash_per_trade": DEFAULT_CASH_CAP,
+    }
+
+    status, prog_widget, log_fn = status_block("Running stock scan…", key_prefix="stock_scan")
+    status.update(label="Loading data…", state="running")
+
+    progress_cb = _progress_callback(prog_widget, log_fn)
+
+    try:
+        ledger, summary = run_scan(
+            params,
+            storage=storage,
+            progress=progress_cb,
+        )
+    except Exception as exc:
+        status.update(label="Scan failed ❌", state="error")
+        st.error("Scan failed")
+        st.exception(exc)
+        return
+
+    status.update(label="Scan complete ✅", state="complete")
+
+    _render_summary(summary)
+    _render_ledger(ledger)


### PR DESCRIPTION
## Summary
- add a dedicated stocks_only_scanner engine that sizes whole-share trades with ATR/SR exits and structured logging
- expose the scanner via a new “Stock Scanner (Shares Only)” Streamlit tab with configurable filters and CSV download
- document the workflow and cover sizing/exit/filter helpers with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d197a6f9ac833295227adcac4f2f42