### PR TITLE
Fix debug panel crash on Stock Scanner

### DIFF
--- a/ui/pages/65_Stock_Scanner_SharesOnly.py
+++ b/ui/pages/65_Stock_Scanner_SharesOnly.py
@@ -191,14 +191,14 @@ def _render_debug_panel(
         else:
             st.write("No events logged.")
 
-        with st.expander("meta / params / env / errors"):
-            st.write("meta")
+        tabs = st.tabs(["meta", "params", "env", "errors"])
+        with tabs[0]:
             st.json(meta)
-            st.write("params")
+        with tabs[1]:
             st.json(params)
-            st.write("env")
+        with tabs[2]:
             st.json(env)
-            st.write("errors")
+        with tabs[3]:
             st.json(debug.errors)
 
 


### PR DESCRIPTION
## Summary
- replace the nested debug expander with tabs to avoid the Streamlit crash
- keep the meta, params, env, and errors information accessible via individual tabs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1bf6c52dc83328ab539cc500d4115