### PR TITLE
Fix: align day lookups by calendar date in stocks-only scanner

### DIFF
--- a/engine/stocks_only_scanner.py
+++ b/engine/stocks_only_scanner.py
@@ -524,7 +524,12 @@ def run_scan(
         if panel_by_day.empty:
             continue
 
-        bars = panel[["date", "open", "high", "low", "close"]].copy()
+        bars = (
+            panel_by_day.drop(columns=["date"], errors="ignore")
+            .assign(date=pd.Index(panel_by_day.index))
+            [["date", "open", "high", "low", "close"]]
+            .copy()
+        )
         if progress is not None:
             progress(idx, len(tickers_sorted), ticker)
 


### PR DESCRIPTION
## Summary
- reuse the cached per-day panel when building exit simulation bars so replay_trade receives one row per session

## Testing
- pytest tests/test_stocks_only_scanner.py
- PYTHONPATH=. pytest tests/test_stocks_only_scanner.py

------
https://chatgpt.com/codex/tasks/task_e_68d1f511712c8332ad6e1d44e45945ac