### PR TITLE
Fix: avoid 'date' index/column ambiguity in stocks-only scanner.

### DIFF
--- a/engine/stocks_only_scanner.py
+++ b/engine/stocks_only_scanner.py
@@ -526,6 +526,8 @@ def run_scan(
         # Ensure the index is not named "date" to avoid ambiguity when creating the bars
         # dataframe that feeds into replay_trade.
         panel_by_day = panel_by_day.rename_axis(None)
+        if "date" in panel_by_day.columns:
+            panel_by_day = panel_by_day.drop(columns=["date"])
 
         bars = (
             panel_by_day


### PR DESCRIPTION
## Summary
- drop any existing `date` column before resetting the per-day panel index so pandas can insert the index as `date`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d20e6d4da48332b0413ab9ebb38dee