### PR TITLE
feat: add Spike Precursor Lab analysis page

### DIFF
--- a/engine/spike_precursor.py
+++ b/engine/spike_precursor.py
@@ -1,0 +1,859 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+import numpy as np
+import pandas as pd
+from pandas.tseries.offsets import BDay
+
+from data_lake.storage import Storage, load_prices_cached
+
+from .features import atr as compute_atr
+
+
+def _normalize_prices_df(df: pd.DataFrame, ticker: str) -> pd.DataFrame:
+    """Return a tidy OHLCV frame with normalized column names and unique dates."""
+
+    working = df.copy()
+    if "date" not in working.columns:
+        index_name = working.index.name
+        working = working.reset_index()
+        if "date" not in working.columns:
+            rename_candidates = []
+            if "Date" in working.columns:
+                rename_candidates.append("Date")
+            if index_name and index_name in working.columns:
+                rename_candidates.append(index_name)
+            if "index" in working.columns:
+                rename_candidates.append("index")
+            if "level_0" in working.columns:
+                rename_candidates.append("level_0")
+            target = next(iter(rename_candidates), working.columns[0])
+            working = working.rename(columns={target: "date"})
+    if "date" not in working.columns and "Date" in working.columns:
+        working = working.rename(columns={"Date": "date"})
+
+    working["date"] = (
+        pd.to_datetime(working["date"], errors="coerce").dt.tz_localize(None)
+    )
+    working = working.dropna(subset=["date"])
+
+    rename_map = {c: c.lower() for c in working.columns}
+    working = working.rename(columns=rename_map)
+
+    for col in ["open", "high", "low", "close"]:
+        if col not in working.columns:
+            raise KeyError(f"Missing required price column '{col}' for {ticker}")
+        working[col] = pd.to_numeric(working[col], errors="coerce")
+
+    if "volume" in working.columns:
+        working["volume"] = pd.to_numeric(working["volume"], errors="coerce")
+    else:
+        working["volume"] = float("nan")
+
+    working = (
+        working.sort_values("date").drop_duplicates(subset=["date"], keep="last")
+    )
+    return working.reset_index(drop=True)
+
+
+def _business_start(ts: pd.Timestamp, lookback: int) -> pd.Timestamp:
+    if lookback <= 0:
+        return ts
+    start = (ts - BDay(int(lookback))).normalize()
+    return pd.Timestamp(start).tz_localize(None)
+
+
+def _rolling_percentile(series: pd.Series, window: int) -> pd.Series:
+    if window <= 1:
+        return pd.Series(np.nan, index=series.index)
+
+    min_periods = min(window, max(3, window // 2))
+
+    def _pct(arr: np.ndarray) -> float:
+        if len(arr) == 0:
+            return float("nan")
+        current = arr[-1]
+        valid = arr[~np.isnan(arr)]
+        if len(valid) == 0:
+            return float("nan")
+        rank = (valid <= current).sum() / len(valid)
+        return float(rank * 100.0)
+
+    return series.rolling(window, min_periods=min_periods).apply(_pct, raw=True)
+
+
+def _discover_all_tickers(storage: Storage) -> list[str]:
+    try:
+        entries = storage.list_prefix("prices/")
+    except Exception:
+        return []
+
+    tickers: set[str] = set()
+    for entry in entries:
+        name = str(entry).replace("\\", "/")
+        parts = [p for p in name.split("/") if p]
+        if not parts:
+            continue
+        last = parts[-1]
+        if last.startswith("_"):
+            continue
+        if last.lower().endswith(".parquet"):
+            stem = last.rsplit(".parquet", 1)[0]
+        else:
+            stem = parts[-1]
+        if stem:
+            tickers.add(stem.upper())
+    return sorted(tickers)
+
+
+def analyze_spike_precursors(
+    storage: Storage,
+    start: pd.Timestamp,
+    end: pd.Timestamp,
+    *,
+    universe: list[str] | None,
+    spike_mode: Literal["pct", "atr"],
+    pct_threshold: float | None,
+    atr_multiple: float | None,
+    atr_window: int,
+    atr_method: str,
+    lookback_days: int,
+    indicator_config: dict[str, Any],
+    debug: object | None = None,
+) -> tuple[pd.DataFrame, dict]:
+    start_ts = pd.Timestamp(start).tz_localize(None)
+    end_ts = pd.Timestamp(end).tz_localize(None)
+    if start_ts > end_ts:
+        start_ts, end_ts = end_ts, start_ts
+
+    universe_list: list[str]
+    if universe:
+        universe_list = sorted({str(t).upper() for t in universe if t})
+    else:
+        universe_list = _discover_all_tickers(storage)
+
+    if debug and hasattr(debug, "log_event"):
+        try:
+            debug.log_event(
+                "universe_resolved",
+                requested=len(universe or []),
+                resolved=len(universe_list),
+            )
+        except Exception:
+            pass
+
+    if not universe_list:
+        empty = pd.DataFrame(columns=["ticker", "spike_date"])
+        summary = {
+            "counts": {
+                "spikes": 0,
+                "tickers": 0,
+                "start": start_ts,
+                "end": end_ts,
+            },
+            "frequency_table": pd.DataFrame(
+                columns=["flag", "hit_count", "hit_rate", "median_lead_days"]
+            ),
+            "combos": pd.DataFrame(columns=["combo", "count", "lift"]),
+            "flag_metadata": {},
+            "lookback_days": lookback_days,
+        }
+        return empty, summary
+
+    atr_method = (atr_method or "wilder").strip().lower()
+
+    config = indicator_config or {}
+
+    volume_filter_cfg = config.get("volume_filter", {})
+    volume_filter_enabled = bool(volume_filter_cfg.get("enabled", False))
+    volume_filter_lookback = int(volume_filter_cfg.get("lookback", 63) or 63)
+    volume_filter_threshold = float(volume_filter_cfg.get("threshold", 1.5) or 1.5)
+
+    pad_days = lookback_days + max(
+        atr_window,
+        volume_filter_lookback if volume_filter_enabled else 0,
+        int(config.get("sr", {}).get("lookback", 63) or 63)
+        if config.get("sr", {}).get("enabled")
+        else 0,
+        int(config.get("volume", {}).get("lookback", 63) or 63)
+        if config.get("volume", {}).get("enabled")
+        else 0,
+        int(config.get("bb", {}).get("pct_window", 126) or 126)
+        if config.get("bb", {}).get("enabled")
+        else 0,
+        int(config.get("atr_squeeze", {}).get("window", 63) or 63)
+        if config.get("atr_squeeze", {}).get("enabled")
+        else 0,
+        int(max(config.get("new_high", {}).get("windows", [63]) or [63]))
+        if config.get("new_high", {}).get("enabled")
+        else 0,
+    )
+    pad_days = max(pad_days, lookback_days + 5)
+    fetch_start = (start_ts - BDay(pad_days)).tz_localize(None)
+
+    if debug and hasattr(debug, "log_event"):
+        try:
+            debug.log_event(
+                "preload_prices:start",
+                tickers=len(universe_list),
+                start=str(fetch_start.date()),
+                end=str(end_ts.date()),
+            )
+        except Exception:
+            pass
+
+    prices_df = load_prices_cached(
+        storage,
+        cache_salt=storage.cache_salt(),
+        tickers=list(universe_list),
+        start=fetch_start,
+        end=end_ts,
+    )
+
+    if debug and hasattr(debug, "log_event"):
+        try:
+            debug.log_event(
+                "preload_prices:done",
+                rows=int(len(prices_df)),
+                tickers=len(universe_list),
+            )
+        except Exception:
+            pass
+
+    if prices_df.empty:
+        empty = pd.DataFrame(columns=["ticker", "spike_date"])
+        summary = {
+            "counts": {
+                "spikes": 0,
+                "tickers": 0,
+                "start": start_ts,
+                "end": end_ts,
+            },
+            "frequency_table": pd.DataFrame(
+                columns=["flag", "hit_count", "hit_rate", "median_lead_days"]
+            ),
+            "combos": pd.DataFrame(columns=["combo", "count", "lift"]),
+            "flag_metadata": {},
+            "lookback_days": lookback_days,
+        }
+        return empty, summary
+
+    prices_df["date"] = pd.to_datetime(prices_df["date"], errors="coerce").dt.tz_localize(
+        None
+    )
+    prices_df = prices_df.dropna(subset=["date"])
+
+    available_start = prices_df["date"].min()
+    available_end = prices_df["date"].max()
+    if debug and hasattr(debug, "log_event"):
+        try:
+            debug.log_event(
+                "coverage",
+                available_start=str(pd.Timestamp(available_start).date())
+                if pd.notna(available_start)
+                else None,
+                available_end=str(pd.Timestamp(available_end).date())
+                if pd.notna(available_end)
+                else None,
+                requested_start=str(start_ts.date()),
+                requested_end=str(end_ts.date()),
+            )
+        except Exception:
+            pass
+
+    spike_rows: list[dict[str, Any]] = []
+    bool_columns: set[str] = set()
+    lead_columns: dict[str, str] = {}
+    flag_metadata: dict[str, dict[str, Any]] = {}
+
+    atr_cfg = config.get("atr_squeeze", {}) if isinstance(config.get("atr_squeeze"), dict) else {}
+    atr_pct_window = int(atr_cfg.get("window", 63) or 63)
+    atr_pct_threshold = float(atr_cfg.get("percentile", 25.0) or 25.0)
+
+    bb_cfg = config.get("bb", {}) if isinstance(config.get("bb"), dict) else {}
+    bb_period = int(bb_cfg.get("period", 20) or 20)
+    bb_pct_window = int(bb_cfg.get("pct_window", 126) or 126)
+    bb_percentile = float(bb_cfg.get("percentile", 20.0) or 20.0)
+
+    trend_cfg = config.get("trend", {}) if isinstance(config.get("trend"), dict) else {}
+    trend_fast = int(trend_cfg.get("fast", 20) or 20)
+    trend_slow = int(trend_cfg.get("slow", 50) or 50)
+
+    rsi_cfg = config.get("rsi", {}) if isinstance(config.get("rsi"), dict) else {}
+    rsi_period = int(rsi_cfg.get("period", 14) or 14)
+    rsi_levels = rsi_cfg.get("levels") or [50.0, 60.0]
+    rsi_levels = [float(x) for x in rsi_levels if x is not None]
+
+    nr7_cfg = config.get("nr7", {}) if isinstance(config.get("nr7"), dict) else {}
+    nr7_window = int(nr7_cfg.get("window", 7) or 7)
+
+    gap_cfg = config.get("gap", {}) if isinstance(config.get("gap"), dict) else {}
+    gap_threshold = float(gap_cfg.get("threshold", 3.0) or 3.0)
+
+    volume_cfg = config.get("volume", {}) if isinstance(config.get("volume"), dict) else {}
+    volume_threshold = float(volume_cfg.get("threshold", 1.5) or 1.5)
+    volume_lookback = int(volume_cfg.get("lookback", 63) or 63)
+
+    sr_cfg = config.get("sr", {}) if isinstance(config.get("sr"), dict) else {}
+    sr_threshold = float(sr_cfg.get("threshold", 2.0) or 2.0)
+    sr_lookback = int(sr_cfg.get("lookback", 63) or 63)
+
+    new_high_cfg = config.get("new_high", {}) if isinstance(config.get("new_high"), dict) else {}
+    new_high_windows = new_high_cfg.get("windows") or [20, 63]
+    new_high_windows = [int(w) for w in new_high_windows if w]
+
+    selected_flags: dict[str, Any] = {}
+
+    for ticker, frame in prices_df.groupby("Ticker"):
+        ticker = str(ticker).upper()
+        try:
+            panel = _normalize_prices_df(frame, ticker)
+        except Exception:
+            if debug and hasattr(debug, "log_event"):
+                try:
+                    debug.log_event("panel_error", ticker=ticker)
+                except Exception:
+                    pass
+            continue
+
+        panel["date"] = pd.to_datetime(panel["date"], errors="coerce").dt.tz_localize(None)
+        panel = panel.dropna(subset=["date"])
+        panel = panel.sort_values("date")
+        panel = panel.drop_duplicates(subset=["date"], keep="last")
+        panel = panel.set_index("date", drop=False)
+        panel.index = panel.index.tz_localize(None)
+        panel.index = panel.index.normalize()
+        panel = panel[~panel.index.duplicated(keep="last")]
+
+        panel = panel.loc[(panel.index >= fetch_start) & (panel.index <= end_ts)].copy()
+        if panel.empty:
+            continue
+
+        close = panel["close"].astype(float)
+        prev_close = close.shift(1)
+        panel["pct_change"] = (close / prev_close - 1.0) * 100.0
+
+        atr_series = compute_atr(panel[["high", "low", "close"]], window=atr_window, method=atr_method)
+        panel["atr"] = atr_series
+        panel["atr_prev"] = panel["atr"].shift(1)
+        panel["atr_multiple"] = np.where(
+            panel["atr_prev"].abs() > 1e-9,
+            (close - prev_close) / panel["atr_prev"],
+            np.nan,
+        )
+
+        if volume_filter_enabled:
+            trailing = panel["volume"].shift(1).rolling(
+                volume_filter_lookback, min_periods=min(10, volume_filter_lookback)
+            ).mean()
+            panel["volume_trailing_avg"] = trailing
+            panel["volume_multiple_spike"] = np.where(
+                trailing > 0, panel["volume"] / trailing, np.nan
+            )
+        else:
+            panel["volume_trailing_avg"] = np.nan
+            panel["volume_multiple_spike"] = np.nan
+
+        if config.get("trend", {}).get("enabled"):
+            ema_fast = close.ewm(span=trend_fast, adjust=False, min_periods=trend_fast).mean()
+            ema_slow = close.ewm(span=trend_slow, adjust=False, min_periods=trend_slow).mean()
+            panel["ema_fast"] = ema_fast
+            panel["ema_slow"] = ema_slow
+            panel["ema_cross_up"] = (
+                (ema_fast > ema_slow) & (ema_fast.shift(1) <= ema_slow.shift(1))
+            )
+
+        if config.get("rsi", {}).get("enabled"):
+            delta = close.diff()
+            gain = delta.clip(lower=0)
+            loss = -delta.clip(upper=0)
+            roll = rsi_period
+            avg_gain = gain.ewm(alpha=1 / roll, adjust=False, min_periods=roll).mean()
+            avg_loss = loss.ewm(alpha=1 / roll, adjust=False, min_periods=roll).mean()
+            rs = avg_gain / avg_loss.replace({0: np.nan})
+            rsi = 100 - (100 / (1 + rs))
+            panel["rsi"] = rsi
+            for level in rsi_levels:
+                key = f"rsi_cross_{int(level)}"
+                panel[key] = (rsi >= level) & (rsi.shift(1) < level)
+
+        if config.get("atr_squeeze", {}).get("enabled"):
+            panel["atr_percentile_rank"] = _rolling_percentile(panel["atr"], atr_pct_window)
+            panel["atr_squeeze_flag"] = panel["atr_percentile_rank"] <= atr_pct_threshold
+
+        if config.get("bb", {}).get("enabled"):
+            mid = close.rolling(bb_period, min_periods=bb_period).mean()
+            std = close.rolling(bb_period, min_periods=bb_period).std(ddof=0)
+            upper = mid + 2 * std
+            lower = mid - 2 * std
+            width = (upper - lower) / mid.replace({0: np.nan})
+            panel["bb_width"] = width
+            panel["bb_width_percentile"] = _rolling_percentile(width, bb_pct_window)
+            panel["bb_squeeze_flag"] = panel["bb_width_percentile"] <= bb_percentile
+
+        if config.get("nr7", {}).get("enabled"):
+            true_range = (panel["high"] - panel["low"]).astype(float)
+            panel["nr7_flag"] = true_range <= true_range.rolling(nr7_window).min()
+
+        if config.get("gap", {}).get("enabled"):
+            panel["gap_pct"] = (panel["open"] / prev_close - 1.0) * 100.0
+
+        if config.get("volume", {}).get("enabled"):
+            vol_avg = panel["volume"].rolling(
+                volume_lookback, min_periods=min(10, volume_lookback)
+            ).mean()
+            panel["volume_multiple"] = np.where(vol_avg > 0, panel["volume"] / vol_avg, np.nan)
+
+        if config.get("sr", {}).get("enabled"):
+            support = panel["low"].rolling(sr_lookback, min_periods=sr_lookback).min()
+            resistance = panel["high"].rolling(sr_lookback, min_periods=sr_lookback).max()
+            price = close
+            denom = price - support
+            with np.errstate(divide="ignore", invalid="ignore"):
+                ratio = (resistance - price) / denom
+            ratio = ratio.where((support < price) & (resistance > price))
+            panel["sr_ratio"] = ratio
+
+        if config.get("new_high", {}).get("enabled"):
+            for window in new_high_windows:
+                rolling_max = close.shift(1).rolling(window, min_periods=window).max()
+                key = f"new_high_{window}"
+                panel[key] = close >= rolling_max
+
+        if panel.empty:
+            continue
+
+        spike_mask = pd.Series(False, index=panel.index)
+        if spike_mode == "pct":
+            threshold = float(pct_threshold or 0.0)
+            spike_mask = panel["pct_change"] >= threshold
+        else:
+            multiple = float(atr_multiple or 0.0)
+            diff = close - prev_close
+            spike_mask = diff >= (multiple * panel["atr_prev"])
+
+        spike_mask &= panel.index.to_series().between(start_ts, end_ts)
+        spike_mask &= prev_close.notna()
+
+        if volume_filter_enabled:
+            spike_mask &= (
+                panel["volume_multiple_spike"] >= volume_filter_threshold
+            )
+
+        spike_dates = panel.index[spike_mask]
+        if not len(spike_dates):
+            continue
+
+        for spike_date in spike_dates:
+            spike_row: dict[str, Any] = {
+                "ticker": ticker,
+                "spike_date": spike_date,
+                "close": float(panel.loc[spike_date, "close"]),
+                "pct_change_t": float(panel.loc[spike_date, "pct_change"]),
+                "atr_mult_t": float(panel.loc[spike_date, "atr_multiple"]),
+                "volume_multiple_t": float(
+                    panel.loc[spike_date, "volume_multiple_spike"]
+                )
+                if volume_filter_enabled
+                else np.nan,
+            }
+
+            window_start = _business_start(spike_date, lookback_days)
+            window_df = panel.loc[(panel.index >= window_start) & (panel.index < spike_date)]
+
+            lead_candidates: list[float] = []
+            active_flags: list[str] = []
+
+            if config.get("trend", {}).get("enabled") and "ema_cross_up" in panel:
+                flag_col = f"ema_cross_{trend_fast}_{trend_slow}_any"
+                lead_col = f"ema_cross_{trend_fast}_{trend_slow}_lead_days"
+                crosses = window_df.index[window_df.get("ema_cross_up", False)]
+                hit = len(crosses) > 0
+                spike_row[flag_col] = bool(hit)
+                if hit:
+                    leads = [int((spike_date - d).days) for d in crosses]
+                    lead = float(min(leads)) if leads else float("nan")
+                    spike_row[lead_col] = lead
+                    lead_candidates.append(lead)
+                    active_flags.append(flag_col)
+                else:
+                    spike_row[lead_col] = float("nan")
+                bool_columns.add(flag_col)
+                lead_columns[flag_col] = lead_col
+                flag_metadata.setdefault(
+                    flag_col,
+                    {
+                        "type": "ema_cross",
+                        "fast": trend_fast,
+                        "slow": trend_slow,
+                    },
+                )
+
+            if config.get("rsi", {}).get("enabled") and "rsi" in panel:
+                spike_row["rsi14_max"] = float(window_df["rsi"].max()) if not window_df.empty else np.nan
+                for level in rsi_levels:
+                    flag_col = f"rsi_{rsi_period}_cross_{int(level)}"
+                    lead_col = f"{flag_col}_lead_days"
+                    cross_col = f"rsi_cross_{int(level)}"
+                    if cross_col not in panel:
+                        continue
+                    crosses = window_df.index[window_df.get(cross_col, False)]
+                    hit = len(crosses) > 0
+                    spike_row[flag_col] = bool(hit)
+                    if hit:
+                        leads = [int((spike_date - d).days) for d in crosses]
+                        lead = float(min(leads)) if leads else float("nan")
+                        spike_row[lead_col] = lead
+                        lead_candidates.append(lead)
+                        active_flags.append(flag_col)
+                    else:
+                        spike_row[lead_col] = float("nan")
+                    bool_columns.add(flag_col)
+                    lead_columns[flag_col] = lead_col
+                    flag_metadata.setdefault(
+                        flag_col,
+                        {
+                            "type": "rsi_above",
+                            "period": rsi_period,
+                            "level": level,
+                        },
+                    )
+
+            if config.get("atr_squeeze", {}).get("enabled") and "atr_squeeze_flag" in panel:
+                flag_col = f"atr_squeeze_le_{atr_pct_threshold:g}p"
+                lead_col = f"{flag_col}_lead_days"
+                hits = window_df.index[window_df.get("atr_squeeze_flag", False)]
+                hit = len(hits) > 0
+                spike_row[flag_col] = bool(hit)
+                spike_row["atr_pctl_min"] = (
+                    float(window_df["atr_percentile_rank"].min())
+                    if not window_df.empty
+                    else np.nan
+                )
+                if hit:
+                    leads = [int((spike_date - d).days) for d in hits]
+                    lead = float(min(leads)) if leads else float("nan")
+                    spike_row[lead_col] = lead
+                    lead_candidates.append(lead)
+                    active_flags.append(flag_col)
+                else:
+                    spike_row[lead_col] = float("nan")
+                bool_columns.add(flag_col)
+                lead_columns[flag_col] = lead_col
+                flag_metadata.setdefault(
+                    flag_col,
+                    {
+                        "type": "squeeze",
+                        "measure": "atr_percentile",
+                        "threshold": atr_pct_threshold,
+                    },
+                )
+
+            if config.get("bb", {}).get("enabled") and "bb_squeeze_flag" in panel:
+                flag_col = f"bb_squeeze_le_{bb_percentile:g}p"
+                lead_col = f"{flag_col}_lead_days"
+                hits = window_df.index[window_df.get("bb_squeeze_flag", False)]
+                hit = len(hits) > 0
+                spike_row[flag_col] = bool(hit)
+                spike_row["bb_width_pctl_min"] = (
+                    float(window_df["bb_width_percentile"].min())
+                    if not window_df.empty
+                    else np.nan
+                )
+                if hit:
+                    leads = [int((spike_date - d).days) for d in hits]
+                    lead = float(min(leads)) if leads else float("nan")
+                    spike_row[lead_col] = lead
+                    lead_candidates.append(lead)
+                    active_flags.append(flag_col)
+                else:
+                    spike_row[lead_col] = float("nan")
+                bool_columns.add(flag_col)
+                lead_columns[flag_col] = lead_col
+                flag_metadata.setdefault(
+                    flag_col,
+                    {
+                        "type": "squeeze",
+                        "measure": "bb_width_percentile",
+                        "threshold": bb_percentile,
+                    },
+                )
+
+            if config.get("nr7", {}).get("enabled") and "nr7_flag" in panel:
+                flag_col = "nr7_any"
+                lead_col = "nr7_lead_days"
+                hits = window_df.index[window_df.get("nr7_flag", False)]
+                hit = len(hits) > 0
+                spike_row[flag_col] = bool(hit)
+                spike_row["nr7_count"] = int(window_df.get("nr7_flag", False).sum())
+                if hit:
+                    leads = [int((spike_date - d).days) for d in hits]
+                    lead = float(min(leads)) if leads else float("nan")
+                    spike_row[lead_col] = lead
+                    lead_candidates.append(lead)
+                    active_flags.append(flag_col)
+                else:
+                    spike_row[lead_col] = float("nan")
+                bool_columns.add(flag_col)
+                lead_columns[flag_col] = lead_col
+                flag_metadata.setdefault(flag_col, {"type": "pattern", "name": "nr7"})
+
+            if config.get("gap", {}).get("enabled") and "gap_pct" in panel:
+                flag_col = f"gap_prior_ge_{gap_threshold:g}pct"
+                lead_col = f"{flag_col}_lead_days"
+                hits = window_df.index[window_df.get("gap_pct", 0.0) >= gap_threshold]
+                hit = len(hits) > 0
+                spike_row[flag_col] = bool(hit)
+                if hit:
+                    leads = [int((spike_date - d).days) for d in hits]
+                    lead = float(min(leads)) if leads else float("nan")
+                    spike_row[lead_col] = lead
+                    lead_candidates.append(lead)
+                    active_flags.append(flag_col)
+                else:
+                    spike_row[lead_col] = float("nan")
+                bool_columns.add(flag_col)
+                lead_columns[flag_col] = lead_col
+                flag_metadata.setdefault(
+                    flag_col,
+                    {"type": "gap", "threshold_pct": gap_threshold},
+                )
+
+            if config.get("volume", {}).get("enabled") and "volume_multiple" in panel:
+                day1 = panel.index.get_loc(spike_date) - 1
+                day2 = panel.index.get_loc(spike_date) - 2
+                if day1 >= 0:
+                    prev_day = panel.index[day1]
+                    mult = panel.iloc[day1]["volume_multiple"]
+                    flag_col = f"vol_day1_ge_{volume_threshold:g}x"
+                    lead_col = f"{flag_col}_lead_days"
+                    hit = float(mult) >= volume_threshold if pd.notna(mult) else False
+                    spike_row[flag_col] = bool(hit)
+                    spike_row[lead_col] = 1.0 if hit else float("nan")
+                    if hit:
+                        lead_candidates.append(1.0)
+                        active_flags.append(flag_col)
+                    bool_columns.add(flag_col)
+                    lead_columns[flag_col] = lead_col
+                    flag_metadata.setdefault(
+                        flag_col,
+                        {
+                            "type": "volume_multiple",
+                            "days_ago": 1,
+                            "threshold": volume_threshold,
+                        },
+                    )
+                if day2 >= 0:
+                    prev2 = panel.index[day2]
+                    mult2 = panel.iloc[day2]["volume_multiple"]
+                    flag_col = f"vol_day2_ge_{volume_threshold:g}x"
+                    lead_col = f"{flag_col}_lead_days"
+                    hit2 = float(mult2) >= volume_threshold if pd.notna(mult2) else False
+                    spike_row[flag_col] = bool(hit2)
+                    spike_row[lead_col] = 2.0 if hit2 else float("nan")
+                    if hit2:
+                        lead_candidates.append(2.0)
+                        active_flags.append(flag_col)
+                    bool_columns.add(flag_col)
+                    lead_columns[flag_col] = lead_col
+                    flag_metadata.setdefault(
+                        flag_col,
+                        {
+                            "type": "volume_multiple",
+                            "days_ago": 2,
+                            "threshold": volume_threshold,
+                        },
+                    )
+
+            if config.get("sr", {}).get("enabled") and "sr_ratio" in panel:
+                flag_col = f"sr_ratio_ge_{sr_threshold:g}"
+                lead_col = f"{flag_col}_lead_days"
+                hits = window_df.index[window_df.get("sr_ratio", 0.0) >= sr_threshold]
+                hit = len(hits) > 0
+                spike_row[flag_col] = bool(hit)
+                spike_row["sr_ratio_max"] = (
+                    float(window_df["sr_ratio"].max()) if not window_df.empty else np.nan
+                )
+                if hit:
+                    leads = [int((spike_date - d).days) for d in hits]
+                    lead = float(min(leads)) if leads else float("nan")
+                    spike_row[lead_col] = lead
+                    lead_candidates.append(lead)
+                    active_flags.append(flag_col)
+                else:
+                    spike_row[lead_col] = float("nan")
+                bool_columns.add(flag_col)
+                lead_columns[flag_col] = lead_col
+                flag_metadata.setdefault(
+                    flag_col,
+                    {"type": "sr_ratio", "threshold": sr_threshold},
+                )
+
+            if config.get("new_high", {}).get("enabled"):
+                for window in new_high_windows:
+                    key = f"new_high_{window}"
+                    if key not in panel:
+                        continue
+                    flag_col = f"{key}_any"
+                    lead_col = f"{flag_col}_lead_days"
+                    hits = window_df.index[window_df.get(key, False)]
+                    hit = len(hits) > 0
+                    spike_row[flag_col] = bool(hit)
+                    if hit:
+                        leads = [int((spike_date - d).days) for d in hits]
+                        lead = float(min(leads)) if leads else float("nan")
+                        spike_row[lead_col] = lead
+                        lead_candidates.append(lead)
+                        active_flags.append(flag_col)
+                    else:
+                        spike_row[lead_col] = float("nan")
+                    bool_columns.add(flag_col)
+                    lead_columns[flag_col] = lead_col
+                    flag_metadata.setdefault(
+                        flag_col,
+                        {"type": "new_high", "window": window},
+                    )
+
+            spike_row["lead_time_first_precursor"] = (
+                float(min(lead_candidates)) if lead_candidates else float("nan")
+            )
+
+            spike_rows.append(spike_row)
+
+            if debug and hasattr(debug, "log_event"):
+                try:
+                    debug.log_event(
+                        "spike_detected",
+                        ticker=ticker,
+                        date=str(spike_date.date()),
+                        pct=float(spike_row["pct_change_t"]),
+                        atr_mult=float(spike_row["atr_mult_t"]),
+                    )
+                    if active_flags:
+                        debug.log_event(
+                            "precursor_flags",
+                            ticker=ticker,
+                            date=str(spike_date.date()),
+                            flags=active_flags,
+                        )
+                except Exception:
+                    pass
+
+    if not spike_rows:
+        empty_df = pd.DataFrame(columns=["ticker", "spike_date"])
+        summary = {
+            "counts": {
+                "spikes": 0,
+                "tickers": len(universe_list),
+                "start": start_ts,
+                "end": end_ts,
+            },
+            "frequency_table": pd.DataFrame(
+                columns=["flag", "hit_count", "hit_rate", "median_lead_days"]
+            ),
+            "combos": pd.DataFrame(columns=["combo", "count", "lift"]),
+            "flag_metadata": flag_metadata,
+            "lookback_days": lookback_days,
+        }
+        return empty_df, summary
+
+    spikes_df = pd.DataFrame(spike_rows)
+    spikes_df = spikes_df.sort_values(["spike_date", "ticker"]).reset_index(drop=True)
+
+    for col in bool_columns:
+        if col in spikes_df.columns:
+            spikes_df[col] = spikes_df[col].fillna(False).astype(bool)
+
+    frequency_rows = []
+    total_spikes = len(spikes_df)
+
+    for flag in sorted(bool_columns):
+        if flag not in spikes_df.columns:
+            continue
+        hits_df = spikes_df[spikes_df[flag]]
+        hit_count = int(hits_df.shape[0])
+        hit_rate = float(hit_count / total_spikes) if total_spikes else 0.0
+        lead_col = lead_columns.get(flag)
+        median_lead = (
+            float(hits_df[lead_col].median())
+            if lead_col and lead_col in hits_df.columns and not hits_df.empty
+            else float("nan")
+        )
+        frequency_rows.append(
+            {
+                "flag": flag,
+                "hit_count": hit_count,
+                "hit_rate": hit_rate,
+                "median_lead_days": median_lead,
+            }
+        )
+
+    frequency_table = pd.DataFrame(frequency_rows).sort_values(
+        ["hit_rate", "hit_count"], ascending=[False, False]
+    )
+
+    lead_stats = {}
+    for flag, lead_col in lead_columns.items():
+        if lead_col in spikes_df.columns:
+            valid = spikes_df.loc[spikes_df[flag], lead_col].dropna()
+            if not valid.empty:
+                lead_stats[flag] = {
+                    "min": float(valid.min()),
+                    "median": float(valid.median()),
+                    "mean": float(valid.mean()),
+                    "max": float(valid.max()),
+                }
+
+    combos_df = pd.DataFrame(columns=["combo", "count", "lift"])
+    if total_spikes <= 5000 and len(bool_columns) >= 2:
+        records = []
+        flags_sorted = sorted([f for f in bool_columns if f in spikes_df.columns])
+        base_rates = {f: float(spikes_df[f].mean()) for f in flags_sorted}
+        for i, flag_a in enumerate(flags_sorted):
+            for flag_b in flags_sorted[i + 1 :]:
+                pair_mask = spikes_df[flag_a] & spikes_df[flag_b]
+                count = int(pair_mask.sum())
+                if count == 0:
+                    continue
+                rate = count / total_spikes if total_spikes else 0.0
+                expected = base_rates.get(flag_a, 0.0) * base_rates.get(flag_b, 0.0)
+                lift = rate / expected if expected > 0 else np.nan
+                records.append(
+                    {
+                        "combo": f"{flag_a} + {flag_b}",
+                        "count": count,
+                        "lift": float(lift) if np.isfinite(lift) else np.nan,
+                    }
+                )
+        if records:
+            combos_df = pd.DataFrame(records).sort_values(
+                "count", ascending=False
+            ).head(10)
+
+    summary = {
+        "counts": {
+            "spikes": total_spikes,
+            "tickers": int(spikes_df["ticker"].nunique()),
+            "start": start_ts,
+            "end": end_ts,
+        },
+        "frequency_table": frequency_table.reset_index(drop=True),
+        "combos": combos_df.reset_index(drop=True),
+        "lead_stats": lead_stats,
+        "flag_metadata": flag_metadata,
+        "lookback_days": lookback_days,
+    }
+
+    if debug and hasattr(debug, "log_event"):
+        try:
+            debug.log_event(
+                "summary:done",
+                spikes=total_spikes,
+                bool_flags=len(bool_columns),
+            )
+        except Exception:
+            pass
+
+    return spikes_df, summary
+

--- a/ui/pages/66_Spike_Precursor_Lab.py
+++ b/ui/pages/66_Spike_Precursor_Lab.py
@@ -1,0 +1,595 @@
+from __future__ import annotations
+
+import json
+import platform
+import traceback
+from datetime import datetime, timezone
+from typing import Any
+
+import pandas as pd
+import streamlit as st
+
+from data_lake.membership import load_membership
+from data_lake.storage import Storage
+
+from engine.spike_precursor import analyze_spike_precursors
+from ui.components.progress import status_block
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+class SpikeDebugCollector:
+    def __init__(self) -> None:
+        self.events: list[dict[str, Any]] = []
+        self.errors: list[dict[str, Any]] = []
+        self.metrics: dict[str, Any] = {}
+
+    def log_event(self, name: str, **data: Any) -> None:
+        self.events.append({"t": _utcnow_iso(), "name": name, "data": data})
+
+    def add_error(self, where: str, exc: BaseException) -> None:
+        self.errors.append(
+            {
+                "t": _utcnow_iso(),
+                "where": where,
+                "message": str(exc),
+                "traceback": "".join(
+                    traceback.format_exception(type(exc), exc, exc.__traceback__)
+                ),
+            }
+        )
+
+    def set_metrics(self, **metrics: Any) -> None:
+        self.metrics.update(metrics)
+
+
+def _render_debug_panel(
+    meta: dict[str, Any],
+    params: dict[str, Any],
+    env: dict[str, Any],
+    debug: SpikeDebugCollector,
+) -> None:
+    with st.expander("🐞 Debug panel", expanded=False):
+        st.caption("Everything below is for diagnostics. Safe to share (secrets redacted).")
+
+        c1, c2, c3 = st.columns(3)
+        c1.metric("Tickers analyzed", int(debug.metrics.get("tickers", 0)))
+        c2.metric("Spikes found", int(debug.metrics.get("spikes", 0)))
+        c3.metric("Flags tracked", int(debug.metrics.get("flags", 0)))
+
+        st.subheader("Event log")
+        events_df = pd.DataFrame(debug.events)
+        if not events_df.empty:
+            events_disp = events_df.copy()
+            events_disp["data"] = events_disp["data"].apply(
+                lambda val: json.dumps(val, default=str)
+                if isinstance(val, (dict, list))
+                else str(val)
+            )
+            st.dataframe(events_disp.tail(500), use_container_width=True, height=260)
+            st.download_button(
+                "Download events CSV",
+                events_disp.to_csv(index=False).encode("utf-8"),
+                file_name="spike_lab_events.csv",
+                mime="text/csv",
+            )
+        else:
+            st.write("No events logged.")
+
+        tabs = st.tabs(["meta", "params", "env", "errors"])
+        with tabs[0]:
+            st.json(meta)
+        with tabs[1]:
+            st.json(params)
+        with tabs[2]:
+            st.json(env)
+        with tabs[3]:
+            st.json(debug.errors)
+
+
+def _default_dates() -> tuple[pd.Timestamp, pd.Timestamp]:
+    end = pd.Timestamp.today().tz_localize(None).normalize()
+    start = end - pd.DateOffset(years=1)
+    return start, end
+
+
+def _load_universe(
+    storage: Storage, start: pd.Timestamp, end: pd.Timestamp
+) -> list[str]:
+    try:
+        members = load_membership(storage, cache_salt=storage.cache_salt())
+    except Exception:
+        return []
+
+    if members is None or members.empty:
+        return []
+
+    members = members.copy()
+    members["start_date"] = pd.to_datetime(
+        members["start_date"], errors="coerce"
+    ).dt.tz_localize(None)
+    members["end_date"] = pd.to_datetime(
+        members.get("end_date"), errors="coerce"
+    ).dt.tz_localize(None)
+
+    mask = (members["start_date"] <= end) & (
+        members["end_date"].isna() | (start <= members["end_date"])
+    )
+    filtered = members.loc[mask]
+    if filtered.empty:
+        return []
+    tickers = (
+        filtered["ticker"].astype(str).str.upper().str.strip().dropna().unique().tolist()
+    )
+    return sorted(tickers)
+
+
+def _clean_levels(text: str) -> list[float]:
+    parts = [p.strip() for p in (text or "").split(",") if p.strip()]
+    levels: list[float] = []
+    for part in parts:
+        try:
+            levels.append(float(part))
+        except Exception:
+            continue
+    return levels
+
+
+def page() -> None:
+    st.header("🚀 Spike Precursor Lab")
+    st.caption(
+        "Reverse-engineer what tends to precede big spikes, then export a rule preset to try in the shares-only scanner."
+    )
+
+    storage = Storage()
+    st.caption(f"storage: {storage.info()} mode={storage.mode}")
+
+    default_start, default_end = _default_dates()
+
+    debug = SpikeDebugCollector()
+
+    debug_meta: dict[str, Any] = {}
+    debug_env: dict[str, Any] = {"storage_mode": storage.mode, "storage_info": storage.info()}
+
+    with st.form("spike_precursor_form"):
+        date_cols = st.columns(2)
+        start_date = date_cols[0].date_input("Start date", value=default_start.date())
+        end_date = date_cols[1].date_input("End date", value=default_end.date())
+
+        use_sp_filter = bool(
+            st.checkbox("S&P 500 membership filter", value=True, help="Limit to tickers with membership overlaps the date range if data is available.")
+        )
+
+        spike_mode = st.radio(
+            "Spike definition",
+            options=("pct", "atr"),
+            index=0,
+            format_func=lambda opt: "Percent spike" if opt == "pct" else "ATR multiple",
+        )
+
+        pct_threshold = None
+        atr_multiple = None
+        atr_window = 14
+        atr_method = "wilder"
+
+        if spike_mode == "pct":
+            pct_threshold = float(
+                st.number_input(
+                    "Close change ≥ X% vs prior close",
+                    min_value=0.1,
+                    value=8.0,
+                    step=0.1,
+                )
+            )
+        else:
+            atr_cols = st.columns(3)
+            atr_multiple = float(
+                atr_cols[0].number_input(
+                    "Close change ≥ K × ATR",
+                    min_value=0.1,
+                    value=3.0,
+                    step=0.1,
+                )
+            )
+            atr_window = int(
+                atr_cols[1].number_input("ATR window", min_value=2, value=14, step=1)
+            )
+            atr_method = atr_cols[2].selectbox(
+                "ATR method",
+                options=("wilder", "sma", "ema"),
+                index=0,
+                format_func=lambda opt: opt.upper() if opt != "wilder" else "Wilder",
+            )
+
+        st.subheader("Optional spike-day filters")
+        volume_filter_enabled = st.checkbox(
+            "Require volume spike vs trailing window", value=False
+        )
+        volume_filter_threshold = 1.5
+        volume_filter_lookback = 63
+        if volume_filter_enabled:
+            vf_cols = st.columns(2)
+            volume_filter_threshold = float(
+                vf_cols[0].number_input(
+                    "Volume multiple threshold", min_value=0.5, value=1.5, step=0.1
+                )
+            )
+            volume_filter_lookback = int(
+                vf_cols[1].number_input(
+                    "Volume lookback (days)", min_value=5, value=63, step=1
+                )
+            )
+
+        lookback_days = int(
+            st.number_input("Precursor window (business days)", min_value=1, value=20, step=1)
+        )
+
+        st.subheader("Indicator panel")
+
+        trend_enabled = st.checkbox("Trend: EMA fast/slow cross", value=True)
+        trend_pair_text = "20,50"
+        if trend_enabled:
+            trend_pair_text = st.text_input(
+                "EMA periods (fast,slow)",
+                value="20,50",
+                help="Comma separated values like 20,50",
+            )
+        trend_fast, trend_slow = 20, 50
+        if trend_pair_text:
+            vals = _clean_levels(trend_pair_text)
+            if len(vals) >= 2:
+                trend_fast, trend_slow = int(vals[0]), int(vals[1])
+
+        rsi_enabled = st.checkbox("Momentum: RSI crosses", value=True)
+        rsi_levels_text = "50,60"
+        if rsi_enabled:
+            rsi_levels_text = st.text_input(
+                "RSI levels (comma separated)", value="50,60"
+            )
+        rsi_levels = _clean_levels(rsi_levels_text)
+        if not rsi_levels:
+            rsi_levels = [50.0, 60.0]
+
+        atr_squeeze_enabled = st.checkbox("Volatility: ATR compression", value=True)
+        atr_percentile = 25.0
+        atr_pct_window = 63
+        if atr_squeeze_enabled:
+            atr_sq_cols = st.columns(2)
+            atr_percentile = float(
+                atr_sq_cols[0].number_input(
+                    "ATR percentile threshold", min_value=1.0, value=25.0, step=1.0
+                )
+            )
+            atr_pct_window = int(
+                atr_sq_cols[1].number_input(
+                    "ATR percentile lookback", min_value=10, value=63, step=1
+                )
+            )
+
+        bb_enabled = st.checkbox("Bollinger: band width squeeze", value=True)
+        bb_percentile = 20.0
+        bb_pct_window = 126
+        bb_period = 20
+        if bb_enabled:
+            bb_cols = st.columns(3)
+            bb_period = int(
+                bb_cols[0].number_input("Bollinger period", min_value=5, value=20, step=1)
+            )
+            bb_percentile = float(
+                bb_cols[1].number_input(
+                    "Width percentile threshold", min_value=1.0, value=20.0, step=1.0
+                )
+            )
+            bb_pct_window = int(
+                bb_cols[2].number_input(
+                    "Percentile lookback", min_value=20, value=126, step=1
+                )
+            )
+
+        nr7_enabled = st.checkbox("Range: NR7 pattern", value=True)
+        nr7_window = 7
+        if nr7_enabled:
+            nr7_window = int(
+                st.number_input("NR7 lookback", min_value=3, value=7, step=1)
+            )
+
+        gap_enabled = st.checkbox("Gaps: prior-day gap ≥ g%", value=True)
+        gap_threshold = 3.0
+        if gap_enabled:
+            gap_threshold = float(
+                st.number_input("Gap threshold (%)", min_value=0.5, value=3.0, step=0.5)
+            )
+
+        volume_enabled = st.checkbox("Volume: day-1/day-2 multiples", value=True)
+        volume_threshold = 1.5
+        volume_lookback = 63
+        if volume_enabled:
+            vol_cols = st.columns(2)
+            volume_threshold = float(
+                vol_cols[0].number_input(
+                    "Volume multiple threshold", min_value=0.5, value=1.5, step=0.1
+                )
+            )
+            volume_lookback = int(
+                vol_cols[1].number_input(
+                    "Volume lookback", min_value=10, value=63, step=1
+                )
+            )
+
+        sr_enabled = st.checkbox("Support/Resistance ratio", value=True)
+        sr_threshold = 2.0
+        sr_lookback = 63
+        if sr_enabled:
+            sr_cols = st.columns(2)
+            sr_threshold = float(
+                sr_cols[0].number_input(
+                    "SR ratio threshold", min_value=0.5, value=2.0, step=0.1
+                )
+            )
+            sr_lookback = int(
+                sr_cols[1].number_input(
+                    "SR lookback", min_value=10, value=63, step=1
+                )
+            )
+
+        new_high_enabled = st.checkbox("New high breakout", value=True)
+        new_high_windows_text = "20,63"
+        if new_high_enabled:
+            new_high_windows_text = st.text_input(
+                "New high windows", value="20,63"
+            )
+        new_high_windows = [int(v) for v in _clean_levels(new_high_windows_text)] or [20, 63]
+
+        run_btn = st.form_submit_button("Run analysis", type="primary")
+
+    analysis_ran = False
+    spikes_df = pd.DataFrame()
+    summary: dict[str, Any] | None = None
+
+    params = {
+        "start_date": str(start_date),
+        "end_date": str(end_date),
+        "spike_mode": spike_mode,
+        "pct_threshold": pct_threshold,
+        "atr_multiple": atr_multiple,
+        "atr_window": atr_window,
+        "atr_method": atr_method,
+        "lookback_days": lookback_days,
+        "use_sp_filter": use_sp_filter,
+    }
+
+    indicator_config = {
+        "volume_filter": {
+            "enabled": volume_filter_enabled,
+            "threshold": volume_filter_threshold,
+            "lookback": volume_filter_lookback,
+        },
+        "trend": {
+            "enabled": trend_enabled,
+            "fast": trend_fast,
+            "slow": trend_slow,
+        },
+        "rsi": {
+            "enabled": rsi_enabled,
+            "period": 14,
+            "levels": rsi_levels,
+        },
+        "atr_squeeze": {
+            "enabled": atr_squeeze_enabled,
+            "percentile": atr_percentile,
+            "window": atr_pct_window,
+        },
+        "bb": {
+            "enabled": bb_enabled,
+            "percentile": bb_percentile,
+            "pct_window": bb_pct_window,
+            "period": bb_period,
+        },
+        "nr7": {
+            "enabled": nr7_enabled,
+            "window": nr7_window,
+        },
+        "gap": {
+            "enabled": gap_enabled,
+            "threshold": gap_threshold,
+        },
+        "volume": {
+            "enabled": volume_enabled,
+            "threshold": volume_threshold,
+            "lookback": volume_lookback,
+        },
+        "sr": {
+            "enabled": sr_enabled,
+            "threshold": sr_threshold,
+            "lookback": sr_lookback,
+        },
+        "new_high": {
+            "enabled": new_high_enabled,
+            "windows": new_high_windows,
+        },
+    }
+
+    if run_btn:
+        analysis_ran = True
+        start_ts = pd.Timestamp(start_date).tz_localize(None)
+        end_ts = pd.Timestamp(end_date).tz_localize(None)
+        if start_ts > end_ts:
+            start_ts, end_ts = end_ts, start_ts
+
+        universe: list[str] | None = None
+        if use_sp_filter:
+            universe = _load_universe(storage, start_ts, end_ts)
+            if not universe:
+                st.warning(
+                    "S&P membership table unavailable or empty. Falling back to all available tickers."
+                )
+                universe = None
+        debug_env.update(
+            {
+                "requested_universe": len(universe) if universe else 0,
+                "use_membership_filter": use_sp_filter,
+            }
+        )
+
+        debug_meta = {
+            "started": _utcnow_iso(),
+            "python": platform.python_version(),
+            "platform": platform.platform(),
+            "streamlit": getattr(st, "__version__", "unknown"),
+        }
+
+        status, prog, log_fn = status_block("Scanning price history", key_prefix="spike_lab")
+        try:
+            prog.progress(0.05)
+        except Exception:
+            pass
+        log_fn("Loading data and computing indicators…")
+
+        try:
+            spikes_df, summary = analyze_spike_precursors(
+                storage,
+                start=start_ts,
+                end=end_ts,
+                universe=universe,
+                spike_mode=spike_mode,
+                pct_threshold=pct_threshold,
+                atr_multiple=atr_multiple,
+                atr_window=atr_window,
+                atr_method=atr_method,
+                lookback_days=lookback_days,
+                indicator_config=indicator_config,
+                debug=debug,
+            )
+            try:
+                prog.progress(1.0)
+                status.update(label="Analysis complete", state="complete")
+            except Exception:
+                pass
+            log_fn(f"Detected {len(spikes_df)} spike events")
+        except Exception as exc:
+            debug.add_error("analysis", exc)
+            st.error(f"Analysis failed: {exc}")
+            log_fn(f"Error: {exc}")
+            summary = None
+        finally:
+            counts = summary.get("counts", {}) if summary else {}
+            debug.set_metrics(
+                tickers=int(counts.get("tickers", 0)),
+                spikes=int(counts.get("spikes", 0)),
+                flags=len(summary.get("flag_metadata", {})) if summary else 0,
+            )
+
+    if analysis_ran and summary:
+        counts = summary.get("counts", {})
+        st.markdown(
+            f"**Date span:** {pd.Timestamp(counts.get('start')).date()} → {pd.Timestamp(counts.get('end')).date()}  \\\n+**Tickers analyzed:** {counts.get('tickers', 0)}"
+        )
+        metrics_cols = st.columns(3)
+        metrics_cols[0].metric("Spikes found", counts.get("spikes", 0))
+        if not spikes_df.empty:
+            bool_cols = [
+                flag
+                for flag in summary.get("flag_metadata", {}).keys()
+                if flag in spikes_df.columns
+            ]
+            if bool_cols:
+                hit_counts = spikes_df[bool_cols].sum(axis=1)
+                median_flags = float(hit_counts.median())
+            else:
+                median_flags = 0.0
+        else:
+            median_flags = 0.0
+        metrics_cols[1].metric(
+            "Median flags per spike", f"{median_flags:.1f}" if median_flags else "0"
+        )
+        metrics_cols[2].metric("Lookback (days)", summary.get("lookback_days", lookback_days))
+
+        freq_df = summary.get("frequency_table")
+        if isinstance(freq_df, pd.DataFrame) and not freq_df.empty:
+            freq_display = freq_df.copy()
+            freq_display["hit_rate_%"] = freq_display["hit_rate"].apply(lambda x: round(x * 100.0, 2))
+            freq_display = freq_display.drop(columns=["hit_rate"])
+            st.subheader("Precursor frequencies")
+            st.dataframe(freq_display, use_container_width=True)
+        else:
+            st.info("No precursor flags met the criteria.")
+
+        combos_df = summary.get("combos")
+        if isinstance(combos_df, pd.DataFrame) and not combos_df.empty:
+            combos_disp = combos_df.copy()
+            combos_disp["lift"] = combos_disp["lift"].round(2)
+            st.subheader("Top 10 combos (pairs)")
+            st.dataframe(combos_disp, use_container_width=True)
+
+        if not spikes_df.empty:
+            st.subheader("Spike events (latest 500)")
+            display_df = spikes_df.sort_values("spike_date", ascending=False).head(500)
+            display_df = display_df.copy()
+            display_df["spike_date"] = pd.to_datetime(display_df["spike_date"]).dt.date
+            st.dataframe(display_df, use_container_width=True)
+            st.download_button(
+                "Download full CSV",
+                spikes_df.to_csv(index=False).encode("utf-8"),
+                file_name="spike_precursors.csv",
+                mime="text/csv",
+            )
+
+        freq_df = summary.get("frequency_table")
+        if isinstance(freq_df, pd.DataFrame) and not freq_df.empty:
+            st.subheader("Export rule preset")
+            threshold_pct = st.slider(
+                "Minimum hit rate for inclusion (%)", min_value=5, max_value=100, value=30, step=5
+            )
+            eligible = freq_df[freq_df["hit_rate"] >= threshold_pct / 100.0]
+            metadata = summary.get("flag_metadata", {})
+            lead_stats = summary.get("lead_stats", {})
+            if eligible.empty:
+                st.info("No flags meet the selected hit-rate threshold.")
+            else:
+                within_default = int(summary.get("lookback_days", lookback_days))
+                selected_flags: list[str] = []
+                for _, row in eligible.iterrows():
+                    flag = row["flag"]
+                    label = f"{flag} ({row['hit_rate'] * 100:.1f}% hits)"
+                    if st.checkbox(label, key=f"preset_{flag}"):
+                        selected_flags.append(flag)
+
+                if selected_flags:
+                    conditions = []
+                    for flag in selected_flags:
+                        meta = dict(metadata.get(flag, {"type": "custom", "flag": flag}))
+                        within_days = within_default
+                        stats = lead_stats.get(flag)
+                        if stats and stats.get("max"):
+                            within_days = max(
+                                within_days,
+                                int(max(1, round(float(stats.get("max")))))
+                            )
+                        meta["within_days"] = within_days
+                        if "flag" not in meta:
+                            meta["flag"] = flag
+                        conditions.append(meta)
+
+                    preset = {
+                        "name": datetime.utcnow().strftime(
+                            "precursor_preset_%Y%m%d_%H%M"
+                        ),
+                        "conditions": conditions,
+                    }
+                    preset_json = json.dumps(preset, indent=2)
+                    st.download_button(
+                        "Download preset JSON",
+                        preset_json.encode("utf-8"),
+                        file_name=f"{preset['name']}.json",
+                        mime="application/json",
+                    )
+                    st.caption(
+                        "You can load this preset from the Stock Scanner (Shares Only) pre-filters (if/when that page supports it)."
+                    )
+                else:
+                    st.info("Select at least one flag to export a preset.")
+
+    _render_debug_panel(debug_meta, params, debug_env, debug)
+


### PR DESCRIPTION
## Summary
- add an engine helper to analyse spike precursors with configurable spike rules and indicator flags
- introduce the new “🚀 Spike Precursor Lab” Streamlit page with spike definitions, precursor summaries, CSV export, and preset builder
- wire in progress logging plus the reusable debug panel to inspect processing metadata

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2cea5929c83329697e92e082c3042