### PR TITLE
Make spike precursor filters interactive outside form

### DIFF
--- a/ui/pages/65_Stock_Scanner_SharesOnly.py
+++ b/ui/pages/65_Stock_Scanner_SharesOnly.py
@@ -378,35 +378,289 @@ def page() -> None:
 
     default_start, default_end = _default_dates()
 
-    precursors_enabled = bool(session.get("scanner_precursor_enabled", False))
-    precursor_within_days = int(
-        session.get("scanner_precursor_within", PRECURSOR_DEFAULTS["lookback_days"])
+    # --- Spike Precursor Filters (outside the form so they react immediately) ---
+    default_enabled = bool(session.get("scanner_precursor_enabled", False))
+    precursors_enabled = st.checkbox(
+        "Enable Spike Precursor filters",
+        key="scanner_precursor_enabled",
+        value=default_enabled,
     )
-    precursor_logic_choice = str(session.get("scanner_precursor_logic", "ANY"))
-    precursor_atr_threshold = float(
-        session.get("scanner_precursor_atr_threshold", PRECURSOR_DEFAULTS["atr_pct_threshold"])
-    )
-    precursor_bb_threshold = float(
-        session.get("scanner_precursor_bb_threshold", PRECURSOR_DEFAULTS["bb_pct_threshold"])
-    )
-    precursor_gap_threshold = float(
-        session.get("scanner_precursor_gap_threshold", PRECURSOR_DEFAULTS["gap_min_pct"])
-    )
-    precursor_vol_threshold = float(
-        session.get("scanner_precursor_vol_threshold", PRECURSOR_DEFAULTS["vol_min_mult"])
-    )
-    ema_selected = bool(session.get("scanner_precursor_ema", False))
-    rsi50_selected = bool(session.get("scanner_precursor_rsi50", False))
-    rsi60_selected = bool(session.get("scanner_precursor_rsi60", False))
-    atr_selected = bool(session.get("scanner_precursor_atr", False))
-    bb_selected = bool(session.get("scanner_precursor_bb", False))
-    nr7_selected = bool(session.get("scanner_precursor_nr7", False))
-    gap_selected = bool(session.get("scanner_precursor_gap", False))
-    vol_d1_selected = bool(session.get("scanner_precursor_vol_d1", False))
-    vol_d2_selected = bool(session.get("scanner_precursor_vol_d2", False))
-    sr_selected = bool(session.get("scanner_precursor_sr", False))
-    new_high_20_selected = bool(session.get("scanner_precursor_high20", False))
-    new_high_63_selected = bool(session.get("scanner_precursor_high63", False))
+
+    with st.expander("Spike Precursor Filters (optional)", expanded=False):
+        disabled_children = not precursors_enabled
+
+        preset_upload = st.file_uploader(
+            "Import from Spike Lab preset",
+            type=["json"],
+            key="scanner_precursor_preset",
+        )
+        if preset_upload is not None:
+            applied_flags: list[str] = []
+            try:
+                preset_raw = preset_upload.read()
+                preset_data = json.loads(preset_raw.decode("utf-8")) if preset_raw else {}
+                conditions = preset_data.get("conditions") or []
+
+                FLAG_MAP: dict[str, tuple[str, bool]] = {
+                    "ema_20_50_cross_up": ("scanner_precursor_ema", True),
+                    "rsi_cross_50": ("scanner_precursor_rsi50", True),
+                    "rsi_cross_60": ("scanner_precursor_rsi60", True),
+                    "atr_squeeze": ("scanner_precursor_atr", True),
+                    "bb_squeeze": ("scanner_precursor_bb", True),
+                    "nr7": ("scanner_precursor_nr7", True),
+                    "gap_prior_day_pct": ("scanner_precursor_gap", True),
+                    "volume_multiple_d1": ("scanner_precursor_vol_d1", True),
+                    "volume_multiple_d2": ("scanner_precursor_vol_d2", True),
+                    "sr_ratio": ("scanner_precursor_sr", True),
+                    "new_high_20": ("scanner_precursor_high20", True),
+                    "new_high_63": ("scanner_precursor_high63", True),
+                }
+
+                ALIASES = {
+                    "ema20_50_cross_up": "ema_20_50_cross_up",
+                    "atr_squeeze_q": "atr_squeeze",
+                    "bb_squeeze_q": "bb_squeeze",
+                    "gap_pct": "gap_prior_day_pct",
+                    "gap_prior_ge_pct": "gap_prior_day_pct",
+                    "vol_d1": "volume_multiple_d1",
+                    "vol_d2": "volume_multiple_d2",
+                    "sr_ratio_gte": "sr_ratio",
+                }
+
+                def _normalize_flag(raw_flag: Any) -> str:
+                    flag_str = str(raw_flag or "").strip().lower()
+                    return ALIASES.get(flag_str, flag_str)
+
+                for cond in conditions:
+                    if isinstance(cond, dict):
+                        meta = cond
+                        raw_flag = cond.get("flag") or cond.get("type") or cond.get("id")
+                    else:
+                        meta = {}
+                        raw_flag = cond
+
+                    flag = _normalize_flag(raw_flag)
+                    if not flag or flag not in FLAG_MAP:
+                        continue
+
+                    state_key, state_value = FLAG_MAP[flag]
+                    session[state_key] = state_value
+                    applied_flags.append(flag)
+
+                    if flag == "atr_squeeze":
+                        pct = _safe_float(
+                            meta.get("percentile") if isinstance(meta, dict) else None
+                        )
+                        if pct is None and isinstance(meta, dict):
+                            pct = _safe_float(meta.get("q") or meta.get("threshold"))
+                        if pct is not None:
+                            session["scanner_precursor_atr_threshold"] = float(pct)
+                    elif flag == "bb_squeeze":
+                        pct = _safe_float(
+                            meta.get("percentile") if isinstance(meta, dict) else None
+                        )
+                        if pct is None and isinstance(meta, dict):
+                            pct = _safe_float(meta.get("q") or meta.get("threshold"))
+                        if pct is not None:
+                            session["scanner_precursor_bb_threshold"] = float(pct)
+                    elif flag == "gap_prior_day_pct" and isinstance(meta, dict):
+                        gap_pct = _safe_float(meta.get("threshold") or meta.get("pct"))
+                        if gap_pct is not None:
+                            session["scanner_precursor_gap_threshold"] = float(gap_pct)
+                    elif flag in {"volume_multiple_d1", "volume_multiple_d2"} and isinstance(meta, dict):
+                        vol_mult = _safe_float(meta.get("threshold") or meta.get("multiple"))
+                        if vol_mult is not None:
+                            session["scanner_precursor_vol_threshold"] = float(vol_mult)
+
+                    if isinstance(meta, dict) and meta.get("within_days") is not None:
+                        try:
+                            session["scanner_precursor_within"] = int(meta["within_days"])
+                        except (TypeError, ValueError):
+                            pass
+
+                preset_within = preset_data.get("within_days") or preset_data.get("lookback_days")
+                if preset_within is not None:
+                    try:
+                        session["scanner_precursor_within"] = int(preset_within)
+                    except (TypeError, ValueError):
+                        pass
+
+                preset_logic = preset_data.get("logic")
+                if isinstance(preset_logic, str):
+                    logic_val = preset_logic.strip().upper()
+                    if logic_val in {"ANY", "ALL"}:
+                        session["scanner_precursor_logic"] = logic_val
+
+                if applied_flags:
+                    flag_summary = ", ".join(sorted(set(applied_flags)))
+                    st.success(f"Preset applied: {flag_summary}")
+                    session["scanner_precursor_enabled"] = True
+                else:
+                    st.warning("Preset contained no supported precursor flags.")
+            except Exception:
+                st.error("Could not read preset JSON. Please check the file format.")
+
+            precursors_enabled = bool(session.get("scanner_precursor_enabled", False))
+            disabled_children = not precursors_enabled
+
+        within_default_raw = _safe_float(session.get("scanner_precursor_within"))
+        if within_default_raw is None:
+            within_default_raw = PRECURSOR_DEFAULTS["lookback_days"]
+        within_default = int(max(1, min(60, float(within_default_raw))))
+        session["scanner_precursor_within"] = st.slider(
+            "Look back within N business days",
+            min_value=1,
+            max_value=60,
+            value=within_default,
+            disabled=disabled_children,
+            key="scanner_precursor_within",
+        )
+
+        logic_options = ("ANY", "ALL")
+        logic_default = str(session.get("scanner_precursor_logic", "ANY")).upper()
+        if logic_default not in logic_options:
+            logic_default = "ANY"
+        logic_index = logic_options.index(logic_default)
+        session["scanner_precursor_logic"] = st.radio(
+            "Logic mode",
+            options=logic_options,
+            index=logic_index,
+            key="scanner_precursor_logic",
+            disabled=disabled_children,
+            horizontal=True,
+        )
+
+        st.markdown("**Trend & Momentum**")
+        trend_cols = st.columns(3)
+        trend_cols[0].checkbox(
+            "EMA 20/50 cross up",
+            key="scanner_precursor_ema",
+            disabled=disabled_children,
+        )
+        trend_cols[1].checkbox(
+            "RSI cross ≥ 50",
+            key="scanner_precursor_rsi50",
+            disabled=disabled_children,
+        )
+        trend_cols[2].checkbox(
+            "RSI cross ≥ 60",
+            key="scanner_precursor_rsi60",
+            disabled=disabled_children,
+        )
+
+        st.markdown("**Volatility squeezes**")
+        squeeze_cols = st.columns(2)
+        with squeeze_cols[0]:
+            st.checkbox(
+                "ATR percentile ≤",
+                key="scanner_precursor_atr",
+                disabled=disabled_children,
+            )
+            atr_default_raw = _safe_float(session.get("scanner_precursor_atr_threshold"))
+            if atr_default_raw is None:
+                atr_default_raw = PRECURSOR_DEFAULTS["atr_pct_threshold"]
+            atr_default = float(max(1.0, min(100.0, float(atr_default_raw))))
+            session["scanner_precursor_atr_threshold"] = st.number_input(
+                "ATR percentile",
+                min_value=1.0,
+                max_value=100.0,
+                step=1.0,
+                key="scanner_precursor_atr_threshold",
+                value=atr_default,
+                disabled=disabled_children
+                or not session.get("scanner_precursor_atr", False),
+            )
+        with squeeze_cols[1]:
+            st.checkbox(
+                "BB width percentile ≤",
+                key="scanner_precursor_bb",
+                disabled=disabled_children,
+            )
+            bb_default_raw = _safe_float(session.get("scanner_precursor_bb_threshold"))
+            if bb_default_raw is None:
+                bb_default_raw = PRECURSOR_DEFAULTS["bb_pct_threshold"]
+            bb_default = float(max(1.0, min(100.0, float(bb_default_raw))))
+            session["scanner_precursor_bb_threshold"] = st.number_input(
+                "BB percentile",
+                min_value=1.0,
+                max_value=100.0,
+                step=1.0,
+                key="scanner_precursor_bb_threshold",
+                value=bb_default,
+                disabled=disabled_children
+                or not session.get("scanner_precursor_bb", False),
+            )
+
+        st.markdown("**Range & breakouts**")
+        range_cols = st.columns(3)
+        range_cols[0].checkbox(
+            "NR7",
+            key="scanner_precursor_nr7",
+            disabled=disabled_children,
+        )
+        range_cols[1].checkbox(
+            "New high 20",
+            key="scanner_precursor_high20",
+            disabled=disabled_children,
+        )
+        range_cols[2].checkbox(
+            "New high 63",
+            key="scanner_precursor_high63",
+            disabled=disabled_children,
+        )
+
+        st.checkbox(
+            "Support/resistance ratio ≥ 2",
+            key="scanner_precursor_sr",
+            disabled=disabled_children,
+        )
+
+        st.markdown("**Gaps & volume**")
+        gv_cols = st.columns(2)
+        with gv_cols[0]:
+            st.checkbox(
+                "Prior-day gap ≥ %",
+                key="scanner_precursor_gap",
+                disabled=disabled_children,
+            )
+            gap_default_raw = _safe_float(session.get("scanner_precursor_gap_threshold"))
+            if gap_default_raw is None:
+                gap_default_raw = PRECURSOR_DEFAULTS["gap_min_pct"]
+            gap_default = float(max(0.0, float(gap_default_raw)))
+            session["scanner_precursor_gap_threshold"] = st.number_input(
+                "Gap percent",
+                min_value=0.0,
+                max_value=50.0,
+                step=0.5,
+                key="scanner_precursor_gap_threshold",
+                value=gap_default,
+                disabled=disabled_children
+                or not session.get("scanner_precursor_gap", False),
+            )
+        with gv_cols[1]:
+            vol_default_raw = _safe_float(session.get("scanner_precursor_vol_threshold"))
+            if vol_default_raw is None:
+                vol_default_raw = PRECURSOR_DEFAULTS["vol_min_mult"]
+            vol_default = float(max(0.1, float(vol_default_raw)))
+            session["scanner_precursor_vol_threshold"] = st.number_input(
+                "Volume multiple",
+                min_value=0.1,
+                max_value=20.0,
+                step=0.1,
+                key="scanner_precursor_vol_threshold",
+                value=vol_default,
+                disabled=disabled_children,
+            )
+            st.checkbox(
+                "Day -1 volume ≥ threshold",
+                key="scanner_precursor_vol_d1",
+                disabled=disabled_children,
+            )
+            st.checkbox(
+                "Day -2 volume ≥ threshold",
+                key="scanner_precursor_vol_d2",
+                disabled=disabled_children,
+            )
 
     with st.form("stock_scanner_form"):
         col_dates = st.columns(2)
@@ -477,296 +731,6 @@ def page() -> None:
             disabled=True,
             help="Whole shares only; trades skip when one share exceeds the cap.",
         )
-
-        with st.expander("Spike Precursor Filters (optional)", expanded=False):
-            default_enabled = bool(session.get("scanner_precursor_enabled", False))
-            precursors_enabled = st.checkbox(
-                "Enable Spike Precursor filters",
-                key="scanner_precursor_enabled",
-                value=default_enabled,
-            )
-            disabled_children = not precursors_enabled
-
-            preset_upload = st.file_uploader(
-                "Import from Spike Lab preset",
-                type=["json"],
-                key="scanner_precursor_preset",
-            )
-            if preset_upload is not None:
-                applied_flags: list[str] = []
-                try:
-                    preset_raw = preset_upload.read()
-                    preset_data = json.loads(preset_raw.decode("utf-8")) if preset_raw else {}
-                    conditions = preset_data.get("conditions") or []
-
-                    FLAG_MAP: dict[str, tuple[str, bool]] = {
-                        "ema_20_50_cross_up": ("scanner_precursor_ema", True),
-                        "rsi_cross_50": ("scanner_precursor_rsi50", True),
-                        "rsi_cross_60": ("scanner_precursor_rsi60", True),
-                        "atr_squeeze": ("scanner_precursor_atr", True),
-                        "bb_squeeze": ("scanner_precursor_bb", True),
-                        "nr7": ("scanner_precursor_nr7", True),
-                        "gap_prior_day_pct": ("scanner_precursor_gap", True),
-                        "volume_multiple_d1": ("scanner_precursor_vol_d1", True),
-                        "volume_multiple_d2": ("scanner_precursor_vol_d2", True),
-                        "sr_ratio": ("scanner_precursor_sr", True),
-                        "new_high_20": ("scanner_precursor_high20", True),
-                        "new_high_63": ("scanner_precursor_high63", True),
-                    }
-
-                    ALIASES = {
-                        "ema20_50_cross_up": "ema_20_50_cross_up",
-                        "atr_squeeze_q": "atr_squeeze",
-                        "bb_squeeze_q": "bb_squeeze",
-                        "gap_pct": "gap_prior_day_pct",
-                        "gap_prior_ge_pct": "gap_prior_day_pct",
-                        "vol_d1": "volume_multiple_d1",
-                        "vol_d2": "volume_multiple_d2",
-                        "sr_ratio_gte": "sr_ratio",
-                    }
-
-                    def _normalize_flag(raw_flag: Any) -> str:
-                        flag_str = str(raw_flag or "").strip().lower()
-                        return ALIASES.get(flag_str, flag_str)
-
-                    for cond in conditions:
-                        if isinstance(cond, dict):
-                            meta = cond
-                            raw_flag = cond.get("flag") or cond.get("type") or cond.get("id")
-                        else:
-                            meta = {}
-                            raw_flag = cond
-
-                        flag = _normalize_flag(raw_flag)
-                        if not flag or flag not in FLAG_MAP:
-                            continue
-
-                        state_key, state_value = FLAG_MAP[flag]
-                        st.session_state[state_key] = state_value
-                        applied_flags.append(flag)
-
-                        if flag == "atr_squeeze":
-                            pct = _safe_float(
-                                meta.get("percentile")
-                                if isinstance(meta, dict)
-                                else None
-                            )
-                            if pct is None and isinstance(meta, dict):
-                                pct = _safe_float(meta.get("q") or meta.get("threshold"))
-                            if pct is not None:
-                                st.session_state["scanner_precursor_atr_threshold"] = float(pct)
-                        elif flag == "bb_squeeze":
-                            pct = _safe_float(
-                                meta.get("percentile")
-                                if isinstance(meta, dict)
-                                else None
-                            )
-                            if pct is None and isinstance(meta, dict):
-                                pct = _safe_float(meta.get("q") or meta.get("threshold"))
-                            if pct is not None:
-                                st.session_state["scanner_precursor_bb_threshold"] = float(pct)
-                        elif flag == "gap_prior_day_pct" and isinstance(meta, dict):
-                            gap_pct = _safe_float(meta.get("threshold") or meta.get("pct"))
-                            if gap_pct is not None:
-                                st.session_state["scanner_precursor_gap_threshold"] = float(gap_pct)
-                        elif flag in {"volume_multiple_d1", "volume_multiple_d2"} and isinstance(meta, dict):
-                            vol_mult = _safe_float(meta.get("threshold") or meta.get("multiple"))
-                            if vol_mult is not None:
-                                st.session_state["scanner_precursor_vol_threshold"] = float(vol_mult)
-
-                        if isinstance(meta, dict) and meta.get("within_days") is not None:
-                            try:
-                                st.session_state["scanner_precursor_within"] = int(meta["within_days"])
-                            except (TypeError, ValueError):
-                                pass
-
-                    preset_within = preset_data.get("within_days") or preset_data.get("lookback_days")
-                    if preset_within is not None:
-                        try:
-                            st.session_state["scanner_precursor_within"] = int(preset_within)
-                        except (TypeError, ValueError):
-                            pass
-
-                    preset_logic = preset_data.get("logic")
-                    if isinstance(preset_logic, str):
-                        logic_val = preset_logic.strip().upper()
-                        if logic_val in {"ANY", "ALL"}:
-                            st.session_state["scanner_precursor_logic"] = logic_val
-
-                    if applied_flags:
-                        flag_summary = ", ".join(sorted(set(applied_flags)))
-                        st.success(f"Preset applied: {flag_summary}")
-                        st.session_state["scanner_precursor_enabled"] = True
-                    else:
-                        st.warning("Preset contained no supported precursor flags.")
-                except Exception:
-                    st.error("Could not read preset JSON. Please check the file format.")
-
-                precursors_enabled = bool(st.session_state.get("scanner_precursor_enabled", False))
-                disabled_children = not precursors_enabled
-
-            within_default_raw = _safe_float(session.get("scanner_precursor_within"))
-            if within_default_raw is None:
-                within_default_raw = PRECURSOR_DEFAULTS["lookback_days"]
-            within_default = int(max(1, min(60, float(within_default_raw))))
-            precursor_within_days = int(
-                st.slider(
-                    "Look back within N business days",
-                    min_value=1,
-                    max_value=60,
-                    value=within_default,
-                    key="scanner_precursor_within",
-                    disabled=disabled_children,
-                )
-            )
-            logic_options = ("ANY", "ALL")
-            logic_default = str(session.get("scanner_precursor_logic", "ANY")).upper()
-            if logic_default not in logic_options:
-                logic_default = "ANY"
-            logic_index = logic_options.index(logic_default)
-            precursor_logic_choice = st.radio(
-                "Logic mode",
-                options=logic_options,
-                index=logic_index,
-                key="scanner_precursor_logic",
-                disabled=disabled_children,
-                horizontal=True,
-            )
-
-            st.markdown("**Trend & Momentum**")
-            trend_cols = st.columns(3)
-            ema_selected = trend_cols[0].checkbox(
-                "EMA 20/50 cross up",
-                key="scanner_precursor_ema",
-                disabled=disabled_children,
-            )
-            rsi50_selected = trend_cols[1].checkbox(
-                "RSI cross ≥ 50",
-                key="scanner_precursor_rsi50",
-                disabled=disabled_children,
-            )
-            rsi60_selected = trend_cols[2].checkbox(
-                "RSI cross ≥ 60",
-                key="scanner_precursor_rsi60",
-                disabled=disabled_children,
-            )
-
-            st.markdown("**Volatility squeezes**")
-            squeeze_cols = st.columns(2)
-            with squeeze_cols[0]:
-                atr_selected = st.checkbox(
-                    "ATR percentile ≤",
-                    key="scanner_precursor_atr",
-                    disabled=disabled_children,
-                )
-                atr_default_raw = _safe_float(session.get("scanner_precursor_atr_threshold"))
-                if atr_default_raw is None:
-                    atr_default_raw = PRECURSOR_DEFAULTS["atr_pct_threshold"]
-                atr_default = float(max(1.0, min(100.0, float(atr_default_raw))))
-                precursor_atr_threshold = float(
-                    st.number_input(
-                        "ATR percentile",
-                        min_value=1.0,
-                        max_value=100.0,
-                        step=1.0,
-                        key="scanner_precursor_atr_threshold",
-                        value=atr_default,
-                        disabled=disabled_children or not atr_selected,
-                    )
-                )
-            with squeeze_cols[1]:
-                bb_selected = st.checkbox(
-                    "BB width percentile ≤",
-                    key="scanner_precursor_bb",
-                    disabled=disabled_children,
-                )
-                bb_default_raw = _safe_float(session.get("scanner_precursor_bb_threshold"))
-                if bb_default_raw is None:
-                    bb_default_raw = PRECURSOR_DEFAULTS["bb_pct_threshold"]
-                bb_default = float(max(1.0, min(100.0, float(bb_default_raw))))
-                precursor_bb_threshold = float(
-                    st.number_input(
-                        "BB percentile",
-                        min_value=1.0,
-                        max_value=100.0,
-                        step=1.0,
-                        key="scanner_precursor_bb_threshold",
-                        value=bb_default,
-                        disabled=disabled_children or not bb_selected,
-                    )
-                )
-
-            st.markdown("**Range & breakouts**")
-            range_cols = st.columns(3)
-            nr7_selected = range_cols[0].checkbox(
-                "NR7",
-                key="scanner_precursor_nr7",
-                disabled=disabled_children,
-            )
-            new_high_20_selected = range_cols[1].checkbox(
-                "New high 20",
-                key="scanner_precursor_high20",
-                disabled=disabled_children,
-            )
-            new_high_63_selected = range_cols[2].checkbox(
-                "New high 63",
-                key="scanner_precursor_high63",
-                disabled=disabled_children,
-            )
-
-            sr_selected = st.checkbox(
-                "Support/resistance ratio ≥ 2",
-                key="scanner_precursor_sr",
-                disabled=disabled_children,
-            )
-
-            st.markdown("**Gaps & volume**")
-            gv_cols = st.columns(2)
-            with gv_cols[0]:
-                gap_selected = st.checkbox(
-                    "Prior-day gap ≥ %",
-                    key="scanner_precursor_gap",
-                    disabled=disabled_children,
-                )
-                gap_default_raw = _safe_float(session.get("scanner_precursor_gap_threshold"))
-                if gap_default_raw is None:
-                    gap_default_raw = PRECURSOR_DEFAULTS["gap_min_pct"]
-                gap_default = float(max(0.0, float(gap_default_raw)))
-                precursor_gap_threshold = float(
-                    st.number_input(
-                        "Gap percent",
-                        min_value=0.0,
-                        step=0.5,
-                        key="scanner_precursor_gap_threshold",
-                        value=gap_default,
-                        disabled=disabled_children or not gap_selected,
-                    )
-                )
-            with gv_cols[1]:
-                vol_default_raw = _safe_float(session.get("scanner_precursor_vol_threshold"))
-                if vol_default_raw is None:
-                    vol_default_raw = PRECURSOR_DEFAULTS["vol_min_mult"]
-                vol_default = float(max(0.1, float(vol_default_raw)))
-                precursor_vol_threshold = float(
-                    st.number_input(
-                        "Volume multiple",
-                        min_value=0.1,
-                        step=0.1,
-                        key="scanner_precursor_vol_threshold",
-                        value=vol_default,
-                        disabled=disabled_children,
-                    )
-                )
-                vol_d1_selected = st.checkbox(
-                    "Day -1 volume ≥ threshold",
-                    key="scanner_precursor_vol_d1",
-                    disabled=disabled_children,
-                )
-                vol_d2_selected = st.checkbox(
-                    "Day -2 volume ≥ threshold",
-                    key="scanner_precursor_vol_d2",
-                    disabled=disabled_children,
-                )
 
         run_scan_btn = st.form_submit_button("Run scan", type="primary")
 


### PR DESCRIPTION
## Summary
- move the Spike Precursor filter controls outside the main form with a master toggle so widgets react immediately
- keep the preset importer writing into session state while disabling child widgets when the master toggle is off
- build the precursor payload for Run scan entirely from session state values

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5686094b88332b0c9bf5c8f12223b