### PR TITLE
feat: unify precursor lab diagnostics with scanner

### DIFF
--- a/backtest/precursor_eval.py
+++ b/backtest/precursor_eval.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pandas as pd
+
+from engine.scan_runner import StocksOnlyScanParams, run_scan
+
+
+@dataclass(frozen=True)
+class EvaluationResult:
+    diagnostics: pd.DataFrame
+    metrics: dict[str, Any]
+
+
+def _normalise_flags(value: Any) -> list[str]:
+    if isinstance(value, str):
+        parts = [segment.strip() for segment in value.split(",") if segment.strip()]
+        return parts
+    if isinstance(value, (list, tuple, set)):
+        return [str(v).strip() for v in value if str(v).strip()]
+    return []
+
+
+def evaluate_precursors_naive(
+    events_df: pd.DataFrame, within_days: int, logic: str
+) -> EvaluationResult:
+    if events_df is None or events_df.empty:
+        empty = pd.DataFrame(columns=["ticker", "signal_date", "spike_date", "flags_fired", "naive_spike_hit"])
+        return EvaluationResult(empty, {"total": 0, "spike_hits": 0, "precision": 0.0, "by_flag": {}})
+
+    working = events_df.copy()
+    if "signal_date" in working.columns:
+        working["signal_date"] = pd.to_datetime(working["signal_date"])
+    elif "date" in working.columns:
+        working["signal_date"] = pd.to_datetime(working["date"])
+    else:
+        working["signal_date"] = pd.NaT
+    if "spike_date" in working.columns:
+        working["spike_date"] = pd.to_datetime(working["spike_date"])
+    else:
+        working["spike_date"] = pd.NaT
+
+    if "flags_fired" not in working.columns:
+        working["flags_fired"] = [[] for _ in range(len(working))]
+    working["flags_fired"] = working["flags_fired"].apply(_normalise_flags)
+
+    within_days = max(int(within_days or 1), 1)
+    logic = str(logic or "ANY").upper()
+    if logic not in {"ANY", "ALL"}:
+        logic = "ANY"
+
+    def _spike_hit(row: pd.Series) -> bool:
+        spike_date = row.get("spike_date")
+        if pd.isna(spike_date):
+            return False
+        signal_date = row.get("signal_date")
+        if pd.isna(signal_date):
+            return False
+        delta = (pd.Timestamp(spike_date) - pd.Timestamp(signal_date)).days
+        return 0 <= delta <= within_days
+
+    working["naive_spike_hit"] = working.apply(_spike_hit, axis=1)
+
+    by_flag: dict[str, dict[str, Any]] = {}
+    for _, row in working.iterrows():
+        flags = row["flags_fired"] or []
+        if not flags:
+            continue
+        for flag in flags:
+            stats = by_flag.setdefault(flag, {"count": 0, "hits": 0})
+            stats["count"] += 1
+            if row["naive_spike_hit"]:
+                stats["hits"] += 1
+
+    total = int(len(working))
+    spike_hits = int(working["naive_spike_hit"].sum())
+    precision = float(spike_hits / total) if total else 0.0
+
+    for stats in by_flag.values():
+        count = max(1, stats["count"])
+        stats["precision"] = stats["hits"] / count
+
+    metrics = {
+        "total": total,
+        "spike_hits": spike_hits,
+        "precision": precision,
+        "logic": logic,
+        "within_days": within_days,
+        "by_flag": by_flag,
+    }
+
+    diagnostics = working[["ticker", "signal_date", "spike_date", "flags_fired", "naive_spike_hit"]]
+    return EvaluationResult(diagnostics, metrics)
+
+
+def evaluate_precursors_scanner_aligned(
+    events_df: pd.DataFrame, scan_params: StocksOnlyScanParams
+) -> EvaluationResult:
+    scan_result = run_scan(scan_params)
+    trades = scan_result["trades"].copy()
+    summary = scan_result["summary"]
+
+    diagnostics = pd.DataFrame(columns=["ticker", "signal_date", "entered_trade", "exit_reason", "pnl"])
+    if events_df is not None and not events_df.empty:
+        diagnostics = events_df.copy()
+        if "signal_date" in diagnostics.columns:
+            diagnostics["signal_date"] = pd.to_datetime(diagnostics["signal_date"])
+        elif "date" in diagnostics.columns:
+            diagnostics["signal_date"] = pd.to_datetime(diagnostics["date"])
+        else:
+            diagnostics["signal_date"] = pd.NaT
+        diagnostics["entered_trade"] = False
+        diagnostics["exit_reason"] = pd.NA
+        diagnostics["pnl"] = pd.NA
+        if "flags_fired" in diagnostics.columns:
+            diagnostics["flags_fired"] = diagnostics["flags_fired"].apply(_normalise_flags)
+        else:
+            diagnostics["flags_fired"] = [[] for _ in range(len(diagnostics))]
+        if not trades.empty:
+            trades = trades.copy()
+            trades["entry_date"] = pd.to_datetime(trades.get("entry_date"))
+            trades["ticker"] = trades.get("ticker").astype(str)
+            diagnostics["ticker"] = diagnostics.get("ticker").astype(str)
+            merged = diagnostics.merge(
+                trades[["ticker", "entry_date", "exit_reason", "pnl"]],
+                left_on=["ticker", "signal_date"],
+                right_on=["ticker", "entry_date"],
+                how="left",
+                suffixes=("", "_trade"),
+            )
+            diagnostics["entered_trade"] = merged["exit_reason_trade"].notna()
+            diagnostics["exit_reason"] = merged["exit_reason_trade"]
+            diagnostics["pnl"] = merged["pnl_trade"]
+
+    trades_taken = int(summary.get("trades", 0)) if isinstance(summary, dict) else 0
+    wins = int(summary.get("wins", 0)) if isinstance(summary, dict) else 0
+    win_rate = float(wins / trades_taken) if trades_taken else 0.0
+    candidates = int(summary.get("candidates", 0)) if isinstance(summary, dict) else 0
+    denom = candidates if candidates else (trades_taken or 1)
+    precision = float(trades_taken / denom) if denom else 0.0
+
+    metrics = {
+        "summary": summary,
+        "trades": trades,
+        "precision": precision,
+        "win_rate": win_rate,
+    }
+
+    return EvaluationResult(diagnostics, metrics)
+
+
+def build_diagnostic_table(naive: EvaluationResult, aligned: EvaluationResult) -> pd.DataFrame:
+    naive_precision = naive.metrics.get("precision", 0.0)
+    aligned_metrics = aligned.metrics.get("summary", {})
+    aligned_precision = aligned.metrics.get("precision", 0.0)
+    win_rate = aligned.metrics.get("win_rate", 0.0)
+    trades = aligned_metrics.get("trades", 0)
+    total = naive.metrics.get("total", 0)
+    trades_df = aligned.metrics.get("trades")
+    if isinstance(trades_df, pd.DataFrame) and "pnl" in trades_df.columns:
+        avg_pnl = float(trades_df["pnl"].mean())
+    else:
+        avg_pnl = float("nan")
+
+    rows = [
+        {"Metric": "Total precursor hits", "Naive": total, "Scanner-aligned": aligned_metrics.get("candidates", trades)},
+        {"Metric": "Spike precision", "Naive": round(naive_precision, 4), "Scanner-aligned": round(aligned_precision, 4)},
+        {"Metric": "Trade win rate", "Naive": "N/A", "Scanner-aligned": round(win_rate, 4)},
+        {"Metric": "Avg P/L per trade", "Naive": "N/A", "Scanner-aligned": avg_pnl},
+    ]
+    return pd.DataFrame(rows)
+
+
+__all__ = [
+    "EvaluationResult",
+    "evaluate_precursors_naive",
+    "evaluate_precursors_scanner_aligned",
+    "build_diagnostic_table",
+]

--- a/engine/precursor_rules.py
+++ b/engine/precursor_rules.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+from typing import Any
+
+from engine.scan_shared.precursor_flags import DEFAULT_PARAMS
+
+PRECURSOR_FLAG_KEYS = {
+    "scanner_precursor_ema": "ema_20_50_cross_up",
+    "scanner_precursor_rsi50": "rsi_cross_50",
+    "scanner_precursor_rsi60": "rsi_cross_60",
+    "scanner_precursor_atr": "atr_squeeze_pct",
+    "scanner_precursor_bb": "bb_squeeze_pct",
+    "scanner_precursor_nr7": "nr7",
+    "scanner_precursor_gap": "gap_up_ge_gpct_prev",
+    "scanner_precursor_vol_d1": "vol_mult_d1_ge_x",
+    "scanner_precursor_vol_d2": "vol_mult_d2_ge_x",
+    "scanner_precursor_sr": "sr_ratio_ge_2",
+    "scanner_precursor_high20": "new_high_20",
+    "scanner_precursor_high63": "new_high_63",
+}
+
+THRESHOLD_KEYS = {
+    "atr_squeeze_pct": ("scanner_precursor_atr_threshold", "max_percentile", 1.0, 100.0, DEFAULT_PARAMS["atr_pct_threshold"]),
+    "bb_squeeze_pct": ("scanner_precursor_bb_threshold", "max_percentile", 1.0, 100.0, DEFAULT_PARAMS["bb_pct_threshold"]),
+    "gap_up_ge_gpct_prev": ("scanner_precursor_gap_threshold", "min_gap_pct", 0.0, None, DEFAULT_PARAMS["gap_min_pct"]),
+    "vol_mult_d1_ge_x": ("scanner_precursor_vol_threshold", "min_mult", 0.1, None, DEFAULT_PARAMS["vol_min_mult"]),
+    "vol_mult_d2_ge_x": ("scanner_precursor_vol_threshold", "min_mult", 0.1, None, DEFAULT_PARAMS["vol_min_mult"]),
+}
+
+ALIASES = {
+    "ema20_50_cross_up": "ema_20_50_cross_up",
+    "atr_squeeze_q": "atr_squeeze_pct",
+    "bb_squeeze_q": "bb_squeeze_pct",
+    "gap_pct": "gap_up_ge_gpct_prev",
+    "gap_prior_ge_pct": "gap_up_ge_gpct_prev",
+    "vol_d1": "vol_mult_d1_ge_x",
+    "vol_d2": "vol_mult_d2_ge_x",
+    "sr_ratio_gte": "sr_ratio_ge_2",
+}
+
+
+def _coerce_float(value: Any, *, default: float, minimum: float | None = None, maximum: float | None = None) -> float:
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        result = float(default)
+    if minimum is not None:
+        result = max(minimum, result)
+    if maximum is not None:
+        result = min(maximum, result)
+    return result
+
+
+def _coerce_int(value: Any, *, default: int, minimum: int = 1) -> int:
+    try:
+        result = int(value)
+    except (TypeError, ValueError):
+        result = int(default)
+    if result < minimum:
+        result = minimum
+    return result
+
+
+def _ensure_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple, set)):
+        return [v for v in value if v is not None]
+    if isinstance(value, str):
+        return [value]
+    return []
+
+
+def build_conditions_from_session(ss: Any) -> dict[str, Any] | None:
+    if not getattr(ss, "get", None):
+        raise TypeError("session state-like object required")
+
+    if not ss.get("scanner_precursor_enabled", False):
+        return None
+
+    within_days = _coerce_int(
+        ss.get("scanner_precursor_within", DEFAULT_PARAMS["lookback_days"]),
+        default=DEFAULT_PARAMS["lookback_days"],
+        minimum=1,
+    )
+    logic = str(ss.get("scanner_precursor_logic", "ANY") or "ANY").upper()
+    if logic not in {"ANY", "ALL"}:
+        logic = "ANY"
+
+    conditions: list[dict[str, Any]] = []
+
+    for session_key, flag in PRECURSOR_FLAG_KEYS.items():
+        if not ss.get(session_key, False):
+            continue
+        payload: dict[str, Any] = {"flag": flag}
+        if flag in THRESHOLD_KEYS:
+            thresh_key, field, minimum, maximum, default = THRESHOLD_KEYS[flag]
+            value = _coerce_float(
+                ss.get(thresh_key, default),
+                default=default,
+                minimum=minimum,
+                maximum=maximum,
+            )
+            payload[field] = value
+        conditions.append(payload)
+
+    if not conditions:
+        return None
+
+    base_thresholds = {
+        "atr_pct_threshold": _coerce_float(
+            ss.get("scanner_precursor_atr_threshold", DEFAULT_PARAMS["atr_pct_threshold"]),
+            default=DEFAULT_PARAMS["atr_pct_threshold"],
+            minimum=1.0,
+            maximum=100.0,
+        ),
+        "bb_pct_threshold": _coerce_float(
+            ss.get("scanner_precursor_bb_threshold", DEFAULT_PARAMS["bb_pct_threshold"]),
+            default=DEFAULT_PARAMS["bb_pct_threshold"],
+            minimum=1.0,
+            maximum=100.0,
+        ),
+        "gap_min_pct": _coerce_float(
+            ss.get("scanner_precursor_gap_threshold", DEFAULT_PARAMS["gap_min_pct"]),
+            default=DEFAULT_PARAMS["gap_min_pct"],
+            minimum=0.0,
+        ),
+        "vol_min_mult": _coerce_float(
+            ss.get("scanner_precursor_vol_threshold", DEFAULT_PARAMS["vol_min_mult"]),
+            default=DEFAULT_PARAMS["vol_min_mult"],
+            minimum=0.1,
+        ),
+    }
+
+    return {
+        "enabled": True,
+        "within_days": within_days,
+        "logic": logic,
+        "conditions": conditions,
+        **base_thresholds,
+    }
+
+
+def apply_preset_to_session(preset_json: dict[str, Any], ss: Any) -> list[str]:
+    if not isinstance(preset_json, dict):
+        raise TypeError("Preset payload must be a dict")
+    if not getattr(ss, "__setitem__", None):
+        raise TypeError("Session state-like object required")
+
+    ss["scanner_precursor_enabled"] = True
+
+    logic = str(preset_json.get("logic", "ANY") or "ANY").upper()
+    if logic not in {"ANY", "ALL"}:
+        logic = "ANY"
+    ss["scanner_precursor_logic"] = logic
+
+    within_candidates: list[int] = []
+    applied_flags: list[str] = []
+
+    for flag_key in PRECURSOR_FLAG_KEYS:
+        ss[flag_key] = False
+
+    for condition in _ensure_list(preset_json.get("conditions")):
+        if isinstance(condition, dict):
+            raw_flag = str(condition.get("flag", "")).strip()
+            if not raw_flag:
+                continue
+            flag = ALIASES.get(raw_flag, raw_flag)
+            session_flag_key = None
+            for key, candidate in PRECURSOR_FLAG_KEYS.items():
+                if candidate == flag:
+                    session_flag_key = key
+                    break
+            if session_flag_key is None:
+                continue
+            ss[session_flag_key] = True
+            applied_flags.append(flag)
+            within_val = condition.get("within_days")
+            if within_val is not None:
+                within_candidates.append(_coerce_int(within_val, default=DEFAULT_PARAMS["lookback_days"]))
+            if flag in THRESHOLD_KEYS:
+                thresh_key, field, minimum, maximum, default = THRESHOLD_KEYS[flag]
+                raw_value = condition.get(field)
+                if raw_value is None:
+                    raw_value = condition.get("threshold")
+                ss[thresh_key] = _coerce_float(
+                    raw_value,
+                    default=default,
+                    minimum=minimum,
+                    maximum=maximum,
+                )
+        else:
+            flag = ALIASES.get(str(condition), str(condition))
+            for key, candidate in PRECURSOR_FLAG_KEYS.items():
+                if candidate == flag:
+                    ss[key] = True
+                    applied_flags.append(flag)
+                    break
+
+    if preset_json.get("within_days") is not None:
+        ss["scanner_precursor_within"] = _coerce_int(
+            preset_json.get("within_days"),
+            default=DEFAULT_PARAMS["lookback_days"],
+        )
+    elif within_candidates:
+        ss["scanner_precursor_within"] = max(within_candidates)
+    else:
+        ss.setdefault("scanner_precursor_within", DEFAULT_PARAMS["lookback_days"])
+
+    return applied_flags
+
+
+__all__ = [
+    "build_conditions_from_session",
+    "apply_preset_to_session",
+    "PRECURSOR_FLAG_KEYS",
+    "ALIASES",
+]

--- a/engine/scan_runner.py
+++ b/engine/scan_runner.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import dataclasses
+import logging
+import random
+from dataclasses import dataclass, asdict
+from typing import Any, Callable
+
+import numpy as np
+import pandas as pd
+
+from engine.stocks_only_scanner import (
+    DEFAULT_CASH_CAP as _DEFAULT_CASH_CAP,
+    ScanSummary as _LegacyScanSummary,
+    run_scan as _legacy_run_scan,
+)
+
+log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class StocksOnlyScanParams:
+    start: pd.Timestamp
+    end: pd.Timestamp
+    horizon_days: int
+    sr_lookback: int
+    sr_min_ratio: float
+    min_yup_pct: float
+    min_gap_pct: float
+    min_volume_multiple: float
+    volume_lookback: int
+    exit_model: str
+    atr_window: int
+    atr_method: str
+    tp_atr_multiple: float
+    sl_atr_multiple: float
+    use_sp_filter: bool
+    cash_per_trade: float = _DEFAULT_CASH_CAP
+    precursors: dict[str, Any] | None = None
+    seed: int | None = 42
+
+
+def _coerce_timestamp(value: Any) -> pd.Timestamp:
+    ts = pd.Timestamp(value)
+    if getattr(ts, "tzinfo", None) is not None:
+        ts = ts.tz_localize(None)
+    return ts.normalize()
+
+
+def _prepare_payload(params: StocksOnlyScanParams) -> dict[str, Any]:
+    payload = asdict(params)
+    payload["start"] = _coerce_timestamp(payload["start"])
+    payload["end"] = _coerce_timestamp(payload["end"])
+    payload.pop("seed", None)
+    return payload
+
+
+def _ensure_precursor_payload(raw: dict[str, Any] | None) -> dict[str, Any] | None:
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        return None
+    cleaned: dict[str, Any] = {str(k): v for k, v in raw.items()}
+    if not cleaned.get("enabled"):
+        return None
+    conditions = []
+    for condition in cleaned.get("conditions", []) or []:
+        if not isinstance(condition, dict):
+            continue
+        flag = str(condition.get("flag", "")).strip()
+        if not flag:
+            continue
+        entry = {"flag": flag}
+        if condition.get("max_percentile") is not None:
+            entry["max_percentile"] = float(condition.get("max_percentile"))
+        if condition.get("min_gap_pct") is not None:
+            entry["min_gap_pct"] = float(condition.get("min_gap_pct"))
+        if condition.get("min_mult") is not None:
+            entry["min_mult"] = float(condition.get("min_mult"))
+        conditions.append(entry)
+    if not conditions:
+        return None
+    cleaned["conditions"] = conditions
+    return cleaned
+
+
+def run_scan(
+    params: StocksOnlyScanParams,
+    *,
+    storage: Any | None = None,
+    prices_by_ticker: dict[str, pd.DataFrame] | None = None,
+    membership: pd.DataFrame | None = None,
+    progress: Callable[[int, int, str], None] | None = None,
+    debug: Any | None = None,
+) -> dict[str, Any]:
+    """Execute the unified shares-only backtest.
+
+    The implementation delegates to :mod:`engine.stocks_only_scanner` and wraps the
+    result into a deterministic, serialisable payload so the UI layers only need to
+    deal with a single structure.
+    """
+
+    if params.seed is not None:
+        np.random.seed(int(params.seed))
+        random.seed(int(params.seed))
+
+    payload = _prepare_payload(params)
+    payload["precursors"] = _ensure_precursor_payload(params.precursors)
+
+    legacy_kwargs: dict[str, Any] = {}
+    if storage is not None:
+        legacy_kwargs["storage"] = storage
+    if prices_by_ticker is not None:
+        legacy_kwargs["prices_by_ticker"] = prices_by_ticker
+    if membership is not None:
+        legacy_kwargs["membership"] = membership
+    if debug is not None:
+        legacy_kwargs["debug"] = debug
+    if progress is not None:
+        legacy_kwargs["progress"] = progress  # type: ignore[assignment]
+
+    log.debug("scan_runner payload=%s", payload)
+
+    trades_df, summary = _legacy_run_scan(payload, **legacy_kwargs)
+    if isinstance(summary, _LegacyScanSummary):
+        summary_dict = dataclasses.asdict(summary)
+    elif isinstance(summary, dict):
+        summary_dict = summary
+    else:
+        summary_dict = {
+            "start": payload["start"],
+            "end": payload["end"],
+        }
+
+    result = {
+        "summary": summary_dict,
+        "trades": trades_df.copy(),
+        "debug": {"seed": params.seed},
+    }
+    return result
+
+
+__all__ = ["StocksOnlyScanParams", "run_scan"]

--- a/tests/test_precursor_eval.py
+++ b/tests/test_precursor_eval.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+import pandas as pd
+
+import backtest.precursor_eval as eval_mod
+from backtest.precursor_eval import (
+    build_diagnostic_table,
+    evaluate_precursors_naive,
+    evaluate_precursors_scanner_aligned,
+)
+from engine.scan_runner import StocksOnlyScanParams
+
+
+def _sample_params() -> StocksOnlyScanParams:
+    return StocksOnlyScanParams(
+        start=pd.Timestamp("2023-01-01"),
+        end=pd.Timestamp("2023-01-10"),
+        horizon_days=5,
+        sr_lookback=20,
+        sr_min_ratio=2.0,
+        min_yup_pct=0.0,
+        min_gap_pct=0.0,
+        min_volume_multiple=1.0,
+        volume_lookback=20,
+        exit_model="atr",
+        atr_window=14,
+        atr_method="wilder",
+        tp_atr_multiple=1.0,
+        sl_atr_multiple=1.0,
+        use_sp_filter=False,
+        precursors=None,
+    )
+
+
+def test_scanner_aligned_invokes_run_scan(monkeypatch):
+    events_df = pd.DataFrame(
+        {
+            "ticker": ["AAA", "BBB"],
+            "signal_date": ["2023-01-03", "2023-01-04"],
+            "spike_date": ["2023-01-05", pd.NaT],
+            "flags_fired": [["atr_squeeze_pct"], ["gap_up_ge_gpct_prev"]],
+        }
+    )
+
+    called = {}
+
+    def stub_run_scan(params: StocksOnlyScanParams, **kwargs):
+        called["params"] = params
+        trades = pd.DataFrame(
+            {
+                "ticker": ["AAA"],
+                "entry_date": [pd.Timestamp("2023-01-03")],
+                "exit_reason": ["tp"],
+                "pnl": [0.1],
+            }
+        )
+        summary = {"trades": 1, "wins": 0, "candidates": 4, "start": params.start, "end": params.end}
+        return {"summary": summary, "trades": trades, "debug": {}}
+
+    monkeypatch.setattr(eval_mod, "run_scan", stub_run_scan)
+
+    naive = evaluate_precursors_naive(events_df, within_days=5, logic="ANY")
+    aligned = evaluate_precursors_scanner_aligned(events_df, _sample_params())
+
+    assert isinstance(called["params"], StocksOnlyScanParams)
+    assert naive.metrics["precision"] > aligned.metrics["precision"]
+
+    table = build_diagnostic_table(naive, aligned)
+    assert "Metric" in table.columns
+    assert len(table) >= 3
+
+
+def test_scan_runner_deterministic(monkeypatch):
+    def stub_run_scan(payload, **kwargs):
+        value = float(np.random.random())
+        trades = pd.DataFrame({"ticker": ["AAA"], "entry_date": [pd.Timestamp("2023-01-03")], "pnl": [value]})
+        summary = {
+            "start": payload["start"],
+            "end": payload["end"],
+            "trades": 1,
+            "wins": 1,
+            "total_pnl": value,
+            "candidates": 1,
+        }
+        return trades, summary
+
+    from engine import scan_runner
+
+    monkeypatch.setattr(scan_runner, "_legacy_run_scan", stub_run_scan)
+
+    params = _sample_params()
+
+    result1 = scan_runner.run_scan(params)
+    result2 = scan_runner.run_scan(params)
+
+    assert result1["trades"].equals(result2["trades"])
+    assert result1["summary"]["total_pnl"] == result2["summary"]["total_pnl"]
+
+    params_b = replace(params, seed=123)
+    result3 = scan_runner.run_scan(params_b)
+    assert result3["summary"]["total_pnl"] != result1["summary"]["total_pnl"]

--- a/tests/test_precursor_rules.py
+++ b/tests/test_precursor_rules.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import pytest
+
+from engine.precursor_rules import apply_preset_to_session, build_conditions_from_session
+
+
+class SessionDict(dict):
+    """Simple session_state stand-in supporting attribute access."""
+
+    def __getattr__(self, item: str):  # pragma: no cover - support streamlit style
+        try:
+            return self[item]
+        except KeyError as exc:  # pragma: no cover
+            raise AttributeError(item) from exc
+
+    def get(self, key, default=None):  # type: ignore[override]
+        return super().get(key, default)
+
+
+def test_apply_preset_sets_expected_keys():
+    session = SessionDict()
+    preset = {
+        "logic": "all",
+        "within_days": 7,
+        "conditions": [
+            {"flag": "atr_squeeze_q", "max_percentile": 15},
+            {"flag": "vol_d1", "min_mult": 2.0},
+        ],
+    }
+
+    applied = apply_preset_to_session(preset, session)
+
+    assert session["scanner_precursor_enabled"] is True
+    assert session["scanner_precursor_logic"] == "ALL"
+    assert session["scanner_precursor_within"] == 7
+    assert "atr_squeeze_pct" in applied
+    assert "vol_mult_d1_ge_x" in applied
+    assert session["scanner_precursor_atr_threshold"] == pytest.approx(15)
+    assert session["scanner_precursor_vol_threshold"] == pytest.approx(2.0)
+
+
+def test_build_conditions_from_session_round_trip():
+    session = SessionDict(
+        scanner_precursor_enabled=True,
+        scanner_precursor_within=10,
+        scanner_precursor_logic="ANY",
+        scanner_precursor_atr=True,
+        scanner_precursor_atr_threshold=20,
+        scanner_precursor_gap=True,
+        scanner_precursor_gap_threshold=4,
+        scanner_precursor_vol_d2=True,
+        scanner_precursor_vol_threshold=1.5,
+    )
+    payload = build_conditions_from_session(session)
+    assert payload is not None
+    assert payload["within_days"] == 10
+    assert payload["logic"] == "ANY"
+    flags = {cond["flag"] for cond in payload["conditions"]}
+    assert {"atr_squeeze_pct", "gap_up_ge_gpct_prev", "vol_mult_d2_ge_x"} <= flags
+    assert payload["atr_pct_threshold"] == pytest.approx(20.0)
+    assert payload["gap_min_pct"] == pytest.approx(4.0)
+    assert payload["vol_min_mult"] == pytest.approx(1.5)
+
+
+def test_build_conditions_returns_none_when_disabled():
+    session = SessionDict(scanner_precursor_enabled=False)
+    assert build_conditions_from_session(session) is None

--- a/tests/test_streamlit_state.py
+++ b/tests/test_streamlit_state.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+STREAMLIT_FILES = [
+    Path("ui/pages/65_Stock_Scanner_SharesOnly.py"),
+    Path("ui/pages/66_Spike_Precursor_Lab.py"),
+]
+
+
+@pytest.mark.parametrize("path", STREAMLIT_FILES)
+def test_no_session_state_double_write(path: Path) -> None:
+    content = path.read_text()
+    pattern = re.compile(r"st\.session_state\[[^\]]+\]\s*=\s*st\.")
+    assert not pattern.search(content), f"Found state double-write in {path}"

--- a/ui/components/precursor_controls.py
+++ b/ui/components/precursor_controls.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import streamlit as st
+
+from engine.precursor_rules import apply_preset_to_session
+from engine.scan_shared.precursor_flags import DEFAULT_PARAMS as PRECURSOR_DEFAULTS
+
+
+def _clamp(value: float, *, minimum: float, maximum: float | None = None) -> float:
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        result = float(minimum)
+    if maximum is not None:
+        result = min(maximum, result)
+    return max(minimum, result)
+
+
+def render_precursor_section(session: Any) -> None:
+    """Render the shared Spike Precursor controls used by lab + scanner pages."""
+
+    default_enabled = bool(session.get("scanner_precursor_enabled", False))
+    st.checkbox(
+        "Enable Spike Precursor filters",
+        key="scanner_precursor_enabled",
+        value=default_enabled,
+        help="When enabled, candidate trades must match at least one precursor flag.",
+    )
+
+    with st.expander("Spike Precursor Filters (optional)", expanded=False):
+        precursors_enabled = bool(session.get("scanner_precursor_enabled", False))
+        disabled_children = not precursors_enabled
+
+        preset_upload = st.file_uploader(
+            "Import from Spike Lab preset",
+            type=["json"],
+            key="scanner_precursor_preset",
+            help="Apply a preset exported from the Spike Precursor Lab.",
+        )
+        if preset_upload is not None:
+            try:
+                preset_raw = preset_upload.read()
+                preset_data = json.loads(preset_raw.decode("utf-8")) if preset_raw else {}
+                applied = apply_preset_to_session(preset_data, session)
+            except Exception:
+                st.error("Could not read preset JSON. Please check the file format.")
+            else:
+                if applied:
+                    st.success(
+                        "Preset applied: " + ", ".join(sorted({flag for flag in applied}))
+                    )
+                else:
+                    st.warning("Preset contained no supported precursor flags.")
+
+        slider_default = int(
+            max(
+                1,
+                min(
+                    60,
+                    float(
+                        session.get(
+                            "scanner_precursor_within", PRECURSOR_DEFAULTS["lookback_days"]
+                        )
+                        or 1
+                    ),
+                ),
+            )
+        )
+        st.slider(
+            "Look back within N business days",
+            min_value=1,
+            max_value=60,
+            value=slider_default,
+            key="scanner_precursor_within",
+            disabled=disabled_children,
+        )
+
+        logic_options = ("ANY", "ALL")
+        logic_default = str(session.get("scanner_precursor_logic", "ANY") or "ANY").upper()
+        if logic_default not in logic_options:
+            logic_default = "ANY"
+        st.radio(
+            "Logic mode",
+            options=logic_options,
+            index=logic_options.index(logic_default),
+            key="scanner_precursor_logic",
+            disabled=disabled_children,
+            horizontal=True,
+        )
+
+        st.markdown("**Trend & Momentum**")
+        trend_cols = st.columns(3)
+        trend_cols[0].checkbox(
+            "EMA 20/50 cross up",
+            key="scanner_precursor_ema",
+            disabled=disabled_children,
+        )
+        trend_cols[1].checkbox(
+            "RSI cross ≥ 50",
+            key="scanner_precursor_rsi50",
+            disabled=disabled_children,
+        )
+        trend_cols[2].checkbox(
+            "RSI cross ≥ 60",
+            key="scanner_precursor_rsi60",
+            disabled=disabled_children,
+        )
+
+        st.markdown("**Volatility squeezes**")
+        squeeze_cols = st.columns(2)
+        with squeeze_cols[0]:
+            st.checkbox(
+                "ATR percentile ≤",
+                key="scanner_precursor_atr",
+                disabled=disabled_children,
+            )
+            atr_value = _clamp(
+                session.get(
+                    "scanner_precursor_atr_threshold", PRECURSOR_DEFAULTS["atr_pct_threshold"]
+                ),
+                minimum=1.0,
+                maximum=100.0,
+            )
+            st.number_input(
+                "ATR percentile",
+                min_value=1.0,
+                max_value=100.0,
+                step=1.0,
+                value=float(atr_value),
+                key="scanner_precursor_atr_threshold",
+                disabled=disabled_children or not session.get("scanner_precursor_atr", False),
+            )
+        with squeeze_cols[1]:
+            st.checkbox(
+                "BB width percentile ≤",
+                key="scanner_precursor_bb",
+                disabled=disabled_children,
+            )
+            bb_value = _clamp(
+                session.get(
+                    "scanner_precursor_bb_threshold", PRECURSOR_DEFAULTS["bb_pct_threshold"]
+                ),
+                minimum=1.0,
+                maximum=100.0,
+            )
+            st.number_input(
+                "BB percentile",
+                min_value=1.0,
+                max_value=100.0,
+                step=1.0,
+                value=float(bb_value),
+                key="scanner_precursor_bb_threshold",
+                disabled=disabled_children or not session.get("scanner_precursor_bb", False),
+            )
+
+        st.markdown("**Range & breakouts**")
+        range_cols = st.columns(3)
+        range_cols[0].checkbox(
+            "NR7",
+            key="scanner_precursor_nr7",
+            disabled=disabled_children,
+        )
+        range_cols[1].checkbox(
+            "New high 20",
+            key="scanner_precursor_high20",
+            disabled=disabled_children,
+        )
+        range_cols[2].checkbox(
+            "New high 63",
+            key="scanner_precursor_high63",
+            disabled=disabled_children,
+        )
+
+        st.checkbox(
+            "Support/resistance ratio ≥ 2",
+            key="scanner_precursor_sr",
+            disabled=disabled_children,
+        )
+
+        st.markdown("**Gaps & volume**")
+        gv_cols = st.columns(2)
+        with gv_cols[0]:
+            st.checkbox(
+                "Prior-day gap ≥ %",
+                key="scanner_precursor_gap",
+                disabled=disabled_children,
+            )
+            gap_value = _clamp(
+                session.get(
+                    "scanner_precursor_gap_threshold", PRECURSOR_DEFAULTS["gap_min_pct"]
+                ),
+                minimum=0.0,
+            )
+            st.number_input(
+                "Gap percent",
+                min_value=0.0,
+                max_value=50.0,
+                step=0.5,
+                value=float(gap_value),
+                key="scanner_precursor_gap_threshold",
+                disabled=disabled_children or not session.get("scanner_precursor_gap", False),
+            )
+        with gv_cols[1]:
+            vol_value = _clamp(
+                session.get(
+                    "scanner_precursor_vol_threshold", PRECURSOR_DEFAULTS["vol_min_mult"]
+                ),
+                minimum=0.1,
+            )
+            st.number_input(
+                "Volume multiple",
+                min_value=0.1,
+                max_value=20.0,
+                step=0.1,
+                value=float(vol_value),
+                key="scanner_precursor_vol_threshold",
+                disabled=disabled_children,
+            )
+            st.checkbox(
+                "Day -1 volume ≥ threshold",
+                key="scanner_precursor_vol_d1",
+                disabled=disabled_children,
+            )
+            st.checkbox(
+                "Day -2 volume ≥ threshold",
+                key="scanner_precursor_vol_d2",
+                disabled=disabled_children,
+            )
+
+
+__all__ = ["render_precursor_section"]

--- a/ui/pages/66_Spike_Precursor_Lab.py
+++ b/ui/pages/66_Spike_Precursor_Lab.py
@@ -1,146 +1,220 @@
 from __future__ import annotations
 
-import json
-import platform
-import traceback
-from datetime import datetime, timezone
-from typing import Any
+import math
+from dataclasses import dataclass
+from typing import Sequence
 
 import pandas as pd
 import streamlit as st
+from pandas.tseries.offsets import BDay
 
+from backtest.precursor_eval import (
+    build_diagnostic_table,
+    evaluate_precursors_naive,
+    evaluate_precursors_scanner_aligned,
+)
 from data_lake.membership import load_membership
-from data_lake.storage import Storage
+from data_lake.storage import Storage, load_prices_cached
+from engine.precursor_rules import build_conditions_from_session
+from engine.scan_runner import StocksOnlyScanParams
+from engine.scan_shared.indicators import IndicatorConfig, ensure_datetime_index
+from engine.scan_shared.precursor_flags import (
+    DEFAULT_PARAMS as PRECURSOR_DEFAULTS,
+    build_precursor_flags,
+)
+from engine.stocks_only_scanner import DEFAULT_CASH_CAP
+from ui.components.precursor_controls import render_precursor_section
+from utils.io_export import export_diagnostics, export_trades
 
-from engine.spike_precursor import analyze_spike_precursors
-from ui.components.progress import status_block
+
+@dataclass(frozen=True)
+class SpikeDefinition:
+    mode: str
+    pct_threshold: float | None
+    atr_multiple: float | None
+    volume_filter_enabled: bool
+    volume_threshold: float
 
 
 def _utcnow_iso() -> str:
-    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
-
-
-class SpikeDebugCollector:
-    def __init__(self) -> None:
-        self.events: list[dict[str, Any]] = []
-        self.errors: list[dict[str, Any]] = []
-        self.metrics: dict[str, Any] = {}
-
-    def log_event(self, name: str, **data: Any) -> None:
-        self.events.append({"t": _utcnow_iso(), "name": name, "data": data})
-
-    def add_error(self, where: str, exc: BaseException) -> None:
-        self.errors.append(
-            {
-                "t": _utcnow_iso(),
-                "where": where,
-                "message": str(exc),
-                "traceback": "".join(
-                    traceback.format_exception(type(exc), exc, exc.__traceback__)
-                ),
-            }
-        )
-
-    def set_metrics(self, **metrics: Any) -> None:
-        self.metrics.update(metrics)
-
-
-def _render_debug_panel(
-    meta: dict[str, Any],
-    params: dict[str, Any],
-    env: dict[str, Any],
-    debug: SpikeDebugCollector,
-) -> None:
-    with st.expander("🐞 Debug panel", expanded=False):
-        st.caption("Everything below is for diagnostics. Safe to share (secrets redacted).")
-
-        c1, c2, c3 = st.columns(3)
-        c1.metric("Tickers analyzed", int(debug.metrics.get("tickers", 0)))
-        c2.metric("Spikes found", int(debug.metrics.get("spikes", 0)))
-        c3.metric("Flags tracked", int(debug.metrics.get("flags", 0)))
-
-        st.subheader("Event log")
-        events_df = pd.DataFrame(debug.events)
-        if not events_df.empty:
-            events_disp = events_df.copy()
-            events_disp["data"] = events_disp["data"].apply(
-                lambda val: json.dumps(val, default=str)
-                if isinstance(val, (dict, list))
-                else str(val)
-            )
-            st.dataframe(events_disp.tail(500), use_container_width=True, height=260)
-            st.download_button(
-                "Download events CSV",
-                events_disp.to_csv(index=False).encode("utf-8"),
-                file_name="spike_lab_events.csv",
-                mime="text/csv",
-            )
-        else:
-            st.write("No events logged.")
-
-        tabs = st.tabs(["meta", "params", "env", "errors"])
-        with tabs[0]:
-            st.json(meta)
-        with tabs[1]:
-            st.json(params)
-        with tabs[2]:
-            st.json(env)
-        with tabs[3]:
-            st.json(debug.errors)
+    return pd.Timestamp.utcnow().isoformat()
 
 
 def _default_dates() -> tuple[pd.Timestamp, pd.Timestamp]:
     end = pd.Timestamp.today().tz_localize(None).normalize()
-    start = end - pd.DateOffset(years=1)
+    start = end - pd.DateOffset(months=6)
     return start, end
 
 
-def _load_universe(
-    storage: Storage, start: pd.Timestamp, end: pd.Timestamp
+def _resolve_universe(
+    storage: Storage, *, use_sp_filter: bool, extra_tickers: Sequence[str] | None
 ) -> list[str]:
+    tickers: set[str] = set()
     try:
-        members = load_membership(storage, cache_salt=storage.cache_salt())
+        membership = load_membership(storage, cache_salt=storage.cache_salt())
     except Exception:
-        return []
+        membership = pd.DataFrame()
 
-    if members is None or members.empty:
-        return []
-
-    members = members.copy()
-    members["start_date"] = pd.to_datetime(
-        members["start_date"], errors="coerce"
-    ).dt.tz_localize(None)
-    members["end_date"] = pd.to_datetime(
-        members.get("end_date"), errors="coerce"
-    ).dt.tz_localize(None)
-
-    mask = (members["start_date"] <= end) & (
-        members["end_date"].isna() | (start <= members["end_date"])
-    )
-    filtered = members.loc[mask]
-    if filtered.empty:
-        return []
-    tickers = (
-        filtered["ticker"].astype(str).str.upper().str.strip().dropna().unique().tolist()
-    )
+    if use_sp_filter and membership is not None and not membership.empty:
+        tickers.update(
+            membership["ticker"].astype(str).str.upper().str.strip().dropna().tolist()
+        )
+    if extra_tickers:
+        tickers.update(str(t).upper().strip() for t in extra_tickers if t)
+    if not tickers and membership is not None and not membership.empty:
+        tickers.update(
+            membership["ticker"].astype(str).str.upper().str.strip().dropna().tolist()
+        )
     return sorted(tickers)
 
 
-def _clean_levels(text: str) -> list[float]:
-    parts = [p.strip() for p in (text or "").split(",") if p.strip()]
-    levels: list[float] = []
-    for part in parts:
-        try:
-            levels.append(float(part))
-        except Exception:
+def _prepare_precursor_params(raw: dict[str, float | int]) -> dict[str, float]:
+    return {
+        "atr_pct_threshold": float(
+            raw.get("atr_pct_threshold", PRECURSOR_DEFAULTS["atr_pct_threshold"])
+        ),
+        "bb_pct_threshold": float(
+            raw.get("bb_pct_threshold", PRECURSOR_DEFAULTS["bb_pct_threshold"])
+        ),
+        "gap_min_pct": float(raw.get("gap_min_pct", PRECURSOR_DEFAULTS["gap_min_pct"])),
+        "vol_min_mult": float(raw.get("vol_min_mult", PRECURSOR_DEFAULTS["vol_min_mult"])),
+        "lookback_days": int(raw.get("lookback_days", PRECURSOR_DEFAULTS["lookback_days"])),
+    }
+
+
+def _find_spike(
+    panel: pd.DataFrame,
+    event_date: pd.Timestamp,
+    *,
+    within_days: int,
+    definition: SpikeDefinition,
+) -> pd.Timestamp | pd.NaT:
+    if event_date not in panel.index:
+        return pd.NaT
+
+    window_end = event_date + BDay(max(1, within_days))
+    future = panel.loc[(panel.index > event_date) & (panel.index <= window_end)].copy()
+    if future.empty:
+        return pd.NaT
+
+    event_close = float(panel.loc[event_date, "close"])
+    if not math.isfinite(event_close) or event_close <= 0:
+        return pd.NaT
+
+    if definition.mode == "pct":
+        target_pct = float(definition.pct_threshold or 0.0)
+        pct_change = (future["close"] / event_close - 1.0) * 100.0
+        mask = pct_change >= target_pct
+    else:
+        atr_multiple = float(definition.atr_multiple or 0.0)
+        atr_value = float(panel.loc[event_date, "atr_value"]) if "atr_value" in panel else float("nan")
+        if not math.isfinite(atr_value) or atr_value <= 0:
+            return pd.NaT
+        diff = future["close"] - event_close
+        mask = diff >= (atr_multiple * atr_value)
+
+    if definition.volume_filter_enabled:
+        vol_col = future.get("vol_mult_raw")
+        if vol_col is not None:
+            mask &= vol_col >= float(definition.volume_threshold)
+
+    hits = future.loc[mask]
+    if hits.empty:
+        return pd.NaT
+    return pd.to_datetime(hits.index[0])
+
+
+def _generate_precursor_events(
+    storage: Storage,
+    *,
+    tickers: Sequence[str],
+    start: pd.Timestamp,
+    end: pd.Timestamp,
+    precursors: dict[str, object] | None,
+    definition: SpikeDefinition,
+) -> pd.DataFrame:
+    columns = ["ticker", "signal_date", "spike_date", "flags_fired"]
+    if not tickers or precursors is None:
+        return pd.DataFrame(columns=columns)
+
+    within_days = int(precursors.get("within_days", PRECURSOR_DEFAULTS["lookback_days"]))
+    base_params = _prepare_precursor_params(precursors)
+
+    config = IndicatorConfig()
+    pad_days = max(config.max_lookback, within_days + 5)
+    fetch_start = (start - BDay(int(pad_days))).tz_localize(None)
+    fetch_end = (end + BDay(int(within_days + 5))).tz_localize(None)
+
+    try:
+        prices = load_prices_cached(
+            storage,
+            tickers=list(tickers),
+            start=fetch_start,
+            end=fetch_end,
+        )
+    except Exception:
+        return pd.DataFrame(columns=columns)
+
+    if prices is None or prices.empty:
+        return pd.DataFrame(columns=columns)
+
+    events: list[dict[str, object]] = []
+    flag_conditions = precursors.get("conditions", []) or []
+    logic = str(precursors.get("logic", "ANY") or "ANY").upper()
+
+    for ticker, frame in prices.groupby("Ticker"):
+        ticker = str(ticker).upper()
+        panel = ensure_datetime_index(frame)
+        if panel.empty:
             continue
-    return levels
+        flags_panel, _ = build_precursor_flags(panel, params=base_params)
+        if flags_panel.empty:
+            continue
+        flags_panel = flags_panel.sort_index()
+        window = flags_panel.loc[(flags_panel.index >= start) & (flags_panel.index <= end)]
+        if window.empty:
+            continue
+
+        for event_date, row in window.iterrows():
+            hit_flags: list[str] = []
+            for condition in flag_conditions:
+                flag = str(condition.get("flag", ""))
+                if not flag:
+                    continue
+                if bool(row.get(flag, False)):
+                    hit_flags.append(flag)
+
+            if logic == "ALL":
+                if len(hit_flags) < len(flag_conditions):
+                    continue
+            else:
+                if not hit_flags:
+                    continue
+
+            spike_date = _find_spike(
+                flags_panel,
+                event_date,
+                within_days=within_days,
+                definition=definition,
+            )
+            events.append(
+                {
+                    "ticker": ticker,
+                    "signal_date": pd.to_datetime(event_date),
+                    "spike_date": pd.to_datetime(spike_date) if spike_date is not pd.NaT else pd.NaT,
+                    "flags_fired": sorted(set(hit_flags)),
+                }
+            )
+
+    if not events:
+        return pd.DataFrame(columns=columns)
+    return pd.DataFrame(events, columns=columns)
 
 
 def page() -> None:
     st.header("🚀 Spike Precursor Lab")
     st.caption(
-        "Reverse-engineer what tends to precede big spikes, then export a rule preset to try in the shares-only scanner."
+        "Evaluate precursor presets against real trades. Compare naive spike counts with scanner-aligned results."
     )
 
     storage = Storage()
@@ -148,646 +222,208 @@ def page() -> None:
 
     default_start, default_end = _default_dates()
 
-    debug = SpikeDebugCollector()
+    render_precursor_section(st.session_state)
 
-    debug_meta: dict[str, Any] = {}
-    debug_env: dict[str, Any] = {"storage_mode": storage.mode, "storage_info": storage.info()}
-
-    default_state = {
-        "spike_lab_spike_mode": "pct",
-        "spike_lab_pct_threshold": 8.0,
-        "spike_lab_atr_multiple": 3.0,
-        "spike_lab_atr_window": 14,
-        "spike_lab_atr_method": "wilder",
-        "spike_lab_volume_filter_enabled": False,
-        "spike_lab_volume_filter_threshold": 1.5,
-        "spike_lab_volume_filter_lookback": 63,
-        "spike_lab_lookback_days": 20,
-        "spike_lab_trend_enabled": False,
-        "spike_lab_trend_pair_text": "20,50",
-        "spike_lab_rsi_enabled": False,
-        "spike_lab_rsi_levels_text": "50,60",
-        "spike_lab_atr_squeeze_enabled": False,
-        "spike_lab_atr_percentile": 25.0,
-        "spike_lab_atr_pct_window": 63,
-        "spike_lab_bb_enabled": False,
-        "spike_lab_bb_period": 20,
-        "spike_lab_bb_percentile": 20.0,
-        "spike_lab_bb_pct_window": 126,
-        "spike_lab_nr7_enabled": False,
-        "spike_lab_nr7_window": 7,
-        "spike_lab_gap_enabled": False,
-        "spike_lab_gap_threshold": 3.0,
-        "spike_lab_volume_enabled": False,
-        "spike_lab_volume_threshold": 1.5,
-        "spike_lab_volume_lookback": 63,
-        "spike_lab_sr_enabled": False,
-        "spike_lab_sr_threshold": 2.0,
-        "spike_lab_sr_lookback": 63,
-        "spike_lab_new_high_enabled": False,
-        "spike_lab_new_high_windows_text": "20,63",
-    }
-
-    for key, value in default_state.items():
-        st.session_state.setdefault(key, value)
-
-    if st.button("Reset to defaults"):
-        for key, value in default_state.items():
-            st.session_state[key] = value
-        try:
-            st.rerun()
-        except AttributeError:
-            st.experimental_rerun()
-
-    with st.form("spike_precursor_form"):
+    with st.form("precursor_lab_form"):
         date_cols = st.columns(2)
         start_date = date_cols[0].date_input("Start date", value=default_start.date())
         end_date = date_cols[1].date_input("End date", value=default_end.date())
 
-        use_sp_filter = bool(
-            st.checkbox("S&P 500 membership filter", value=True, help="Limit to tickers with membership overlaps the date range if data is available.")
+        use_sp_filter = st.checkbox(
+            "Use S&P 500 membership filter",
+            value=True,
+            help="When enabled, restrict analysis to tickers present in the S&P 500 universe.",
+        )
+        extra_ticker_text = st.text_input(
+            "Additional tickers (comma separated)",
+            help="Optional: evaluate extra tickers alongside the membership universe.",
+        )
+        extra_tickers = [
+            token.strip()
+            for token in extra_ticker_text.split(",")
+            if token.strip()
+        ]
+
+        st.subheader("Scanner alignment settings")
+        horizon = int(st.number_input("Horizon (business days)", min_value=1, value=30, step=1))
+        sr_cols = st.columns(2)
+        sr_lookback = int(
+            sr_cols[0].number_input("SR lookback (days)", min_value=5, value=21, step=1)
+        )
+        sr_min_ratio = float(
+            sr_cols[1].number_input("Minimum SR ratio", min_value=0.5, value=2.0, step=0.1)
         )
 
-        spike_mode_options = ("pct", "atr")
-        current_mode = st.session_state.get("spike_lab_spike_mode", "pct")
-        mode_index = (
-            spike_mode_options.index(current_mode)
-            if current_mode in spike_mode_options
-            else 0
+        gap_cols = st.columns(3)
+        min_yup_pct = float(
+            gap_cols[0].number_input("Yesterday % up minimum", value=0.0, step=0.1)
         )
+        min_gap_pct = float(
+            gap_cols[1].number_input("Open gap minimum %", value=0.0, step=0.1)
+        )
+        min_volume_multiple = float(
+            gap_cols[2].number_input("Volume multiple minimum", value=1.0, step=0.1)
+        )
+
+        volume_lookback = int(
+            st.number_input("Volume lookback (days)", min_value=5, value=63, step=1)
+        )
+
+        exit_model = st.selectbox(
+            "Exit model",
+            options=("atr", "sr"),
+            index=0,
+            format_func=lambda opt: "ATR targets" if opt == "atr" else "Support/Resistance",
+        )
+        atr_cols = st.columns(3)
+        atr_window = int(atr_cols[0].number_input("ATR window", min_value=2, value=14, step=1))
+        atr_method = atr_cols[1].selectbox(
+            "ATR method",
+            options=("wilder", "sma", "ema"),
+            index=0,
+            format_func=lambda opt: "Wilder" if opt == "wilder" else opt.upper(),
+        )
+        tp_atr_multiple = float(atr_cols[2].number_input("TP ATR multiple", value=1.0, step=0.1))
+        sl_atr_multiple = float(
+            st.number_input("SL ATR multiple", min_value=0.1, value=1.0, step=0.1)
+        )
+
+        st.subheader("Spike definition")
         spike_mode = st.radio(
-            "Spike definition",
-            options=spike_mode_options,
-            index=mode_index,
-            key="spike_lab_spike_mode",
+            "Spike mode",
+            options=("pct", "atr"),
+            index=0,
             format_func=lambda opt: "Percent spike" if opt == "pct" else "ATR multiple",
         )
-
-        pct_threshold_value: float | None = None
-        atr_multiple_value: float | None = None
-        atr_window_value = int(st.session_state.get("spike_lab_atr_window", 14))
-        atr_method_value = st.session_state.get("spike_lab_atr_method", "wilder")
-
+        pct_threshold = None
+        atr_multiple = None
         if spike_mode == "pct":
-            pct_threshold_value = float(
+            pct_threshold = float(
                 st.number_input(
                     "Close change ≥ X% vs prior close",
                     min_value=0.1,
+                    value=8.0,
                     step=0.1,
-                    key="spike_lab_pct_threshold",
                 )
             )
-            atr_multiple_value = None
         else:
-            atr_cols = st.columns(3)
-            atr_multiple_value = float(
-                atr_cols[0].number_input(
-                    "Close change ≥ K × ATR",
-                    min_value=0.1,
-                    step=0.1,
-                    key="spike_lab_atr_multiple",
-                )
+            atr_multiple = float(
+                st.number_input("Close change ≥ K × ATR", min_value=0.1, value=3.0, step=0.1)
             )
-            atr_window_value = int(
-                atr_cols[1].number_input(
-                    "ATR window",
-                    min_value=2,
-                    step=1,
-                    key="spike_lab_atr_window",
-                )
-            )
-            atr_method_value = atr_cols[2].selectbox(
-                "ATR method",
-                options=("wilder", "sma", "ema"),
-                key="spike_lab_atr_method",
-                format_func=lambda opt: opt.upper() if opt != "wilder" else "Wilder",
-            )
-            pct_threshold_value = None
 
-        st.subheader("Optional spike-day filters")
         volume_filter_enabled = st.checkbox(
-            "Require volume spike vs trailing window",
-            key="spike_lab_volume_filter_enabled",
+            "Require spike-day volume multiple",
+            value=False,
+            help="When enabled, spike days must exceed the selected volume multiple threshold.",
         )
         volume_filter_threshold = float(
-            st.session_state.get("spike_lab_volume_filter_threshold", 1.5)
-        )
-        volume_filter_lookback = int(
-            st.session_state.get("spike_lab_volume_filter_lookback", 63)
-        )
-        if volume_filter_enabled:
-            vf_cols = st.columns(2)
-            volume_filter_threshold = float(
-                vf_cols[0].number_input(
-                    "Volume multiple threshold",
-                    min_value=0.5,
-                    step=0.1,
-                    key="spike_lab_volume_filter_threshold",
-                )
-            )
-            volume_filter_lookback = int(
-                vf_cols[1].number_input(
-                    "Volume lookback (days)",
-                    min_value=5,
-                    step=1,
-                    key="spike_lab_volume_filter_lookback",
-                )
-            )
-
-        lookback_days = int(
-            st.number_input(
-                "Precursor window (business days)",
-                min_value=1,
-                step=1,
-                key="spike_lab_lookback_days",
-            )
+            st.number_input("Volume multiple threshold", min_value=0.5, value=1.5, step=0.1)
         )
 
-        st.subheader("Indicator panel")
+        run_btn = st.form_submit_button("Run diagnostics", type="primary")
 
-        trend_enabled = st.checkbox(
-            "Trend: EMA fast/slow cross", key="spike_lab_trend_enabled"
-        )
-        trend_pair_text = st.session_state.get("spike_lab_trend_pair_text", "20,50")
-        if trend_enabled:
-            trend_pair_text = st.text_input(
-                "EMA periods (fast,slow)",
-                key="spike_lab_trend_pair_text",
-                help="Comma separated values like 20,50",
-            )
-        trend_fast, trend_slow = 20, 50
-        if trend_pair_text:
-            vals = _clean_levels(trend_pair_text)
-            if len(vals) >= 2:
-                trend_fast, trend_slow = int(vals[0]), int(vals[1])
+    if not run_btn:
+        return
 
-        rsi_enabled = st.checkbox("Momentum: RSI crosses", key="spike_lab_rsi_enabled")
-        rsi_levels_text = st.session_state.get("spike_lab_rsi_levels_text", "50,60")
-        if rsi_enabled:
-            rsi_levels_text = st.text_input(
-                "RSI levels (comma separated)", key="spike_lab_rsi_levels_text"
-            )
-        rsi_levels = _clean_levels(rsi_levels_text)
-        if not rsi_levels:
-            rsi_levels = [50.0, 60.0]
+    start_ts = pd.Timestamp(start_date).tz_localize(None)
+    end_ts = pd.Timestamp(end_date).tz_localize(None)
+    if end_ts < start_ts:
+        st.error("End date must be on or after the start date.")
+        return
 
-        atr_squeeze_enabled = st.checkbox(
-            "Volatility: ATR compression", key="spike_lab_atr_squeeze_enabled"
-        )
-        atr_percentile = float(
-            st.session_state.get("spike_lab_atr_percentile", 25.0)
-        )
-        atr_pct_window = int(st.session_state.get("spike_lab_atr_pct_window", 63))
-        if atr_squeeze_enabled:
-            atr_sq_cols = st.columns(2)
-            atr_percentile = float(
-                atr_sq_cols[0].number_input(
-                    "ATR percentile threshold",
-                    min_value=1.0,
-                    step=1.0,
-                    key="spike_lab_atr_percentile",
-                )
-            )
-            atr_pct_window = int(
-                atr_sq_cols[1].number_input(
-                    "ATR percentile lookback",
-                    min_value=10,
-                    step=1,
-                    key="spike_lab_atr_pct_window",
-                )
-            )
+    precursors_payload = build_conditions_from_session(st.session_state)
+    tickers = _resolve_universe(storage, use_sp_filter=use_sp_filter, extra_tickers=extra_tickers)
 
-        bb_enabled = st.checkbox(
-            "Bollinger: band width squeeze", key="spike_lab_bb_enabled"
-        )
-        bb_period = int(st.session_state.get("spike_lab_bb_period", 20))
-        bb_percentile = float(
-            st.session_state.get("spike_lab_bb_percentile", 20.0)
-        )
-        bb_pct_window = int(st.session_state.get("spike_lab_bb_pct_window", 126))
-        if bb_enabled:
-            bb_cols = st.columns(3)
-            bb_period = int(
-                bb_cols[0].number_input(
-                    "Bollinger period",
-                    min_value=5,
-                    step=1,
-                    key="spike_lab_bb_period",
-                )
-            )
-            bb_percentile = float(
-                bb_cols[1].number_input(
-                    "Width percentile threshold",
-                    min_value=1.0,
-                    step=1.0,
-                    key="spike_lab_bb_percentile",
-                )
-            )
-            bb_pct_window = int(
-                bb_cols[2].number_input(
-                    "Percentile lookback",
-                    min_value=20,
-                    step=1,
-                    key="spike_lab_bb_pct_window",
-                )
-            )
+    spike_definition = SpikeDefinition(
+        mode=spike_mode,
+        pct_threshold=pct_threshold,
+        atr_multiple=atr_multiple,
+        volume_filter_enabled=volume_filter_enabled,
+        volume_threshold=volume_filter_threshold,
+    )
 
-        nr7_enabled = st.checkbox("Range: NR7 pattern", key="spike_lab_nr7_enabled")
-        nr7_window = int(st.session_state.get("spike_lab_nr7_window", 7))
-        if nr7_enabled:
-            nr7_window = int(
-                st.number_input(
-                    "NR7 lookback",
-                    min_value=3,
-                    step=1,
-                    key="spike_lab_nr7_window",
-                )
-            )
+    events_df = _generate_precursor_events(
+        storage,
+        tickers=tickers,
+        start=start_ts,
+        end=end_ts,
+        precursors=precursors_payload,
+        definition=spike_definition,
+    )
 
-        gap_enabled = st.checkbox("Gaps: prior-day gap ≥ g%", key="spike_lab_gap_enabled")
-        gap_threshold = float(st.session_state.get("spike_lab_gap_threshold", 3.0))
-        if gap_enabled:
-            gap_threshold = float(
-                st.number_input(
-                    "Gap threshold (%)",
-                    min_value=0.5,
-                    step=0.5,
-                    key="spike_lab_gap_threshold",
-                )
-            )
+    within_days = int(
+        precursors_payload.get("within_days", PRECURSOR_DEFAULTS["lookback_days"])
+        if precursors_payload
+        else PRECURSOR_DEFAULTS["lookback_days"]
+    )
+    logic = str(
+        precursors_payload.get("logic", "ANY") if precursors_payload else "ANY"
+    ).upper()
 
-        volume_enabled = st.checkbox(
-            "Volume: day-1/day-2 multiples", key="spike_lab_volume_enabled"
-        )
-        volume_threshold = float(
-            st.session_state.get("spike_lab_volume_threshold", 1.5)
-        )
-        volume_lookback = int(st.session_state.get("spike_lab_volume_lookback", 63))
-        if volume_enabled:
-            vol_cols = st.columns(2)
-            volume_threshold = float(
-                vol_cols[0].number_input(
-                    "Volume multiple threshold",
-                    min_value=0.5,
-                    step=0.1,
-                    key="spike_lab_volume_threshold",
-                )
-            )
-            volume_lookback = int(
-                vol_cols[1].number_input(
-                    "Volume lookback",
-                    min_value=10,
-                    step=1,
-                    key="spike_lab_volume_lookback",
-                )
-            )
+    naive_result = evaluate_precursors_naive(events_df, within_days=within_days, logic=logic)
 
-        sr_enabled = st.checkbox("Support/Resistance ratio", key="spike_lab_sr_enabled")
-        sr_threshold = float(st.session_state.get("spike_lab_sr_threshold", 2.0))
-        sr_lookback = int(st.session_state.get("spike_lab_sr_lookback", 63))
-        if sr_enabled:
-            sr_cols = st.columns(2)
-            sr_threshold = float(
-                sr_cols[0].number_input(
-                    "SR ratio threshold",
-                    min_value=0.5,
-                    step=0.1,
-                    key="spike_lab_sr_threshold",
-                )
-            )
-            sr_lookback = int(
-                sr_cols[1].number_input(
-                    "SR lookback",
-                    min_value=10,
-                    step=1,
-                    key="spike_lab_sr_lookback",
-                )
-            )
+    scan_params = StocksOnlyScanParams(
+        start=start_ts,
+        end=end_ts,
+        horizon_days=horizon,
+        sr_lookback=sr_lookback,
+        sr_min_ratio=sr_min_ratio,
+        min_yup_pct=min_yup_pct,
+        min_gap_pct=min_gap_pct,
+        min_volume_multiple=min_volume_multiple,
+        volume_lookback=volume_lookback,
+        exit_model=exit_model,
+        atr_window=atr_window,
+        atr_method=atr_method,
+        tp_atr_multiple=tp_atr_multiple,
+        sl_atr_multiple=sl_atr_multiple,
+        use_sp_filter=use_sp_filter,
+        cash_per_trade=DEFAULT_CASH_CAP,
+        precursors=precursors_payload,
+    )
 
-        new_high_enabled = st.checkbox(
-            "New high breakout", key="spike_lab_new_high_enabled"
-        )
-        new_high_windows_text = st.session_state.get(
-            "spike_lab_new_high_windows_text", "20,63"
-        )
-        if new_high_enabled:
-            new_high_windows_text = st.text_input(
-                "New high windows", key="spike_lab_new_high_windows_text"
-            )
-        new_high_windows = [int(v) for v in _clean_levels(new_high_windows_text)] or [20, 63]
+    aligned_result = evaluate_precursors_scanner_aligned(events_df, scan_params)
 
-        run_btn = st.form_submit_button("Run analysis", type="primary")
+    summary = aligned_result.metrics.get("summary", {})
+    trades_df = aligned_result.metrics.get("trades", pd.DataFrame())
 
-    analysis_ran = False
-    spikes_df = pd.DataFrame()
-    summary: dict[str, Any] | None = None
-    effective_config: dict[str, Any] | None = None
+    diag_table = build_diagnostic_table(naive_result, aligned_result)
 
-    pct_threshold_active = pct_threshold_value if spike_mode == "pct" else None
-    atr_multiple_active = atr_multiple_value if spike_mode == "atr" else None
+    st.subheader("Diagnostic comparison")
+    st.dataframe(diag_table, use_container_width=True)
 
-    params = {
-        "start_date": str(start_date),
-        "end_date": str(end_date),
-        "spike_mode": spike_mode,
-        "pct_threshold": pct_threshold_active,
-        "atr_multiple": atr_multiple_active,
-        "atr_window": atr_window_value,
-        "atr_method": atr_method_value,
-        "lookback_days": lookback_days,
-        "use_sp_filter": use_sp_filter,
-    }
-
-    volume_filter_payload: dict[str, Any] | None = None
-    if volume_filter_enabled:
-        volume_filter_payload = {
-            "enabled": True,
-            "threshold": volume_filter_threshold,
-            "lookback": volume_filter_lookback,
-        }
-
-    indicator_config: dict[str, Any] = {}
-    if volume_filter_payload:
-        indicator_config["volume_filter"] = volume_filter_payload
-    if trend_enabled:
-        indicator_config["trend"] = {
-            "enabled": True,
-            "fast": trend_fast,
-            "slow": trend_slow,
-        }
-    if rsi_enabled:
-        indicator_config["rsi"] = {
-            "enabled": True,
-            "period": 14,
-            "levels": rsi_levels,
-        }
-    if atr_squeeze_enabled:
-        indicator_config["atr_squeeze"] = {
-            "enabled": True,
-            "percentile": atr_percentile,
-            "window": atr_pct_window,
-        }
-    if bb_enabled:
-        indicator_config["bb"] = {
-            "enabled": True,
-            "percentile": bb_percentile,
-            "pct_window": bb_pct_window,
-            "period": bb_period,
-        }
-    if nr7_enabled:
-        indicator_config["nr7"] = {
-            "enabled": True,
-            "window": nr7_window,
-        }
-    if gap_enabled:
-        indicator_config["gap"] = {
-            "enabled": True,
-            "threshold": gap_threshold,
-        }
-    if volume_enabled:
-        indicator_config["volume"] = {
-            "enabled": True,
-            "threshold": volume_threshold,
-            "lookback": volume_lookback,
-        }
-    if sr_enabled:
-        indicator_config["sr"] = {
-            "enabled": True,
-            "threshold": sr_threshold,
-            "lookback": sr_lookback,
-        }
-    if new_high_enabled:
-        indicator_config["new_high"] = {
-            "enabled": True,
-            "windows": new_high_windows,
-        }
-
-    effective_config = {
-        "spike_mode": spike_mode,
-        "pct_threshold": pct_threshold_active if spike_mode == "pct" else None,
-        "atr_multiple": atr_multiple_active if spike_mode == "atr" else None,
-        "atr_window": atr_window_value if spike_mode == "atr" else None,
-        "lookback_days": lookback_days,
-        "volume_filter_enabled": volume_filter_enabled,
-        "enabled_indicators": sorted(indicator_config.keys()),
-    }
-
-    active_indicator_keys = [
-        key for key in indicator_config.keys() if key != "volume_filter"
-    ]
-
-    if run_btn:
-        analysis_ran = True
-        start_ts = pd.Timestamp(start_date).tz_localize(None)
-        end_ts = pd.Timestamp(end_date).tz_localize(None)
-        if start_ts > end_ts:
-            start_ts, end_ts = end_ts, start_ts
-
-        universe: list[str] | None = None
-        requested_universe_count = 0
-        if use_sp_filter:
-            resolved = _load_universe(storage, start_ts, end_ts) or []
-            requested_universe_count = len(resolved)
-            if len(resolved) == 0:
-                st.warning(
-                    "S&P membership returned 0 tickers for this span; falling back to all tickers."
-                )
-                universe = None
-            else:
-                universe = resolved
-        debug_env.update(
-            {
-                "requested_universe": requested_universe_count,
-                "use_membership_filter": use_sp_filter,
-            }
+    naive_precision = float(naive_result.metrics.get("precision", 0.0))
+    win_rate = float(aligned_result.metrics.get("win_rate", 0.0))
+    if naive_precision - win_rate >= 0.30:
+        st.warning(
+            "Precursor-only stats overstate success. Use scanner-aligned results for trading decisions."
         )
 
-        debug_meta = {
-            "started": _utcnow_iso(),
-            "python": platform.python_version(),
-            "platform": platform.platform(),
-            "streamlit": getattr(st, "__version__", "unknown"),
-        }
+    metrics_cols = st.columns(3)
+    metrics_cols[0].metric("Signals evaluated", int(naive_result.metrics.get("total", 0)))
+    metrics_cols[1].metric("Scanner trades", int(summary.get("trades", 0)))
+    metrics_cols[2].metric("Win rate", f"{win_rate:.1%}")
 
-        status, prog, log_fn = status_block("Scanning price history", key_prefix="spike_lab")
-        try:
-            prog.progress(0.05)
-        except Exception:
-            pass
-        log_fn("Loading data and computing indicators…")
+    if not events_df.empty:
+        st.subheader("Sample precursor signals")
+        st.dataframe(events_df.head(200), use_container_width=True)
+    else:
+        st.info("No precursor signals matched the current configuration.")
 
-        if effective_config and debug and hasattr(debug, "log_event"):
-            try:
-                debug.log_event("effective_config", **effective_config)
-            except Exception:
-                pass
+    if not trades_df.empty:
+        st.subheader("Scanner-aligned trades")
+        st.dataframe(trades_df, use_container_width=True)
+    else:
+        st.info("Scanner produced no trades for this configuration.")
 
-        try:
-            spikes_df, summary = analyze_spike_precursors(
-                storage,
-                start=start_ts,
-                end=end_ts,
-                universe=universe,
-                spike_mode=spike_mode,
-                pct_threshold=pct_threshold_active,
-                atr_multiple=atr_multiple_active,
-                atr_window=atr_window_value,
-                atr_method=atr_method_value,
-                lookback_days=lookback_days,
-                indicator_config=indicator_config,
-                debug=debug,
-            )
-            try:
-                prog.progress(1.0)
-                status.update(label="Analysis complete", state="complete")
-            except Exception:
-                pass
-            log_fn(f"Detected {len(spikes_df)} spike events")
-        except Exception as exc:
-            debug.add_error("analysis", exc)
-            st.error(f"Analysis failed: {exc}")
-            log_fn(f"Error: {exc}")
-            summary = None
-        finally:
-            counts = summary.get("counts", {}) if summary else {}
-            debug.set_metrics(
-                tickers=int(counts.get("tickers", 0)),
-                spikes=int(counts.get("spikes", 0)),
-                flags=len(summary.get("flag_metadata", {})) if summary else 0,
-            )
+    diag_base = f"precursor_lab_{start_ts.strftime('%Y%m%d')}_{end_ts.strftime('%Y%m%d')}"
+    diag_path = export_diagnostics(aligned_result.diagnostics, diag_base)
+    trades_path = export_trades(trades_df, diag_base)
+    st.caption(f"Saved diagnostics CSV to {diag_path}")
+    st.caption(f"Saved trades CSV to {trades_path}")
 
-    if analysis_ran and effective_config:
-        st.caption("Effective configuration (what actually ran)")
-        st.json(effective_config)
+    st.caption(f"Session recorded at {_utcnow_iso()}")
 
-        if not active_indicator_keys and not volume_filter_enabled:
-            if spike_mode == "pct" and pct_threshold_active is not None:
-                if abs(pct_threshold_active - 8.0) < 1e-9:
-                    st.success("Running: 8% up only")
-                else:
-                    st.info(
-                        f"Running: Percent spike only ({pct_threshold_active:.1f}%)"
-                    )
-            elif spike_mode == "atr" and atr_multiple_active is not None:
-                st.info(f"Running: ATR spike only ({atr_multiple_active:.2f}×)")
 
-    if analysis_ran and summary:
-        counts = summary.get("counts", {})
-        st.markdown(
-            f"**Date span:** {pd.Timestamp(counts.get('start')).date()} → {pd.Timestamp(counts.get('end')).date()}  \\\n+**Tickers analyzed:** {counts.get('tickers', 0)}"
-        )
-        metrics_cols = st.columns(3)
-        metrics_cols[0].metric("Spikes found", counts.get("spikes", 0))
-        if not spikes_df.empty:
-            bool_cols = [
-                flag
-                for flag in summary.get("flag_metadata", {}).keys()
-                if flag in spikes_df.columns
-            ]
-            if bool_cols:
-                hit_counts = spikes_df[bool_cols].sum(axis=1)
-                median_flags = float(hit_counts.median())
-            else:
-                median_flags = 0.0
-        else:
-            median_flags = 0.0
-        metrics_cols[1].metric(
-            "Median flags per spike", f"{median_flags:.1f}" if median_flags else "0"
-        )
-        metrics_cols[2].metric("Lookback (days)", summary.get("lookback_days", lookback_days))
-
-        if active_indicator_keys:
-            freq_df = summary.get("frequency_table")
-            if isinstance(freq_df, pd.DataFrame) and not freq_df.empty:
-                freq_display = freq_df.copy()
-                freq_display["hit_rate_%"] = freq_display["hit_rate"].apply(
-                    lambda x: round(x * 100.0, 2)
-                )
-                freq_display = freq_display.drop(columns=["hit_rate"])
-                st.subheader("Precursor frequencies")
-                st.dataframe(freq_display, use_container_width=True)
-            else:
-                st.info("No precursor flags met the criteria.")
-
-            combos_df = summary.get("combos")
-            if isinstance(combos_df, pd.DataFrame) and not combos_df.empty:
-                combos_disp = combos_df.copy()
-                combos_disp["lift"] = combos_disp["lift"].round(2)
-                st.subheader("Top 10 combos (pairs)")
-                st.dataframe(combos_disp, use_container_width=True)
-
-        if not spikes_df.empty:
-            st.subheader("Spike events (latest 500)")
-            display_df = spikes_df.sort_values("spike_date", ascending=False).head(500)
-            display_df = display_df.copy()
-            display_df["spike_date"] = pd.to_datetime(display_df["spike_date"]).dt.date
-            st.dataframe(display_df, use_container_width=True)
-            st.download_button(
-                "Download full CSV",
-                spikes_df.to_csv(index=False).encode("utf-8"),
-                file_name="spike_precursors.csv",
-                mime="text/csv",
-            )
-
-        if active_indicator_keys:
-            freq_df = summary.get("frequency_table")
-            if isinstance(freq_df, pd.DataFrame) and not freq_df.empty:
-                st.subheader("Export rule preset")
-                threshold_pct = st.slider(
-                    "Minimum hit rate for inclusion (%)",
-                    min_value=5,
-                    max_value=100,
-                    value=30,
-                    step=5,
-                )
-                eligible = freq_df[freq_df["hit_rate"] >= threshold_pct / 100.0]
-                metadata = summary.get("flag_metadata", {})
-                lead_stats = summary.get("lead_stats", {})
-                if eligible.empty:
-                    st.info("No flags meet the selected hit-rate threshold.")
-                else:
-                    within_default = int(summary.get("lookback_days", lookback_days))
-                    selected_flags: list[str] = []
-                    for _, row in eligible.iterrows():
-                        flag = row["flag"]
-                        label = f"{flag} ({row['hit_rate'] * 100:.1f}% hits)"
-                        if st.checkbox(label, key=f"preset_{flag}"):
-                            selected_flags.append(flag)
-
-                    if selected_flags:
-                        conditions = []
-                        for flag in selected_flags:
-                            meta = dict(metadata.get(flag, {"type": "custom", "flag": flag}))
-                            within_days = within_default
-                            stats = lead_stats.get(flag)
-                            if stats and stats.get("max"):
-                                within_days = max(
-                                    within_days,
-                                    int(max(1, round(float(stats.get("max")))))
-                                )
-                            meta["within_days"] = within_days
-                            if "flag" not in meta:
-                                meta["flag"] = flag
-                            conditions.append(meta)
-
-                        preset = {
-                            "name": datetime.utcnow().strftime(
-                                "precursor_preset_%Y%m%d_%H%M"
-                            ),
-                            "conditions": conditions,
-                        }
-                        preset_json = json.dumps(preset, indent=2)
-                        st.download_button(
-                            "Download preset JSON",
-                            preset_json.encode("utf-8"),
-                            file_name=f"{preset['name']}.json",
-                            mime="application/json",
-                        )
-                        st.caption(
-                            "You can load this preset from the Stock Scanner (Shares Only) pre-filters (if/when that page supports it)."
-                        )
-                    else:
-                        st.info("Select at least one flag to export a preset.")
-
-    _render_debug_panel(debug_meta, params, debug_env, debug)
-
+if __name__ == "__main__":  # pragma: no cover
+    page()

--- a/utils/io_export.py
+++ b/utils/io_export.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+EXPORT_ROOT = Path("data/exports")
+EXPORT_ROOT.mkdir(parents=True, exist_ok=True)
+
+
+def _resolve_name(base_name: str, suffix: str) -> Path:
+    safe = base_name.replace("/", "_").replace("\\", "_")
+    return EXPORT_ROOT / f"{safe}_{suffix}.csv"
+
+
+def export_trades(trades_df: pd.DataFrame, base_name: str) -> str:
+    if trades_df is None or trades_df.empty:
+        path = _resolve_name(base_name, "trades")
+        trades_df = pd.DataFrame(columns=["ticker", "entry_date", "exit_date", "pnl"])
+    else:
+        path = _resolve_name(base_name, "trades")
+    trades_df.to_csv(path, index=False)
+    return str(path)
+
+
+def export_diagnostics(diag_df: pd.DataFrame, base_name: str) -> str:
+    if diag_df is None:
+        diag_df = pd.DataFrame()
+    path = _resolve_name(base_name, "diagnostics")
+    diag_df.to_csv(path, index=False)
+    return str(path)
+
+
+__all__ = ["export_trades", "export_diagnostics"]


### PR DESCRIPTION
## Summary
- add a shared Streamlit precursor control component and reuse it on the shares-only scanner
- rebuild the precursor lab to run presets through the unified scan runner and emit diagnostics/trade exports
- export scanner trades via the shared io helper and extend the Streamlit state guard to the lab page

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6d82140b08332a6851a3e69c85861