### PR TITLE
Fix Spike Precursor Lab import and prune legacy test page

### DIFF
--- a/ui/pages/64_Spike_Precursor_Lab.py
+++ b/ui/pages/64_Spike_Precursor_Lab.py
@@ -28,6 +28,8 @@ def _initialize() -> None:
     import math
     from typing import Any, Sequence
 
+    # NOTE: SpikeDefinition is defined at module scope; do not redefine here.
+
     import pandas as pd
     import streamlit as st
     from pandas.tseries.offsets import BDay


### PR DESCRIPTION
## Summary
- ensure SpikeDefinition remains defined only at module scope in the Spike Precursor Lab page
- document the module-scope SpikeDefinition within `_initialize`
- remove the deleted 66_* page from the streamlit state tests

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dad460d0f48332aa04d284054a885f