### PR TITLE
Document precursor evaluation module

### DIFF
--- a/backtest/precursor_eval.py
+++ b/backtest/precursor_eval.py
@@ -1,3 +1,5 @@
+"""Evaluation helpers for precursor spike analysis."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass


### PR DESCRIPTION
## Summary
- add a module-level docstring to `backtest/precursor_eval.py` for clarity about the precursor evaluation helpers

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dae4a3b34483329e10d832d4628fba