### PR TITLE
Handle export-root fallback during import

### DIFF
--- a/tests/test_precursor_lab_page.py
+++ b/tests/test_precursor_lab_page.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
 import re
+import runpy
+import sys
+import tempfile
 from pathlib import Path
 
 import pytest
 
 
 PAGE_PATH = Path("ui/pages/64_Spike_Precursor_Lab.py")
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
 
 @pytest.mark.skipif(not PAGE_PATH.exists(), reason="Spike Precursor Lab page missing")
@@ -21,3 +27,34 @@ def test_no_double_write(path: Path) -> None:
     content = path.read_text(encoding="utf-8")
     pattern = r"st\.session_state\[[^\]]+\]\s*=\s*st\."
     assert not re.search(pattern, content)
+
+
+def test_precursor_lab_import_handles_export_permission(monkeypatch: pytest.MonkeyPatch) -> None:
+    import pathlib
+
+    target = pathlib.Path("data/exports")
+    original_mkdir = pathlib.Path.mkdir
+
+    def fake_mkdir(self: pathlib.Path, *args, **kwargs):
+        if pathlib.Path(self) == target:
+            raise PermissionError("mocked permission failure")
+        return original_mkdir(self, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "mkdir", fake_mkdir)
+    if hasattr(pathlib, "PosixPath"):
+        monkeypatch.setattr(pathlib.PosixPath, "mkdir", fake_mkdir, raising=False)
+    if hasattr(pathlib, "WindowsPath"):
+        monkeypatch.setattr(pathlib.WindowsPath, "mkdir", fake_mkdir, raising=False)
+
+    for module in ["utils.io_export"]:
+        sys.modules.pop(module, None)
+
+    module_globals = runpy.run_path(str(PAGE_PATH), run_name="__test__")
+    assert module_globals
+
+    io_export = sys.modules.get("utils.io_export")
+    assert io_export is not None
+    fallback_root = Path(tempfile.gettempdir()) / "sp500scn_exports"
+    assert io_export.DEFAULT_EXPORT_PATH == Path("data/exports")
+    assert io_export.EXPORT_ROOT == fallback_root
+    assert io_export.EXPORT_ROOT.exists()

--- a/utils/io_export.py
+++ b/utils/io_export.py
@@ -1,13 +1,21 @@
 from __future__ import annotations
 
+import tempfile
 from pathlib import Path
-from typing import Any
-
 import pandas as pd
 
-EXPORT_ROOT = Path("data/exports")
-EXPORT_ROOT.mkdir(parents=True, exist_ok=True)
 
+def _prepare_export_root(path: Path) -> Path:
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+    except (OSError, PermissionError):
+        fallback = Path(tempfile.gettempdir()) / "sp500scn_exports"
+        fallback.mkdir(parents=True, exist_ok=True)
+        return fallback
+
+DEFAULT_EXPORT_PATH = Path("data/exports")
+EXPORT_ROOT = _prepare_export_root(DEFAULT_EXPORT_PATH)
 
 def _resolve_name(base_name: str, suffix: str) -> Path:
     safe = base_name.replace("/", "_").replace("\\", "_")


### PR DESCRIPTION
## Summary
- ensure the guarded export directory helper remains the only place that creates the export root, falling back to a temp directory when the default path is unavailable
- keep the Spike Precursor Lab regression asserting the module switches to the fallback directory after a simulated permission failure

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dbfe022ccc83328020cdfd57b49d9e